### PR TITLE
add general mitiq testing to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,5 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
+        pytest mitiq/tests
         pytest mitiq/qiskit/tests


### PR DESCRIPTION
I realized today that the continuous integration tests were only running the `mitiq/qiskit/tests` and not the general ones. 

This PR fixes this to run the general mitiq tests as well as the qiskit ones.

**NOTE** This change uncovers some bugs that previously were not caught by the CI!

@rmlarose @andreamari If you have suggestions on what these bugs might be or how to fix them then please do push those bug fixes directly to this branch. I propose we freeze any other merges into master until we get this resolved.