### PR TITLE
Make QPROGRAM type environment dependent

### DIFF
--- a/mitiq/__init__.py
+++ b/mitiq/__init__.py
@@ -3,7 +3,6 @@
 This is the top level module from which functions and classes of
 Mitiq can be directly imported.
 """
-from importlib import import_module
 import os
 from typing import Union
 


### PR DESCRIPTION
Fixes #85.

**What the error was**
The error was caused by the imports in `__init__.py` for the mitiq module. These imports of pyquil and qiskit were used to construct the union type `QPROGRAM`

**What this PR does**
These modules are now optionally imported using try except statements. Whatever modules are available will be added to the Union type of `QPROGRAM`. If neither qiskit or pyquil are available then only the `Circuit` type from cirq will be used.
