### PR TITLE
Run continuous integration on pull request from fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Python Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Change the .github workflow for continuous integration to be triggered by a pull request, as per #49.