### PR TITLE
Fix factor fold_global bug: factor of 2. 

### DIFF
--- a/docs/source/guide/guide-folding.rst
+++ b/docs/source/guide/guide-folding.rst
@@ -174,7 +174,7 @@ circuit above is shown below.
     1: ───────X───
 
     # Fold the circuit
-    >>> folded = fold_global(circ, stretch=2.)
+    >>> folded = fold_global(circ, stretch=3.)
     >>> print("Folded circuit:", folded, sep="\n")
     Folded circuit:
     0: ───H───@───@───H───H───@───

--- a/mitiq/folding.py
+++ b/mitiq/folding.py
@@ -593,7 +593,7 @@ def fold_global(circuit: QPROGRAM, stretch: float, **kwargs) -> QPROGRAM:
 
     # Fold remaining gates until the stretch is reached
     ops = list(base_circuit.all_operations())
-    num_to_fold = int(round(fractional_stretch * len(ops)))
+    num_to_fold = int(round(fractional_stretch * len(ops) / 2))
 
     if num_to_fold > 0:
         folded += Circuit([inverse(ops[-num_to_fold:])], [ops[-num_to_fold:]])

--- a/mitiq/tests/test_folding.py
+++ b/mitiq/tests/test_folding.py
@@ -1028,12 +1028,10 @@ def test_global_fold_stretch_factor_eight_terminal_measurements():
         circ,
         inverse(
             Circuit(
-                [ops.CNOT.on(qreg[0], qreg[1])],
                 [ops.T.on(qreg[2])],
                 [ops.TOFFOLI.on(*qreg)],
             )
         ),
-        [ops.CNOT.on(qreg[0], qreg[1])],
         [ops.T.on(qreg[2])],
         [ops.TOFFOLI.on(*qreg)],
         meas,


### PR DESCRIPTION
1. Fix factor of 2 in `fold_global`
2. Update a test related to this
3. Minor change in documentation of `fold_global` (`stretch=2.0` --> `stretch=3.`)

@rmlarose Feel free to directly commit any change. 