### PR TITLE
Adds exponential decay and exponential poly-decay factories

### DIFF
--- a/mitiq/factories.py
+++ b/mitiq/factories.py
@@ -291,7 +291,6 @@ class PolyDecayFactory(BatchedFactory):
         # CASE 2: asymptote is given.
         # Plynomial fit of z(x).
         zstack = [np.log(max(y - asymptote, eps)) for y in outstack]
-        print("zstack", zstack)
         # Get coefficients {z_j} of z(x)= z_0 + z_1*x + z_2*x**2...
         # Note: coefficients are ordered from high powers of x to low powers x.
         z_coefficients = np.polyfit(instack, zstack, deg=order)

--- a/mitiq/factories.py
+++ b/mitiq/factories.py
@@ -203,7 +203,7 @@ class PolyExpFactory(BatchedFactory):
     y(x) = a + s * exp(z(x)), where z(x) is a polynomial of a given order.
 
     The parameter "s" is a sign variable which can be either 1 or -1, corresponding to
-    decreasing and increasing exponentials, respectively. The parameter "s" is 
+    decreasing and increasing exponentials, respectively. The parameter "s" is
     automatically deduced from the data.
 
     If the asymptotic value (y(x->inf) = a) is known, a linear fit with respect
@@ -235,13 +235,13 @@ class PolyExpFactory(BatchedFactory):
         y(x) = a + s * exp(z(x)), where z(x) is a polynomial of a given order.
 
         The parameter "s" is a sign variable which can be either 1 or -1, corresponding to
-        decreasing and increasing exponentials, respectively. The parameter "s" is 
+        decreasing and increasing exponentials, respectively. The parameter "s" is
         automatically deduced from the data.
 
         It is also assumed that z(x-->inf)=-inf, such that y(x-->inf)-->a.
 
         If asymptote is None, the ansatz y(x) is fitted with a non-linear optimization.
-        Otherwise, a linear fit with respect to z(x) := log(sign * (y(x) - asymptote)) 
+        Otherwise, a linear fit with respect to z(x) := log(sign * (y(x) - asymptote))
         is performed.
 
         This static method is equivalent to the "self.reduce" method of PolyExpFactory,
@@ -253,7 +253,7 @@ class PolyExpFactory(BatchedFactory):
             outstack: y data values.
             asymptote: y(x->inf).
             order: extrapolation order.
-            eps: epsilon to regularize log(sign (instack - asymptote)) when 
+            eps: epsilon to regularize log(sign (instack - asymptote)) when
                  the argument is to close to zero or negative.
         """
         # Shift is 0 if asymptote is given, 1 if asymptote is not given
@@ -271,7 +271,7 @@ class PolyExpFactory(BatchedFactory):
             )
 
         # CASE 1: asymptote is None.
-        # TODO: it works, but there must be better way of doing this. 
+        # TODO: it works, but there must be better way of doing this.
         # Note: *args does not seem to work with curve_fit.
         # For the moment only orders up to 3 are suppoerted.
         def ansatz_zero(x: float, asympt: float, b: float) -> float:
@@ -296,7 +296,7 @@ class PolyExpFactory(BatchedFactory):
             # Return ansatz(0)= asympt + b
             return opt_params[0] + opt_params[1]
 
-        # CASE 2: asymptote is given.  
+        # CASE 2: asymptote is given.
         # deduce if the exponential is a decay or a growth
         mean_y = sum(outstack) / len(outstack)
         sign = np.sign(mean_y - asymptote)
@@ -312,7 +312,7 @@ class PolyExpFactory(BatchedFactory):
         """Returns the zero-noise limit, assuming an exponential ansatz:
         y(x) = a + s * exp(z(x)), where z(x) is a polynomial of a given order.
         The parameter "s" is a sign variable which can be either 1 or -1, corresponding to
