### PR TITLE
Makes Qiskit conversion functions public.

### DIFF
--- a/mitiq/folding.py
+++ b/mitiq/folding.py
@@ -90,9 +90,9 @@ def convert_to_mitiq(circuit: QPROGRAM) -> Tuple[Circuit, str]:
         input_circuit_type: Type of input circuit represented by a string.
     """
     if "qiskit" in circuit.__module__:
-        from mitiq.mitiq_qiskit.conversions import _from_qiskit
+        from mitiq.mitiq_qiskit.conversions import from_qiskit
         input_circuit_type = "qiskit"
-        mitiq_circuit = _from_qiskit(circuit)
+        mitiq_circuit = from_qiskit(circuit)
     elif isinstance(circuit, Circuit):
         input_circuit_type = "cirq"
         mitiq_circuit = circuit
@@ -112,8 +112,8 @@ def convert_from_mitiq(circuit: Circuit, conversion_type: str) -> QPROGRAM:
         conversion_type: String specifier for the converted circuit type.
     """
     if conversion_type == "qiskit":
-        from mitiq.mitiq_qiskit.conversions import _to_qiskit
-        converted_circuit = _to_qiskit(circuit)
+        from mitiq.mitiq_qiskit.conversions import to_qiskit
+        converted_circuit = to_qiskit(circuit)
     elif isinstance(circuit, Circuit):
         converted_circuit = circuit
     else:

--- a/mitiq/mitiq_qiskit/conversions.py
+++ b/mitiq/mitiq_qiskit/conversions.py
@@ -1,5 +1,5 @@
-"""Functions to convert from Mitiq's internal circuit representation
-to Qiskit representations.
+"""Functions to convert between Mitiq's internal circuit representation
+and Qiskit's circuit representation.
 """
 
 import cirq
@@ -10,7 +10,7 @@ from qiskit import QuantumCircuit
 QASMType = str
 
 
-def _to_qasm(circuit: cirq.Circuit) -> QASMType:
+def to_qasm(circuit: cirq.Circuit) -> QASMType:
     """Returns a QASM string representing the input Mitiq circuit.
 
     Args:
@@ -22,7 +22,7 @@ def _to_qasm(circuit: cirq.Circuit) -> QASMType:
     return circuit.to_qasm()
 
 
-def _to_qiskit(circuit: cirq.Circuit) -> QuantumCircuit:
+def to_qiskit(circuit: cirq.Circuit) -> QuantumCircuit:
     """Returns a Qiskit circuit equivalent to the input Mitiq circuit.
 
     Args:
@@ -31,10 +31,10 @@ def _to_qiskit(circuit: cirq.Circuit) -> QuantumCircuit:
     Returns:
         Qiskit.QuantumCircuit object equivalent to the input Mitiq circuit.
     """
-    return QuantumCircuit.from_qasm_str(_to_qasm(circuit))
+    return QuantumCircuit.from_qasm_str(to_qasm(circuit))
 
 
-def _from_qiskit(circuit: QuantumCircuit) -> cirq.Circuit:
+def from_qiskit(circuit: QuantumCircuit) -> cirq.Circuit:
     """Returns a Mitiq circuit equivalent to the input Qiskit circuit.
 
     Args:
@@ -43,10 +43,10 @@ def _from_qiskit(circuit: QuantumCircuit) -> cirq.Circuit:
     Returns:
         Mitiq circuit representation equivalent to the input Qiskit circuit.
     """
