### PR TITLE
Fixes bug in available program types

### DIFF
--- a/mitiq/__init__.py
+++ b/mitiq/__init__.py
@@ -13,8 +13,7 @@ from cirq import Circuit
 # by mitiq based on what packages are installed in the environment
 SUPPORTED_PROGRAM_TYPES = {
     "cirq": "Circuit",
-    "qiskit": "QuantumCircuit",
-    "pyquil": "Program"
+    "qiskit": "QuantumCircuit"
 }
 AVAILABLE_PROGRAM_TYPES = {}
 
@@ -25,7 +24,10 @@ for (module, program_type) in SUPPORTED_PROGRAM_TYPES.items():
     except ImportError:
         pass
 
-QPROGRAM = Union[tuple(AVAILABLE_PROGRAM_TYPES)]
+QPROGRAM = Union[
+    tuple(f"{package}.{circuit}"
+     for package, circuit in AVAILABLE_PROGRAM_TYPES.items())
+]
 
 # this must be after QPROGRAM as the zne.py module imports QPROGRAM
 from mitiq.zne import execute_with_zne, mitigate_executor


### PR DESCRIPTION
Fixes part of #106. Also removes pyQuil.Program from supported program types.

Behavior is now as expected for an installation with only Cirq:

```python
import mitiq

mitiq.SUPPORTED_PROGRAM_TYPES
# {'cirq': 'Circuit', 'qiskit': 'QuantumCircuit'}

mitiq.AVAILABLE_PROGRAM_TYPES
# {'cirq': 'Circuit'}

mitiq.QPROGRAM
# _ForwardRef('cirq.Circuit')
```