-        decreasing and increasing exponentials, respectively. The parameter "s" is 
+        decreasing and increasing exponentials, respectively. The parameter "s" is
         automatically deduced from the data.
         It is also assumed that z(x-->inf)=-inf, such that y(x-->inf)-->a.
         """

--- a/mitiq/factories.py
+++ b/mitiq/factories.py
@@ -256,19 +256,21 @@ class PolyDecayFactory(BatchedFactory):
         # CASE 1: asymptote is None.
         # TODO: there must be better way of doing this. *args does not work with curve_fit.
         # For the moment only orders up to 3 are suppoerted.
-        def ansatz_zero(x:float, asympt, z_zero) -> float:
+        def ansatz_zero(x:float, asympt:float, z_zero:float) -> float:
             """Ansatz function of order 0"""
             return asympt + np.exp(z_zero)
-        def ansatz_one(x:float, asympt, z_zero, z_one) -> float:
+        def ansatz_one(x:float, asympt:float, z_zero:float, z_one:float) -> float:
             """Ansatz function of order 1"""
             return asympt + np.exp(z_zero + z_one * x)
-        def ansatz_two(x:float, asympt, z_zero, z_one, z_two) -> float:
+        def ansatz_two(x:float, asympt:float, z_zero:float, z_one:float, z_two:float) -> float:
             """Ansatz function of order 2."""
             return asympt + np.exp(z_zero + z_one * x + z_two * x ** 2)
-        def ansatz_three(x:float, asympt, z_zero, z_one, z_two, z_three) -> float:
+        def ansatz_three(
+                x:float, asympt:float, z_zero:float, z_one:float, z_two:float, z_three:float
+            ) -> float:
             """Ansatz function of order 3."""
             return asympt + np.exp(z_zero + z_one * x + z_two * x ** 2 + z_three * x ** 3)
-            
+
         ansatzes = (ansatz_zero, ansatz_one, ansatz_two, ansatz_three)
         
         if asymptote is None:

--- a/mitiq/factories.py
+++ b/mitiq/factories.py
@@ -256,7 +256,7 @@ class PolyDecayFactory(BatchedFactory):
             raise ValueError(error_str)
         if len(instack) != len(outstack) or len(instack) < 2:
             raise ValueError(error_str)
-        if order > len(instack) - 1:
+        if order > len(instack) - (1 + shift):
             raise ValueError(
                 "Extrapolation order is too high. "
                 f"The order cannot exceed the number of data points minus {1 + shift}."

--- a/mitiq/tests/test_factories.py
+++ b/mitiq/tests/test_factories.py
@@ -105,8 +105,8 @@ def test_poly_exp_factory_with_asympt():
 
 
 def test_exp_factory_no_asympt():
+    """Test of exponential extrapolator."""
     for f in [f_exp_down, f_exp_up]:
-        """Test of exponential extrapolator."""
         algo_object = ExpFactory(X_VALS, asymptote=None)
         run_factory(algo_object, f)
         assert np.isclose(algo_object.reduce(), f(0, err=0), atol=CLOSE_TOL)

--- a/mitiq/tests/test_factories.py
+++ b/mitiq/tests/test_factories.py
@@ -2,23 +2,43 @@
 
 from typing import Callable
 import numpy as np
-from mitiq.factories import Factory, RichardsonFactory, LinearFactory, PolyFactory
+from mitiq.factories import (
+    Factory, 
+    RichardsonFactory, 
+    LinearFactory, 
+    PolyFactory,
+    DecayFactory,
+    PolyDecayFactory,
+)
 from mitiq.zne import run_factory
 
 # Constant parameters for test functions:
 A = 1.2
 B = 1.5
 C = 1.7
+D = 0.9
 X_VALS = [1, 1.4, 1.9]
 
-# Classical test functions (f_lin and f_non_lin):
+# Classical test functions:
 def f_lin(x: float) -> float:
     """Linear function."""
     return A + B * x
 
+
 def f_non_lin(x: float) -> float:
     """Non-linear function."""
     return A + B * x + C * x ** 2
+
+
+def f_decay(x: float) -> float:
+    """Exponential decay function."""
+    return A + B * np.exp(-C * x)
+
+
+def f_poly_decay(x: float) -> float:
+    """Polynomial decay function."""
+    return A + B * np.exp(-C * x - D * x ** 2)
+
 
 def test_richardson_extr():
     """Test of the Richardson's extrapolator."""
