### PR TITLE
Reformat code in .py scripts with black

### DIFF
--- a/mitiq/__init__.py
+++ b/mitiq/__init__.py
@@ -16,7 +16,7 @@ QPROGRAM = Union[QuantumCircuit, Program]
 directory_of_this_file = os.path.dirname(os.path.abspath(__file__))
 
 
-with open(str(directory_of_this_file)+"/../VERSION.txt", "r") as f:
+with open(str(directory_of_this_file) + "/../VERSION.txt", "r") as f:
     __version__ = f.read().strip()
 
 

--- a/mitiq/factories.py
+++ b/mitiq/factories.py
@@ -79,7 +79,7 @@ class BatchedFactory(Factory):
         if len(scalars) == 0:
             raise ValueError(
                 "The argument 'scalars' should contain at least one element."
-                "At least 2 elements are necessary"\
+                "At least 2 elements are necessary"
                 " for non-trivial extrapolation."
             )
         self.scalars = scalars
@@ -120,16 +120,12 @@ class PolyFactory(BatchedFactory):
                    It cannot exceed len(scalars) - 1.
         """
         if order > len(scalars) - 1:
-            raise ValueError(
-                "The extrapolation order cannot exceed len(scalars) - 1."
-            )
+            raise ValueError("The extrapolation order cannot exceed len(scalars) - 1.")
         self.order = order
         super(PolyFactory, self).__init__(scalars)
 
     @staticmethod
-    def static_reduce(
-        instack: List[float], outstack: List[float], order: int
-    ) -> float:
+    def static_reduce(instack: List[float], outstack: List[float], order: int) -> float:
         """
         Determines with a least squared method, the polynomial of degree equal
         to 'order' which optimally fits the input data.
@@ -141,9 +137,7 @@ class PolyFactory(BatchedFactory):
         and RichardsonFactory.
         """
         # Check arguments
-        error_str = (
-            "Data is not enough: at least two data points are necessary."
-        )
+        error_str = "Data is not enough: at least two data points are necessary."
         if instack is None or outstack is None:
             raise ValueError(error_str)
         if len(instack) != len(outstack) or len(instack) < 2:
@@ -165,9 +159,7 @@ class PolyFactory(BatchedFactory):
         to "self.order"
         which optimally fits the input data. The zero-noise limit is returned.
         """
-        return PolyFactory.static_reduce(
-            self.instack, self.outstack, self.order
-        )
+        return PolyFactory.static_reduce(self.instack, self.outstack, self.order)
 
 
 class RichardsonFactory(BatchedFactory):
@@ -178,9 +170,7 @@ class RichardsonFactory(BatchedFactory):
         # Richardson's extrapolation is a particular case of a polynomial fit
         # with order equal to the number of data points minus 1.
         order = len(self.instack) - 1
-        return PolyFactory.static_reduce(
-            self.instack, self.outstack, order=order
-        )
+        return PolyFactory.static_reduce(self.instack, self.outstack, order=order)
 
 
 class LinearFactory(BatchedFactory):
@@ -219,9 +209,7 @@ class ExpFactory(BatchedFactory):
         """
         super(ExpFactory, self).__init__(scalars)
         if not (asymptote is None or isinstance(asymptote, float)):
-            raise ValueError(
-                "The argument 'asymptote' must be either a float or None"
-            )
+            raise ValueError("The argument 'asymptote' must be either a float or None")
         self.asymptote = asymptote
 
     def reduce(self) -> float:
@@ -265,9 +253,7 @@ class PolyExpFactory(BatchedFactory):
         """
         super(PolyExpFactory, self).__init__(scalars)
         if not (asymptote is None or isinstance(asymptote, float)):
-            raise ValueError(
-                "The argument 'asymptote' must be either a float or None"
-            )
+            raise ValueError("The argument 'asymptote' must be either a float or None")
         self.order = order
         self.asymptote = asymptote
 
@@ -316,9 +302,7 @@ class PolyExpFactory(BatchedFactory):
         # Shift is 0 if asymptote is given, 1 if asymptote is not given
         shift = int(asymptote is None)
         # Check arguments
