### PR TITLE
small fix: remove line with 'var' in getting_started

### DIFF
--- a/docs/source/guide/guide_02-getting-started.rst
+++ b/docs/source/guide/guide_02-getting-started.rst
@@ -86,8 +86,6 @@ performance.
 
     Mitigation provides a 97.6 factor of improvement.
 
-The variance in the mitigated expectation value is now stored in ``var``.
-
 You can also use ``mitiq`` to wrap your backend execution function into an
 error-mitigated version.
 


### PR DESCRIPTION
@willzeng I guess this is an old line which should be removed. Right?