@@ -27,11 +47,13 @@ def test_richardson_extr():
         run_factory(algo_object, f)
         assert np.isclose(algo_object.reduce(), f(0), atol=1.0e-7)
 
+
 def test_linear_extr():
     """Test of linear extrapolator."""
     algo_object = LinearFactory(X_VALS)
     run_factory(algo_object, f_lin)
     assert np.isclose(algo_object.reduce(), f_lin(0), atol=1.0e-7)
+
 
 def test_poly_extr():
     """Test of polynomial extrapolator."""
@@ -43,7 +65,24 @@ def test_poly_extr():
     # order=1 is bad while ored=2 is better.
     algo_object = PolyFactory(X_VALS, order=1)
     run_factory(algo_object, f_non_lin)
-    assert not np.isclose(algo_object.reduce(), f_non_lin(0), atol=1) 
+    assert not np.isclose(algo_object.reduce(), f_non_lin(0), atol=1)
     algo_object = PolyFactory(X_VALS, order=2)
     run_factory(algo_object, f_non_lin)
     assert np.isclose(algo_object.reduce(), f_non_lin(0), atol=1.0e-7)
+
+def test_decay_factory():
+    """Test of exponential decay extrapolator."""
+    algo_object = DecayFactory(X_VALS, asymptote=A)
+    run_factory(algo_object, f_decay)
+    assert np.isclose(algo_object.reduce(), f_decay(0), atol=1.0e-7)
+
+def test_poly_decay_factory():
+    """Test of (almost) exponential decay extrapolator."""
+    # test that, for a decay with a non-linear exponent,
+    # order=1 is bad while ored=2 is better.
+    algo_object = PolyDecayFactory(X_VALS, order=1, asymptote=A)
+    run_factory(algo_object, f_poly_decay)
+    assert not np.isclose(algo_object.reduce(), f_decay(0), atol=1.0)
+    algo_object = PolyDecayFactory(X_VALS, order=2, asymptote=A)
+    run_factory(algo_object, f_poly_decay)
+    assert np.isclose(algo_object.reduce(), f_decay(0), atol=1.0e-7)

--- a/mitiq/tests/test_factories.py
+++ b/mitiq/tests/test_factories.py
@@ -1,11 +1,9 @@
-# test_algorithms.py
+"""Testing of zero-noise extrapolation methods (factories) with classically generated data."""
 