-        error_str = (
-            "Data is not enough: at least two data points are necessary."
-        )
+        error_str = "Data is not enough: at least two data points are necessary."
         if instack is None or outstack is None:
             raise ValueError(error_str)
         if len(instack) != len(outstack) or len(instack) < 2:
@@ -326,7 +310,7 @@ class PolyExpFactory(BatchedFactory):
         if order > len(instack) - (1 + shift):
             raise ValueError(
                 "Extrapolation order is too high. "
-                f"The order cannot exceed the number" \
+                f"The order cannot exceed the number"
                 " of data points minus {1 + shift}."
             )
 
@@ -389,10 +373,7 @@ class AdaExpFactory(Factory):
     _SHIFT_FACTOR = 1.27846
 
     def __init__(
-        self,
-        steps: int,
-        scalar: float = 2,
-        asymptote: Union[float, None] = None,
+        self, steps: int, scalar: float = 2, asymptote: Union[float, None] = None,
     ) -> None:
         """Instantiate a new object of this Factory class.
 
@@ -406,18 +387,14 @@ class AdaExpFactory(Factory):
         """
         super(AdaExpFactory, self).__init__()
         if not (asymptote is None or isinstance(asymptote, float)):
-            raise ValueError(
-                "The argument 'asymptote' must be either a float or None"
-            )
+            raise ValueError("The argument 'asymptote' must be either a float or None")
         if scalar <= 1:
-            raise ValueError(
-                "The argument 'scalar' must be strictly larger than one."
-            )
+            raise ValueError("The argument 'scalar' must be strictly larger than one.")
         if steps < 3 + int(asymptote is None):
             raise ValueError(
-                "The argument 'steps' must be an integer"\
+                "The argument 'steps' must be an integer"
                 " greater or equal to 3. "
-                "If 'asymptote' is None, 'steps' must be"\
+                "If 'asymptote' is None, 'steps' must be"
                 " greater or equal to 4."
             )
         self.steps = steps

--- a/mitiq/folding_cirq.py
+++ b/mitiq/folding_cirq.py
@@ -17,13 +17,9 @@ def _is_measurement(op: ops.Operation) -> bool:
     return isinstance(op.gate, ops.measurement_gate.MeasurementGate)
 
 
-def _pop_measurements(
-    circuit: Circuit,
-) -> List[List[Union[int, ops.Operation]]]:
+def _pop_measurements(circuit: Circuit,) -> List[List[Union[int, ops.Operation]]]:
     """Removes all measurements from a circuit."""
-    measurements = [
-        list(m) for m in circuit.findall_operations(_is_measurement)
-    ]
+    measurements = [list(m) for m in circuit.findall_operations(_is_measurement)]
     circuit.batch_remove(measurements)
     return measurements
 
