### PR TITLE
Add a build / test script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest mitiq/tests
-        pytest mitiq/benchmarks/tests
-        pytest mitiq/mitiq_qiskit/tests
+        ./test_build.sh -tests
     - name: Test documentation with sphinx
       run: |
-        cd docs && make html
-        make doctest
+        ./test_build.sh -docs

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ updated to the latest release can be found
 
 ## Development and Testing
 Ensure that you have installed the development environment. Then
-you can run tests with `pytest`.
+you can run tests and build the docs with `./test_build.sh`.
 
 ## Contributing
 You can contribute to `mitiq` code by raising an

--- a/test_build.sh
+++ b/test_build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [ "$1" != "-docs" ]; then
+    echo "Running Tests...";
+    pytest mitiq/tests;
+    pytest mitiq/benchmarks/tests;
+    pytest mitiq/mitiq_qiskit/tests;
+elif [ "$1" != "-tests" ]; then
+    echo "Building and Testing Docs...";
+    cd docs && make html;
+    make doctest;
+fi


### PR DESCRIPTION
This PR is related to #155.

Thanks to the wonders of doctest, our documentation now includes testing that should be regularly done locally as well as by the automated system.

This PR adds a test script `test_build.sh` that can be run locally to do all the customized testing and building that we want. This PR also changes the CLI to run this script for its testing, thus ensuring that local testing is the same as the CLI testing.