-    return _from_qasm(circuit.qasm())
+    return from_qasm(circuit.qasm())
 
 
-def _from_qasm(qasm: QASMType) -> cirq.Circuit:
+def from_qasm(qasm: QASMType) -> cirq.Circuit:
     """Returns a Mitiq circuit equivalent to the input QASM string.
 
     Args:

--- a/mitiq/mitiq_qiskit/tests/test_conversions.py
+++ b/mitiq/mitiq_qiskit/tests/test_conversions.py
@@ -5,10 +5,10 @@ Mitiq circuits and Qiskit circuits.
 import cirq
 
 from mitiq.utils import (_equal, random_circuit)
-from mitiq.mitiq_qiskit.conversions import (_to_qasm,
-                                      _to_qiskit,
-                                      _from_qasm,
-                                      _from_qiskit)
+from mitiq.mitiq_qiskit.conversions import (to_qasm,
+                                            to_qiskit,
+                                            from_qasm,
+                                            from_qiskit)
 
 
 def test_bell_state_to_from_circuits():
@@ -19,8 +19,8 @@ def test_bell_state_to_from_circuits():
     cirq_circuit = cirq.Circuit(
         [cirq.ops.H.on(qreg[0]), cirq.ops.CNOT.on(qreg[0], qreg[1])]
     )
-    qiskit_circuit = _to_qiskit(cirq_circuit)  # Qiskit from Cirq
-    circuit_cirq = _from_qiskit(qiskit_circuit)  # Cirq from Qiskit
+    qiskit_circuit = to_qiskit(cirq_circuit)  # Qiskit from Cirq
+    circuit_cirq = from_qiskit(qiskit_circuit)  # Cirq from Qiskit
     assert _equal(cirq_circuit, circuit_cirq)
 
 
@@ -32,8 +32,8 @@ def test_bell_state_to_from_qasm():
     cirq_circuit = cirq.Circuit(
         [cirq.ops.H.on(qreg[0]), cirq.ops.CNOT.on(qreg[0], qreg[1])]
     )
-    qasm = _to_qasm(cirq_circuit)  # Qasm from Cirq
-    circuit_cirq = _from_qasm(qasm)
+    qasm = to_qasm(cirq_circuit)  # Qasm from Cirq
+    circuit_cirq = from_qasm(qasm)
     assert _equal(cirq_circuit, circuit_cirq)
 
 
@@ -42,8 +42,8 @@ def test_random_circuit_to_from_circuits():
     with a random one-qubit circuit.
     """
     cirq_circuit = random_circuit(depth=20)
-    qiskit_circuit = _to_qiskit(cirq_circuit)
-    circuit_cirq = _from_qiskit(qiskit_circuit)
+    qiskit_circuit = to_qiskit(cirq_circuit)
+    circuit_cirq = from_qiskit(qiskit_circuit)
     assert _equal(cirq_circuit, circuit_cirq)
 
 
@@ -52,6 +52,6 @@ def test_random_circuit_to_from_qasm():
      with a random one-qubit circuit.
     """
     cirq_circuit = random_circuit(depth=20)
-    qasm = _to_qasm(cirq_circuit)
-    circuit_cirq = _from_qasm(qasm)
+    qasm = to_qasm(cirq_circuit)
+    circuit_cirq = from_qasm(qasm)
     assert _equal(cirq_circuit, circuit_cirq)

--- a/mitiq/tests/test_folding.py
+++ b/mitiq/tests/test_folding.py
@@ -37,7 +37,7 @@ from mitiq.folding import (
     fold_local,
     fold_global,
 )
-from mitiq.mitiq_qiskit.conversions import _from_qiskit
+from mitiq.mitiq_qiskit.conversions import from_qiskit
 
 
 def test_is_measurement():
@@ -1189,7 +1189,7 @@ def test_fold_from_left_with_qiskit_circuits():
     #  See https://github.com/unitaryfund/mitiq/issues/99.
 
     # Check equality of the final unitaries
-    cirq_circuit = _from_qiskit(qiskit_circuit)
+    cirq_circuit = from_qiskit(qiskit_circuit)
     unitary = cirq_circuit.unitary()
     folded_unitary = correct_folded_circuit.unitary()
     assert equal_up_to_global_phase(unitary, folded_unitary)
@@ -1241,7 +1241,7 @@ def test_fold_from_right_with_qiskit_circuits():
     #  See https://github.com/unitaryfund/mitiq/issues/99.
 
     # Check equality of the final unitaries
-    cirq_circuit = _from_qiskit(qiskit_circuit)
+    cirq_circuit = from_qiskit(qiskit_circuit)
     unitary = cirq_circuit.unitary()
     folded_unitary = correct_folded_circuit.unitary()
     assert equal_up_to_global_phase(unitary, folded_unitary)
@@ -1291,7 +1291,7 @@ def test_fold_at_random_with_qiskit_circuits():
     #  See https://github.com/unitaryfund/mitiq/issues/99.
 
     # Check equality of the final unitaries
-    cirq_circuit = _from_qiskit(qiskit_circuit)
+    cirq_circuit = from_qiskit(qiskit_circuit)
     unitary = cirq_circuit.unitary()
     folded_unitary = correct_folded_circuit.unitary()
     assert equal_up_to_global_phase(unitary, folded_unitary)


### PR DESCRIPTION
Immediate reason for this is the example using an IBMQ backend with a Cirq frontend (PR #140). More generally these conversions will probably be useful elsewhere and so should be public.