@@ -54,9 +50,7 @@ def _fold_gate_at_index_in_moment(
         None
     """
     op = circuit[moment_index].operations[gate_index]
-    circuit.insert(
-        moment_index, [op, inverse(op)], strategy=InsertStrategy.NEW
-    )
+    circuit.insert(moment_index, [op, inverse(op)], strategy=InsertStrategy.NEW)
 
 
 def _fold_gates_in_moment(
@@ -80,9 +74,7 @@ def _fold_gates_in_moment(
 
 
 def fold_gates(
-    circuit: Circuit,
-    moment_indices: Iterable[int],
-    gate_indices: List[Iterable[int]],
+    circuit: Circuit, moment_indices: Iterable[int], gate_indices: List[Iterable[int]],
 ) -> Circuit:
     """Returns a new circuit with specified gates folded.
 
@@ -106,9 +98,7 @@ def fold_gates(
         _fold_gates_in_moment(
             folded, moment_index + moment_index_shift, gate_indices[i]
         )
-        moment_index_shift += 2 * len(
-            gate_indices[i]
-        )  # Folding gates adds moments
+        moment_index_shift += 2 * len(gate_indices[i])  # Folding gates adds moments
     return folded
 
 
@@ -124,9 +114,7 @@ def _fold_moments(circuit: Circuit, moment_indices: List[int]) -> None:
     """
     shift = 0
     for i in moment_indices:
-        circuit.insert(
-            i + shift, [circuit[i + shift], inverse(circuit[i + shift])]
-        )
+        circuit.insert(i + shift, [circuit[i + shift], inverse(circuit[i + shift])])
         shift += 2
 
 
@@ -181,14 +169,11 @@ def fold_gates_from_left(circuit: Circuit, stretch: float) -> Circuit:
     """
     if not circuit.are_all_measurements_terminal():
         raise ValueError(
-            f"Input circuit contains intermediate measurements" \
-            " and cannot be folded."
+            f"Input circuit contains intermediate measurements" " and cannot be folded."
         )
 
     if not 1 <= stretch <= 3:
-        raise ValueError(
-            "The stretch factor must be a real number between 1 and 3."
-        )
+        raise ValueError("The stretch factor must be a real number between 1 and 3.")
 
     folded = deepcopy(circuit)
 
@@ -232,8 +217,7 @@ def fold_gates_from_right(circuit: Circuit, stretch: float) -> Circuit:
     """
     if not circuit.are_all_measurements_terminal():
         raise ValueError(
-            f"Input circuit contains intermediate measurements" \
-            " and cannot be folded."
+            f"Input circuit contains intermediate measurements" " and cannot be folded."
         )
 
     measurements = _pop_measurements(circuit)
@@ -276,7 +260,7 @@ def _update_moment_indices(
     """
     if moment_index_where_gate_was_folded not in moment_indices.keys():
         raise ValueError(
-            f"Moment index {moment_index_where_gate_was_folded} not in moment"\
+            f"Moment index {moment_index_where_gate_was_folded} not in moment"
             " indices"
         )
     for i in moment_indices.keys():
@@ -304,14 +288,11 @@ def fold_gates_at_random(
     """
     if not circuit.are_all_measurements_terminal():
         raise ValueError(
-            f"Input circuit contains intermediate measurements" \
-            " and cannot be folded."
+            f"Input circuit contains intermediate measurements" " and cannot be folded."
         )
 
     if not 1 <= stretch <= 3:
-        raise ValueError(
-            "The stretch factor must be a real number between 1 and 3."
-        )
+        raise ValueError("The stretch factor must be a real number between 1 and 3.")
 
     folded = deepcopy(circuit)
 
@@ -333,8 +314,7 @@ def fold_gates_at_random(
 
     # Keep track of which gates we can fold in each moment
     remaining_gate_indices = {
-        moment: list(range(len(circuit[moment])))
-        for moment in range(len(circuit))
+        moment: list(range(len(circuit[moment]))) for moment in range(len(circuit))
     }
 
     # Any moment with at least one gate is fair game
@@ -348,9 +328,7 @@ def fold_gates_at_random(
         gate_index = np.random.choice(remaining_gate_indices[moment_index])
 
         # Do the fold
-        _fold_gate_at_index_in_moment(
-            folded, moment_indices[moment_index], gate_index
-        )
+        _fold_gate_at_index_in_moment(folded, moment_indices[moment_index], gate_index)
 
         # Update the moment indices for the folded circuit
         _update_moment_indices(moment_indices, moment_index)
@@ -370,9 +348,7 @@ def fold_gates_at_random(
 def fold_local(
     circuit: Circuit,
     stretch: float,
-    fold_method: Callable[
-        [Circuit, float, Tuple[Any]], Circuit
-    ] = fold_gates_from_left,
+    fold_method: Callable[[Circuit, float, Tuple[Any]], Circuit] = fold_gates_from_left,
     fold_method_args: Tuple[Any] = (),
 ) -> Circuit:
     """Returns a folded circuit by folding gates according to the input
@@ -406,9 +382,7 @@ def fold_local(
         return folded
 
     if not 1 <= stretch:
-        raise ValueError(
-            f"The stretch factor must be a real number greater than 1."
-        )
+        raise ValueError(f"The stretch factor must be a real number greater than 1.")
 
     while stretch > 1.0:
         this_stretch = 3.0 if stretch > 3.0 else stretch
@@ -434,8 +408,7 @@ def fold_global(circuit: Circuit, stretch: float) -> Circuit:
 
     if not circuit.are_all_measurements_terminal():
         raise ValueError(
-            "Input circuit contains intermediate measurements" \
-            " and cannot be folded."
+            "Input circuit contains intermediate measurements" " and cannot be folded."
         )
 
     folded = deepcopy(circuit)

--- a/mitiq/pyquil/pyquil_utils.py
+++ b/mitiq/pyquil/pyquil_utils.py
@@ -111,8 +111,10 @@ NATIVE_NOISE = 0.007
 
 def scale_noise(pq: Program, param: float) -> Program:
     noise = param * NATIVE_NOISE
-    assert (noise <= 1.0), "Noise scaled to {} is out of bounds (<=1.0) for " \
-    "depolarizing channel.".format(noise)
+    assert noise <= 1.0, (
+        "Noise scaled to {} is out of bounds (<=1.0) for "
+        "depolarizing channel.".format(noise)
+    )
     return add_depolarizing_noise(pq, noise)
 
 

--- a/mitiq/pyquil/tests/test_zne.py
+++ b/mitiq/pyquil/tests/test_zne.py
@@ -4,9 +4,9 @@ import numpy as np
 from mitiq import QPROGRAM
 from mitiq.factories import RichardsonFactory
 from mitiq.zne import (
-    qrun_factory, 
-    execute_with_zne, 
-    mitigate_executor, 
+    qrun_factory,
+    execute_with_zne,
+    mitigate_executor,
     zne_decorator,
 )
 from mitiq.pyquil.pyquil_utils import (
@@ -49,9 +49,11 @@ def test_mitigate_executor():
     assert not np.isclose(bad_result, 1.0, atol=1.0e-1)
     assert np.isclose(good_result, 1.0, atol=1.0e-1)
 
+
 @zne_decorator(None, scale_noise)
 def decorated_executor(qp: QPROGRAM) -> float:
     return basic_executor(qp)
+
 
 def test_zne_decorator():
     rand_circ = random_identity_circuit(depth=TEST_DEPTH)

--- a/mitiq/qiskit/qiskit_utils.py
+++ b/mitiq/qiskit/qiskit_utils.py
@@ -5,9 +5,7 @@ from qiskit import QuantumCircuit
 
 # Noise simulation packages
 from qiskit.providers.aer.noise import NoiseModel
-from qiskit.providers.aer.noise.errors.standard_errors import (
-    depolarizing_error,
-)
+from qiskit.providers.aer.noise.errors.standard_errors import depolarizing_error
 
 BACKEND = qiskit.Aer.get_backend("qasm_simulator")
 # Set the random seeds for testing
@@ -99,11 +97,9 @@ CURRENT_NOISE = None
 def scale_noise(pq, param: float):
     global CURRENT_NOISE
     noise = param * NATIVE_NOISE
-    assert (
-        noise <= 1.0
-    ), "Noise scaled to {} is out of bounds (<=1.0) for depolarizing " \
-    "channel.".format(
-        noise
+    assert noise <= 1.0, (
+        "Noise scaled to {} is out of bounds (<=1.0) for depolarizing "
+        "channel.".format(noise)
     )
 
     noise_model = NoiseModel()

--- a/mitiq/qiskit/tests/test_conversions.py
+++ b/mitiq/qiskit/tests/test_conversions.py
@@ -4,11 +4,8 @@ Mitiq circuits and Qiskit circuits.
 
 import cirq
 
-from mitiq.utils import (_equal, random_circuit)
-from mitiq.qiskit.conversions import (_to_qasm,
-                                      _to_qiskit,
-                                      _from_qasm,
-                                      _from_qiskit)
+from mitiq.utils import _equal, random_circuit
+from mitiq.qiskit.conversions import _to_qasm, _to_qiskit, _from_qasm, _from_qiskit
 
 
 def test_bell_state_to_from_circuits():

--- a/mitiq/qiskit/tests/test_zne.py
+++ b/mitiq/qiskit/tests/test_zne.py
@@ -5,9 +5,9 @@ import numpy as np
 
 from mitiq.factories import RichardsonFactory
 from mitiq.zne import (
-    qrun_factory, 
-    execute_with_zne, 
-    mitigate_executor, 
+    qrun_factory,
+    execute_with_zne,
+    mitigate_executor,
     zne_decorator,
 )
 from mitiq.qiskit.qiskit_utils import (
@@ -26,7 +26,7 @@ def basic_executor(qp: QPROGRAM, shots: int = 500) -> float:
 
 def test_qrun_factory():
     qp = random_identity_circuit(depth=TEST_DEPTH)
-    qp= measure(qp, 0)
+    qp = measure(qp, 0)
     fac = RichardsonFactory([1.0, 2.0, 3.0])
     qrun_factory(fac, qp, basic_executor, scale_noise)
     result = fac.reduce()
@@ -50,9 +50,11 @@ def test_mitigate_executor():
     assert not np.isclose(bad_result, 1.0, atol=1.0e-1)
     assert np.isclose(good_result, 1.0, atol=1.0e-1)
 
+
 @zne_decorator(None, scale_noise)
 def decorated_executor(qp: QPROGRAM) -> float:
     return basic_executor(qp)
+
 
 def test_zne_decorator():
     rand_circ = random_identity_circuit(depth=TEST_DEPTH)

--- a/mitiq/tests/test_factories.py
+++ b/mitiq/tests/test_factories.py
@@ -80,14 +80,10 @@ def test_poly_extr():
     # order=1 is bad while ored=2 is better.
     algo_object = PolyFactory(X_VALS, order=1)
     run_factory(algo_object, f_non_lin)
-    assert not np.isclose(
-        algo_object.reduce(), f_non_lin(0, err=0), atol=NOT_CLOSE_TOL
-    )
+    assert not np.isclose(algo_object.reduce(), f_non_lin(0, err=0), atol=NOT_CLOSE_TOL)
     algo_object = PolyFactory(X_VALS, order=2)
     run_factory(algo_object, f_non_lin)
-    assert np.isclose(
-        algo_object.reduce(), f_non_lin(0, err=0), atol=CLOSE_TOL
-    )
+    assert np.isclose(algo_object.reduce(), f_non_lin(0, err=0), atol=CLOSE_TOL)
 
 
 @mark.parametrize("test_f", [f_exp_down, f_exp_up])
@@ -105,9 +101,7 @@ def test_poly_exp_factory_with_asympt(test_f: Callable[[float], float]):
     # order=1 is bad while order=2 is better.
     algo_object = PolyExpFactory(X_VALS, order=1, asymptote=A)
     run_factory(algo_object, test_f)
-    assert not np.isclose(
-        algo_object.reduce(), test_f(0, err=0), atol=NOT_CLOSE_TOL
-    )
+    assert not np.isclose(algo_object.reduce(), test_f(0, err=0), atol=NOT_CLOSE_TOL)
     algo_object = PolyExpFactory(X_VALS, order=2, asymptote=A)
     run_factory(algo_object, test_f)
     assert np.isclose(algo_object.reduce(), test_f(0, err=0), atol=CLOSE_TOL)
@@ -128,9 +122,7 @@ def test_poly_exp_factory_no_asympt(test_f: Callable[[float], float]):
     # order=1 is bad while order=2 is better.
     algo_object = PolyExpFactory(X_VALS, order=1, asymptote=None)
     run_factory(algo_object, test_f)
-    assert not np.isclose(
-        algo_object.reduce(), test_f(0, err=0), atol=NOT_CLOSE_TOL
-    )
+    assert not np.isclose(algo_object.reduce(), test_f(0, err=0), atol=NOT_CLOSE_TOL)
     algo_object = PolyExpFactory(X_VALS, order=2, asymptote=None)
     run_factory(algo_object, test_f)
     assert np.isclose(algo_object.reduce(), test_f(0, err=0), atol=CLOSE_TOL)
@@ -145,9 +137,7 @@ def test_ada_exp_factory_with_asympt(test_f: Callable[[float], float]):
 
 
 @mark.parametrize("test_f", [f_exp_down, f_exp_up])
-def test_ada_exp_factory_with_asympt_more_steps(
-    test_f: Callable[[float], float]
-):
+def test_ada_exp_factory_with_asympt_more_steps(test_f: Callable[[float], float]):
     """Test of the adaptive exponential extrapolator."""
     algo_object = AdaExpFactory(steps=6, scalar=2.0, asymptote=A)
     run_factory(algo_object, test_f)
@@ -163,9 +153,7 @@ def test_ada_exp_factory_no_asympt(test_f: Callable[[float], float]):
 
 
 @mark.parametrize("test_f", [f_exp_down, f_exp_up])
-def test_ada_exp_factory_no_asympt_more_steps(
-    test_f: Callable[[float], float]
-):
+def test_ada_exp_factory_no_asympt_more_steps(test_f: Callable[[float], float]):
     """Test of the adaptive exponential extrapolator."""
     algo_object = AdaExpFactory(steps=8, scalar=2.0, asymptote=None)
     run_factory(algo_object, test_f)

--- a/mitiq/tests/test_folding_cirq.py
+++ b/mitiq/tests/test_folding_cirq.py
@@ -30,9 +30,7 @@ def test_is_measurement():
     # Test circuit:
     # 0: ───H───X───Z───
     qbit = LineQubit(0)
-    circ = Circuit(
-        [ops.H.on(qbit), ops.X.on(qbit), ops.Z.on(qbit), ops.measure(qbit)]
-    )
+    circ = Circuit([ops.H.on(qbit), ops.X.on(qbit), ops.Z.on(qbit), ops.measure(qbit)])
     for (i, op) in enumerate(circ.all_operations()):
         if i == 3:
             assert _is_measurement(op)
@@ -59,9 +57,7 @@ def test_pop_measurements_and_add_measurements():
     copy = deepcopy(circ)
     measurements = _pop_measurements(copy)
     correct = Circuit(
-        [ops.H.on_each(qreg)],
-        [ops.T.on(qreg[0])],
-        [ops.CNOT.on(qreg[0], qreg[2])],
+        [ops.H.on_each(qreg)], [ops.T.on(qreg[0])], [ops.CNOT.on(qreg[0], qreg[2])],
     )
     assert _equal(copy, correct)
     _append_measurements(copy, measurements)
@@ -90,21 +86,15 @@ def test_fold_gate_at_index_in_moment_one_qubit():
     # Fold the zeroth operation in the zeroth moment
     folded = deepcopy(circ)
     _fold_gate_at_index_in_moment(folded, moment_index=0, gate_index=0)
-    assert folded == Circuit(
-        [ops.H.on(qbit)] * 3 + [ops.X.on(qbit)] + [ops.Z.on(qbit)]
-    )
+    assert folded == Circuit([ops.H.on(qbit)] * 3 + [ops.X.on(qbit)] + [ops.Z.on(qbit)])
     # Fold the zeroth operation in the first moment
     folded = deepcopy(circ)
     _fold_gate_at_index_in_moment(folded, moment_index=1, gate_index=0)
-    assert folded == Circuit(
-        [ops.H.on(qbit)] + [ops.X.on(qbit)] * 3 + [ops.Z.on(qbit)]
-    )
+    assert folded == Circuit([ops.H.on(qbit)] + [ops.X.on(qbit)] * 3 + [ops.Z.on(qbit)])
     # Fold the zeroth operation in the second moment
     folded = deepcopy(circ)
     _fold_gate_at_index_in_moment(folded, moment_index=2, gate_index=0)
-    assert folded == Circuit(
-        [ops.H.on(qbit)] + [ops.X.on(qbit)] + [ops.Z.on(qbit)] * 3
-    )
+    assert folded == Circuit([ops.H.on(qbit)] + [ops.X.on(qbit)] + [ops.Z.on(qbit)] * 3)
     # Make sure the original circuit wasn't modified
     old = Circuit([ops.H.on(qbit), ops.X.on(qbit), ops.Z.on(qbit)])
     assert _equal(circ, old)
@@ -125,8 +115,7 @@ def test_fold_gate_at_index_in_moment_two_qubits():
     folded = deepcopy(circ)
     _fold_gate_at_index_in_moment(folded, moment_index=0, gate_index=0)
     correct = Circuit(
-        [ops.H.on(qreg[0]), ops.H.on(qreg[0]) ** -1]
-        + list(circ.all_operations())
+        [ops.H.on(qreg[0]), ops.H.on(qreg[0]) ** -1] + list(circ.all_operations())
     )
     assert _equal(folded, correct)
 
@@ -134,8 +123,7 @@ def test_fold_gate_at_index_in_moment_two_qubits():
     folded = deepcopy(circ)
     _fold_gate_at_index_in_moment(folded, moment_index=0, gate_index=1)
     correct = Circuit(
-        [ops.H.on(qreg[1]), ops.H.on(qreg[1]) ** -1]
-        + list(circ.all_operations())
+        [ops.H.on(qreg[1]), ops.H.on(qreg[1]) ** -1] + list(circ.all_operations())
     )
     assert _equal(folded, correct)
 
@@ -178,8 +166,7 @@ def test_fold_gate_at_index_in_moment_two_qubit_gates():
     folded = deepcopy(circ)
     _fold_gate_at_index_in_moment(folded, moment_index=0, gate_index=0)
     correct = Circuit(
-        [ops.H.on(qreg[0]) ** -1, ops.H.on(qreg[0])]
-        + list(circ.all_operations())
+        [ops.H.on(qreg[0]) ** -1, ops.H.on(qreg[0])] + list(circ.all_operations())
     )
     assert _equal(folded, correct)
 
@@ -306,9 +293,7 @@ def test_fold_gates():
             ops.TOFFOLI.on(*qreg),
         ]
     )
-    folded = fold_gates(
-        circ, moment_indices=[0, 1], gate_indices=[[0, 1, 2], [1]]
-    )
+    folded = fold_gates(circ, moment_indices=[0, 1], gate_indices=[[0, 1, 2], [1]])
     correct = Circuit(
         [ops.H.on_each(*qreg)] * 3,
         [ops.CNOT.on(qreg[0], qreg[1])],
@@ -417,19 +402,13 @@ def test_fold_all_gates_locally_three_qubits():
 def test_fold_from_left_two_qubits():
     qreg = LineQubit.range(2)
     circ = Circuit(
-        [
-            ops.H.on_each(*qreg),
-            ops.CNOT.on(qreg[0], qreg[1]),
-            ops.T.on(qreg[1]),
-        ]
+        [ops.H.on_each(*qreg), ops.CNOT.on(qreg[0], qreg[1]), ops.T.on(qreg[1]),]
     )
 
     # Intermediate stretch factor
     folded = fold_gates_from_left(circ, stretch=2.5)
     correct = Circuit(
-        [ops.H.on_each(*qreg)] * 3,
-        [ops.CNOT.on(*qreg)] * 3,
-        [ops.T.on(qreg[1])],
+        [ops.H.on_each(*qreg)] * 3, [ops.CNOT.on(*qreg)] * 3, [ops.T.on(qreg[1])],
     )
     assert _equal(folded, correct)
 
@@ -551,9 +530,7 @@ def test_fold_from_right_basic():
     # 1: ───H───X───T───
     qreg = LineQubit.range(2)
     circ = Circuit(
-        [ops.H.on_each(*qreg)],
-        [ops.CNOT.on(qreg[0], qreg[1])],
-        [ops.T.on(qreg[1])],
+        [ops.H.on_each(*qreg)], [ops.CNOT.on(qreg[0], qreg[1])], [ops.T.on(qreg[1])],
     )
 
     # Small stretch factor
@@ -666,16 +643,12 @@ def test_fold_gates_at_random_seed_one_qubit():
     circuit = Circuit([ops.X.on(qubit), ops.Y.on(qubit), ops.Z.on(qubit)])
     # Small stretch
     folded = fold_gates_at_random(circuit, stretch=1.4, seed=1)
-    correct = Circuit(
-        [ops.X.on(qubit)], [ops.Y.on(qubit)] * 3, [ops.Z.on(qubit)]
-    )
+    correct = Circuit([ops.X.on(qubit)], [ops.Y.on(qubit)] * 3, [ops.Z.on(qubit)])
     assert _equal(folded, correct)
 
     # Medium stretch, fold two gates
     folded = fold_gates_at_random(circuit, stretch=2.5, seed=1)
-    correct = Circuit(
-        [ops.X.on(qubit)], [ops.Y.on(qubit)] * 3, [ops.Z.on(qubit)] * 3,
-    )
+    correct = Circuit([ops.X.on(qubit)], [ops.Y.on(qubit)] * 3, [ops.Z.on(qubit)] * 3,)
     assert _equal(folded, correct)
 
     # Max stretch, fold three gates

--- a/mitiq/tests/test_utils.py
+++ b/mitiq/tests/test_utils.py
@@ -23,9 +23,7 @@ def test_circuit_equality_identical_qubits(require_qubit_equality):
 
 
 @pytest.mark.parametrize(["require_qubit_equality"], [[True], [False]])
-def test_circuit_equality_nonidentical_but_equal_qubits(
-    require_qubit_equality,
-):
+def test_circuit_equality_nonidentical_but_equal_qubits(require_qubit_equality,):
     n = 5
     qregA = cirq.NamedQubit.range(n, prefix="q_")
     qregB = cirq.NamedQubit.range(n, prefix="q_")

--- a/mitiq/utils.py
+++ b/mitiq/utils.py
@@ -20,9 +20,7 @@ def random_circuit(depth: int, seed: Optional[int] = None) -> cirq.Circuit:
 
     qubit = cirq.GridQubit(0, 0)
     gates = [cirq.ops.X, cirq.ops.Y, cirq.ops.Z]
-    circuit = cirq.Circuit(
-        [random.choice(gates).on(qubit) for _ in range(depth)]
-    )
+    circuit = cirq.Circuit([random.choice(gates).on(qubit) for _ in range(depth)])
 
     return circuit
 
@@ -54,13 +52,10 @@ def _equal(
     if not require_qubit_equality:
         # Transform the qubits of circuit one to those of circuit two
         qubit_map = dict(
-            zip(
-                sorted(circuit_one.all_qubits()),
-                sorted(circuit_two.all_qubits()),
-            )
+            zip(sorted(circuit_one.all_qubits()), sorted(circuit_two.all_qubits()),)
         )
         circuit_one = circuit_one.transform_qubits(lambda q: qubit_map[q])
 
-    return cirq.CircuitDag.from_circuit(
-        circuit_one
-    ) == cirq.CircuitDag.from_circuit(circuit_two)
+    return cirq.CircuitDag.from_circuit(circuit_one) == cirq.CircuitDag.from_circuit(
+        circuit_two
+    )

--- a/mitiq/zne.py
+++ b/mitiq/zne.py
@@ -7,9 +7,7 @@ from mitiq.factories import Factory, LinearFactory
 
 
 def run_factory(
-    fac: Factory,
-    noise_to_expval: Callable[[float], float],
-    max_iterations: int = 100,
+    fac: Factory, noise_to_expval: Callable[[float], float], max_iterations: int = 100,
 ) -> None:
     """
     Runs a factory until convergence (or iterations reach "max_iterations").
@@ -121,8 +119,7 @@ def mitigate_executor(
 
 
 def zne_decorator(
-    fac: Factory = None,
-    scale_noise: Callable[[QPROGRAM, float], QPROGRAM] = None,
+    fac: Factory = None, scale_noise: Callable[[QPROGRAM, float], QPROGRAM] = None,
 ) -> Callable[[QPROGRAM], float]:
     """
     Decorator which automatically adds error mitigation to any circuit-executor
@@ -139,9 +136,7 @@ def zne_decorator(
     """
     # Formally, the function below is the actual decorator, while the function
     # "zne_decorator" is necessary to give additional arguments to "decorator".
-    def decorator(
-        executor: Callable[[QPROGRAM], float]
-    ) -> Callable[[QPROGRAM], float]:
+    def decorator(executor: Callable[[QPROGRAM], float]) -> Callable[[QPROGRAM], float]:
         return mitigate_executor(executor, fac, scale_noise)
 
     return decorator


### PR DESCRIPTION
Apply `black` to code prototyping formatting to all scripts. 
It includes also the changes made in PR #59 and would need to be reviewed after that PR.  