-from typing import Callable
 import numpy as np
 from mitiq.factories import (
-    Factory, 
-    RichardsonFactory, 
-    LinearFactory, 
+    RichardsonFactory,
+    LinearFactory,
     PolyFactory,
     DecayFactory,
     PolyDecayFactory,
@@ -13,32 +11,35 @@ from mitiq.factories import (
 from mitiq.zne import run_factory
 
 # Constant parameters for test functions:
-A = 1.2
-B = 1.5
-C = 1.7
-D = 0.9
-X_VALS = [1, 1.4, 1.9]
-X_VALS_MORE = [1, 1.4, 1.9, 2.3]
+A = 0.5
+B = 0.7
+C = 0.4
+D = 0.3
+X_VALS = [1, 1.3, 1.7, 2.2]
 
-# Classical test functions:
-def f_lin(x: float) -> float:
+STAT_NOISE = 0.0001
+CLOSE_TOL = 1.0e-2
+NOT_CLOSE_TOL = 1.0e-1
+
+# Classical test functions with statistical error:
+def f_lin(x: float, err: float = STAT_NOISE) -> float:
     """Linear function."""
-    return A + B * x
+    return A + B * x + np.random.normal(scale=err)
 
 
-def f_non_lin(x: float) -> float:
+def f_non_lin(x: float, err: float = STAT_NOISE) -> float:
     """Non-linear function."""
-    return A + B * x + C * x ** 2
+    return A + B * x + C * x ** 2 + np.random.normal(scale=err)
 
 
-def f_decay(x: float) -> float:
+def f_decay(x: float, err: float = STAT_NOISE) -> float:
     """Exponential decay function."""
-    return A + B * np.exp(-C * x)
+    return A + B * np.exp(-C * x) + np.random.normal(scale=err)
 
 
-def f_poly_decay(x: float) -> float:
+def f_poly_decay(x: float, err: float = STAT_NOISE) -> float:
     """Polynomial decay function."""
-    return A + B * np.exp(-C * x - D * x ** 2)
+    return A + B * np.exp(-C * x - D * x ** 2) + np.random.normal(scale=err)
 
 
 def test_richardson_extr():
@@ -46,14 +47,14 @@ def test_richardson_extr():
     for f in [f_lin, f_non_lin]:
         algo_object = RichardsonFactory(X_VALS)
         run_factory(algo_object, f)
-        assert np.isclose(algo_object.reduce(), f(0), atol=1.0e-7)
+        assert np.isclose(algo_object.reduce(), f(0, err=0), atol=CLOSE_TOL)
 
 
 def test_linear_extr():
     """Test of linear extrapolator."""
     algo_object = LinearFactory(X_VALS)
     run_factory(algo_object, f_lin)
-    assert np.isclose(algo_object.reduce(), f_lin(0), atol=1.0e-7)
+    assert np.isclose(algo_object.reduce(), f_lin(0, err=0), atol=CLOSE_TOL)
 
 
 def test_poly_extr():
@@ -61,21 +62,23 @@ def test_poly_extr():
     # test (order=1)
     algo_object = PolyFactory(X_VALS, order=1)
     run_factory(algo_object, f_lin)
-    assert np.isclose(algo_object.reduce(), f_lin(0), atol=1.0e-7)
+    assert np.isclose(algo_object.reduce(), f_lin(0, err=0), atol=CLOSE_TOL)
     # test that, for some non-linear functions,
     # order=1 is bad while ored=2 is better.
     algo_object = PolyFactory(X_VALS, order=1)
     run_factory(algo_object, f_non_lin)
-    assert not np.isclose(algo_object.reduce(), f_non_lin(0), atol=1)
+    assert not np.isclose(algo_object.reduce(), f_non_lin(0, err=0), atol=NOT_CLOSE_TOL)
     algo_object = PolyFactory(X_VALS, order=2)
     run_factory(algo_object, f_non_lin)
-    assert np.isclose(algo_object.reduce(), f_non_lin(0), atol=1.0e-7)
+    assert np.isclose(algo_object.reduce(), f_non_lin(0, err=0), atol=CLOSE_TOL)
+
 
 def test_decay_factory_with_asympt():
     """Test of exponential decay extrapolator."""
     algo_object = DecayFactory(X_VALS, asymptote=A)
     run_factory(algo_object, f_decay)
-    assert np.isclose(algo_object.reduce(), f_decay(0), atol=1.0e-7)
+    assert np.isclose(algo_object.reduce(), f_decay(0, err=0), atol=CLOSE_TOL)
+
 
 def test_poly_decay_factory_with_asympt():
     """Test of (almost) exponential decay extrapolator."""
@@ -83,26 +86,26 @@ def test_poly_decay_factory_with_asympt():
     # order=1 is bad while ored=2 is better.
     algo_object = PolyDecayFactory(X_VALS, order=1, asymptote=A)
     run_factory(algo_object, f_poly_decay)
-    assert not np.isclose(algo_object.reduce(), f_poly_decay(0), atol=1.0)
+    assert not np.isclose(algo_object.reduce(), f_poly_decay(0, err=0), atol=NOT_CLOSE_TOL)
     algo_object = PolyDecayFactory(X_VALS, order=2, asymptote=A)
     run_factory(algo_object, f_poly_decay)
-    assert np.isclose(algo_object.reduce(), f_poly_decay(0), atol=1.0e-7)
+    assert np.isclose(algo_object.reduce(), f_poly_decay(0, err=0), atol=CLOSE_TOL)
 
-# TODO: don't work if asymptote=None
+
 def test_decay_factory_no_asympt():
     """Test of exponential decay extrapolator."""
-    algo_object = DecayFactory(X_VALS_MORE, asymptote=A)
+    algo_object = DecayFactory(X_VALS, asymptote=None)
     run_factory(algo_object, f_decay)
-    assert np.isclose(algo_object.reduce(), f_decay(0), atol=1.0e-7)
+    assert np.isclose(algo_object.reduce(), f_decay(0, err=0), atol=CLOSE_TOL)
 
-# TODO: don't work if asymptote=None
+
 def test_poly_decay_factory_no_asympt():
     """Test of (almost) exponential decay extrapolator."""
     # test that, for a decay with a non-linear exponent,
     # order=1 is bad while ored=2 is better.
-    algo_object = PolyDecayFactory(X_VALS_MORE, order=1, asymptote=A)
+    algo_object = PolyDecayFactory(X_VALS, order=1, asymptote=None)
     run_factory(algo_object, f_poly_decay)
-    assert not np.isclose(algo_object.reduce(), f_poly_decay(0), atol=1.0)
-    algo_object = PolyDecayFactory(X_VALS_MORE, order=2, asymptote=A)
+    assert not np.isclose(algo_object.reduce(), f_poly_decay(0, err=0), atol=NOT_CLOSE_TOL)
+    algo_object = PolyDecayFactory(X_VALS, order=2, asymptote=None)
     run_factory(algo_object, f_poly_decay)
-    assert np.isclose(algo_object.reduce(), f_poly_decay(0), atol=1.0e-7)
+    assert np.isclose(algo_object.reduce(), f_poly_decay(0, err=0), atol=CLOSE_TOL)

--- a/mitiq/tests/test_factories.py
+++ b/mitiq/tests/test_factories.py
@@ -18,7 +18,7 @@ B = 1.5
 C = 1.7
 D = 0.9
 X_VALS = [1, 1.4, 1.9]
-X_VALS_MORE = [1, 1.2, 1.4, 1.6]
+X_VALS_MORE = [1, 1.4, 1.9, 2.3]
 
 # Classical test functions:
 def f_lin(x: float) -> float:
@@ -91,7 +91,7 @@ def test_poly_decay_factory_with_asympt():
 # TODO: don't work if asymptote=None
 def test_decay_factory_no_asympt():
     """Test of exponential decay extrapolator."""
-    algo_object = DecayFactory(X_VALS_MORE, asymptote=A)
+    algo_object = DecayFactory(X_VALS_MORE, asymptote=None)
     run_factory(algo_object, f_decay)
     assert np.isclose(algo_object.reduce(), f_decay(0), atol=1.0e-7)
 

--- a/mitiq/tests/test_factories.py
+++ b/mitiq/tests/test_factories.py
@@ -18,6 +18,7 @@ B = 1.5
 C = 1.7
 D = 0.9
 X_VALS = [1, 1.4, 1.9]
+X_VALS_MORE = [1, 1.2, 1.4, 1.6]
 
 # Classical test functions:
 def f_lin(x: float) -> float:
@@ -70,19 +71,38 @@ def test_poly_extr():
     run_factory(algo_object, f_non_lin)
     assert np.isclose(algo_object.reduce(), f_non_lin(0), atol=1.0e-7)
 
-def test_decay_factory():
+def test_decay_factory_with_asympt():
     """Test of exponential decay extrapolator."""
     algo_object = DecayFactory(X_VALS, asymptote=A)
     run_factory(algo_object, f_decay)
     assert np.isclose(algo_object.reduce(), f_decay(0), atol=1.0e-7)
 
-def test_poly_decay_factory():
+def test_poly_decay_factory_with_asympt():
     """Test of (almost) exponential decay extrapolator."""
     # test that, for a decay with a non-linear exponent,
     # order=1 is bad while ored=2 is better.
     algo_object = PolyDecayFactory(X_VALS, order=1, asymptote=A)
     run_factory(algo_object, f_poly_decay)
-    assert not np.isclose(algo_object.reduce(), f_decay(0), atol=1.0)
+    assert not np.isclose(algo_object.reduce(), f_poly_decay(0), atol=1.0)
     algo_object = PolyDecayFactory(X_VALS, order=2, asymptote=A)
     run_factory(algo_object, f_poly_decay)
+    assert np.isclose(algo_object.reduce(), f_poly_decay(0), atol=1.0e-7)
+
+# TODO: don't work if asymptote=None
+def test_decay_factory_no_asympt():
+    """Test of exponential decay extrapolator."""
+    algo_object = DecayFactory(X_VALS_MORE, asymptote=A)
+    run_factory(algo_object, f_decay)
     assert np.isclose(algo_object.reduce(), f_decay(0), atol=1.0e-7)
+
+# TODO: don't work if asymptote=None
+def test_poly_decay_factory_no_asympt():
+    """Test of (almost) exponential decay extrapolator."""
+    # test that, for a decay with a non-linear exponent,
+    # order=1 is bad while ored=2 is better.
+    algo_object = PolyDecayFactory(X_VALS_MORE, order=1, asymptote=A)
+    run_factory(algo_object, f_poly_decay)
+    assert not np.isclose(algo_object.reduce(), f_poly_decay(0), atol=1.0)
+    algo_object = PolyDecayFactory(X_VALS_MORE, order=2, asymptote=A)
+    run_factory(algo_object, f_poly_decay)
+    assert np.isclose(algo_object.reduce(), f_poly_decay(0), atol=1.0e-7)

--- a/mitiq/tests/test_factories.py
+++ b/mitiq/tests/test_factories.py
@@ -91,7 +91,7 @@ def test_poly_decay_factory_with_asympt():
 # TODO: don't work if asymptote=None
 def test_decay_factory_no_asympt():
     """Test of exponential decay extrapolator."""
-    algo_object = DecayFactory(X_VALS_MORE, asymptote=None)
+    algo_object = DecayFactory(X_VALS_MORE, asymptote=A)
     run_factory(algo_object, f_decay)
     assert np.isclose(algo_object.reduce(), f_decay(0), atol=1.0e-7)
 


### PR DESCRIPTION
Fixes #14 .

Main changes:
-  New factory `DecayFactory`: does zne using the ansatz y(x) = a + b * exp(-c * x), with c > 0.
-  New factory `PolyDecayFactory`: y(x) = a + exp(z(x)), where z(x) is a polynomial of a given order. This is useful to fit data which deviates from an ideal exponential but still has a general decay structure. 
- Associated tests in `test_factories.py`

Note: if the asymptotic value (the "a" constant of the functions above) is given, a linear fit of z(x) = log(y - a) is evaluated to make the extrapolation. Otherwise a non-linear fit is directly applied to the decay ansatz using `scipy.optimize.curve_fit`, in other words in this case we try to fit also the "a" parameter.

Note there is a "TODO:" in `factories.py`: for the moment if the `asymptote` parameter is not given, we can only fit with `order` at most `3` and the code is not very elegant. At some point we have to clean this part. If you have a simple solution in mind, we can solve this issue in this PR. Otherwise we can keep it as a "TODO".

@willzeng @rmlarose 

@tudorgt (you can have a look if you want and if you have time. These methods are perhaps not particularly sophisticated but better to start with simple things).
