### PR TITLE
Clean up mitiq_qiskit

### DIFF
--- a/mitiq/mitiq_qiskit/__init__.py
+++ b/mitiq/mitiq_qiskit/__init__.py
@@ -1,0 +1,10 @@
+from mitiq.mitiq_qiskit.conversions import (
+    from_qasm,
+    from_qiskit,
+    to_qasm,
+    to_qiskit
+)
+from mitiq.mitiq_qiskit.qiskit_utils import (
+    random_one_qubit_identity_circuit,
+    run_with_noise
+)

--- a/mitiq/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/mitiq_qiskit/qiskit_utils.py
@@ -1,39 +1,35 @@
 from typing import Optional
-import qiskit
-from qiskit import QuantumCircuit, ClassicalRegister
+from qiskit import Aer, execute, ClassicalRegister, QuantumCircuit
 
 # Noise simulation packages
 from qiskit.providers.aer.noise import NoiseModel
-from qiskit.providers.aer.noise.errors.standard_errors import (
-    depolarizing_error,
-)
+from qiskit.providers.aer.noise.errors.standard_errors import depolarizing_error
 
 from mitiq.benchmarks.randomized_benchmarking import rb_circuits
 from mitiq.mitiq_qiskit.conversions import to_qiskit
 
-BACKEND = qiskit.Aer.get_backend("qasm_simulator")
+BACKEND = Aer.get_backend("qasm_simulator")
 
 
-def random_identity_circuit(num_cliffords=None, seed: Optional[int] = None):
+def random_one_qubit_identity_circuit(num_cliffords: int) -> QuantumCircuit:
     """Returns a single-qubit identity circuit.
 
     Args:
-        num_cliffords (int): Number of cliffords used to generate the random circuit.
-        seed: Optional seed for random number generator.
+        num_cliffords (int): Number of cliffords used to generate the circuit.
 
     Returns:
         circuit: Quantum circuit as a :class:`qiskit.QuantumCircuit` object.
     """
-    return to_qiskit(rb_circuits(n_qubits=1,
-                                 num_cliffords=[num_cliffords],
-                                 trials=1)[0])
+    return to_qiskit(
+        rb_circuits(n_qubits=1, num_cliffords=[num_cliffords], trials=1)[0]
+    )
 
 
 def run_with_noise(
-        circuit: QuantumCircuit,
-        noise: float,
-        shots: int,
-        seed: Optional[int] = None
+    circuit: QuantumCircuit,
+    noise: float,
+    shots: int,
+    seed: Optional[int] = None
 ) -> float:
     """Runs the quantum circuit with a depolarizing channel noise model.
 
@@ -56,7 +52,7 @@ def run_with_noise(
     )
 
     # execution of the experiment
-    job = qiskit.execute(
+    job = execute(
         circuit,
         backend=BACKEND,
         basis_gates=["u1", "u2", "u3"],
@@ -126,7 +122,7 @@ def run_program(pq: QuantumCircuit, shots: int = 100,
     Returns:
         expval: expected value.
     """
