### PR TITLE
Build ci only on pull request review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: Python Build
 
-on: [pull_request]:
-  types: [review_requested]
+on:
+  pull_request:
+    types: [review_requested]
 
 jobs:
   build:


### PR DESCRIPTION
Address #133 by reducing the number of builds. It removes mac, push, and should build on pull request not on single commits that are pushed but only when the PR review is requested. (I also reverted some commits pushing directly to master without a branch).