### PR TITLE
Add `about()` box  with info on environment and dependencies

### DIFF
--- a/mitiq/about.py
+++ b/mitiq/about.py
@@ -1,0 +1,54 @@
+"""
+Command line output of information on Mitiq and dependencies.
+"""
+__all__ = ['about']
+
+import sys
+import os
+import platform
+import numpy
+import scipy
+import mitiq
+import inspect
+
+def about():
+    """
+    About box for Mitiq. Gives version numbers for
+    Mitiq, NumPy, SciPy, Cirq, PyQuil, Qiskit.
+    """
+    try:
+        import cirq
+        cirq_ver = cirq.__version__
+    except:
+        cirq_ver = 'None'
+    try:
+        import pyquil
+        pyquil_ver = pyquil.__version__
+    except:
+        pyquil_ver = 'None'
+    try:
+        import qiskit
+        qiskit_ver = qiskit.__version__
+    except:
+        qiskit_ver = 'None'
+    print("")
+    print("Mitiq: A Python toolkit for implementing ") 
+    print("error mitigation on quantum computers.")
+    print("========================================")
+    print("Mitiq team – 2020 and later.")
+    print("See https://github.com/unitaryfund/mitiq for details.")
+    print("")
+    print("Mitiq Version:      %s" % mitiq.__version__)
+    print("Numpy Version:      %s" % numpy.__version__)
+    print("Scipy Version:      %s" % scipy.__version__)
+    print("Cirq Version:       %s" % cirq_ver)
+    print("Pyquil Version:     %s" % pyquil_ver)
+    print("Qiskit Version:     %s" % qiskit_ver)
+    print("Python Version:     %d.%d.%d" % sys.version_info[0:3])
+    print("Platform Info:      %s (%s)" % (platform.system(),
+                                           platform.machine()))
+    mitiq_install_path = os.path.dirname(inspect.getsourcefile(mitiq))
+    print("Installation path:  %s" % mitiq_install_path)
+
+if __name__ == "__main__":
+    about()


### PR DESCRIPTION
Add an `about()` function with a box collecting information on environment and dependencies. Heavily inspired by `qutip.about()`. I think it will become handy in future, due to the interconnectivity of the library. 
Typical print:
```
mitiq.about()
Mitiq: A Python toolkit for implementing 
error mitigation on quantum computers.
========================================
Mitiq team – 2020 and later.
See https://github.com/unitaryfund/mitiq for details.

Mitiq Version:      0.0.0
Numpy Version:      1.18.1
Scipy Version:      1.4.1
Cirq Version:       0.7.0
Pyquil Version:     2.18.0
Qiskit Version:     0.12.0
Python Version:     3.8.1
Platform Info:      Darwin (x86_64)
Installation path:  /Users/nathanshammah/github/mitiq/mitiq
```
