### PR TITLE
Remove error from pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
 filterwarnings =
-    error
     ignore::UserWarning
     ignore::DeprecationWarning


### PR DESCRIPTION
Remove `error` from the `pytest.ini` configuration file. The current warnings are there in order to suppress their messages when running pytest on mitiq. This should fix the problems with pytest on master #176.   