-    job = qiskit.execute(
+    job = execute(
         pq,
         backend=BACKEND,
         basis_gates=["u1", "u2", "u3"],
@@ -141,22 +137,3 @@ def run_program(pq: QuantumCircuit, shots: int = 100,
     counts = results.get_counts()
     expval = counts["0"] / shots
     return expval
-
-
-def measure(circuit, qid) -> QuantumCircuit:
-    """Apply the measure method on the first qubit of a quantum circuit
-    given a classical register.
-
-    Args:
-        circuit: Quantum circuit.
-        qid: classical register.
-
-    Returns:
-        circuit: circuit after the measurement.
-    """
-    # Ensure that we have a classical register of enough size available
-    if len(circuit.clbits) == 0:
-        reg = ClassicalRegister(qid + 1,'creg')
-        circuit.add_register(reg)
-    circuit.measure(0, qid)
-    return circuit

--- a/mitiq/mitiq_qiskit/tests/test_zne.py
+++ b/mitiq/mitiq_qiskit/tests/test_zne.py
@@ -3,6 +3,8 @@
 from mitiq import QPROGRAM
 import numpy as np
 
+from qiskit import ClassicalRegister, QuantumCircuit
+
 from mitiq.factories import RichardsonFactory
 from mitiq.zne import (
     execute_with_zne,
@@ -10,8 +12,7 @@ from mitiq.zne import (
     zne_decorator,
 )
 from mitiq.mitiq_qiskit.qiskit_utils import (
-    random_identity_circuit,
-    measure,
+    random_one_qubit_identity_circuit,
     run_program,
     scale_noise,
 )
@@ -19,6 +20,25 @@ from mitiq.mitiq_qiskit.qiskit_utils import (
 TEST_DEPTH = 30
 CIRCUIT_SEED = 1
 QISKIT_SEED = 1337
+
+
+def measure(circuit, qid) -> QuantumCircuit:
+    """Apply the measure method on the first qubit of a quantum circuit
+    given a classical register.
+
+    Args:
+        circuit: Quantum circuit.
+        qid: classical register.
+
+    Returns:
+        circuit: circuit after the measurement.
+    """
+    # Ensure that we have a classical register of enough size available
+    if len(circuit.clbits) == 0:
+        reg = ClassicalRegister(qid + 1, 'creg')
+        circuit.add_register(reg)
+    circuit.measure(0, qid)
+    return circuit
 
 
 def basic_executor(qp: QPROGRAM, shots: int = 500) -> float:
@@ -36,7 +56,7 @@ def basic_executor(qp: QPROGRAM, shots: int = 500) -> float:
 
 def test_run_factory():
     """Tests qrun of a Richardson Factory."""
-    qp = random_identity_circuit(num_cliffords=TEST_DEPTH, seed=CIRCUIT_SEED)
+    qp = random_one_qubit_identity_circuit(num_cliffords=TEST_DEPTH)
     qp = measure(qp, 0)
     fac = RichardsonFactory([1.0, 2.0, 3.0])
     fac.run(qp, basic_executor, scale_noise)
@@ -47,8 +67,7 @@ def test_run_factory():
 def test_execute_with_zne():
     """Tests a random identity circuit execution with zero-noise extrapolation.
     """
-    rand_circ = random_identity_circuit(num_cliffords=TEST_DEPTH,
-                                        seed=CIRCUIT_SEED)
+    rand_circ = random_one_qubit_identity_circuit(num_cliffords=TEST_DEPTH)
     qp = measure(rand_circ, qid=0)
     result = execute_with_zne(qp, basic_executor, None, scale_noise)
     assert np.isclose(result, 1.0, atol=1.0e-1)
@@ -56,7 +75,7 @@ def test_execute_with_zne():
 
 def test_mitigate_executor():
     """Tests a random identity circuit executor."""
-    rand_circ = random_identity_circuit(num_cliffords=TEST_DEPTH)
+    rand_circ = random_one_qubit_identity_circuit(num_cliffords=TEST_DEPTH)
     qp = measure(rand_circ, qid=0)
     new_executor = mitigate_executor(basic_executor, None, scale_noise)
     # bad_result is computed with native noise (scale = 1)
@@ -73,8 +92,7 @@ def decorated_executor(qp: QPROGRAM) -> float:
 
 def test_zne_decorator():
     """Tests a zne decorator."""
-    rand_circ = random_identity_circuit(num_cliffords=TEST_DEPTH,
-                                        seed=CIRCUIT_SEED)
+    rand_circ = random_one_qubit_identity_circuit(num_cliffords=TEST_DEPTH)
     qp = measure(rand_circ, qid=0)
     # bad_result is computed with native noise (scale = 1)
     bad_result = basic_executor(scale_noise(qp, 1))


### PR DESCRIPTION
Fixes #202.

Changes:

- Imports in mitiq_qiskit. 
- Removes unused seed for random_identity_circuit + renames function. 
- Moves `measure` from utils to the test file.