### PR TITLE
preserve doc of executor and fix decorator error

### DIFF
--- a/mitiq/tests/test_zne.py
+++ b/mitiq/tests/test_zne.py
@@ -10,7 +10,7 @@ from mitiq.factories import LinearFactory, RichardsonFactory
 from mitiq.folding import (
     fold_gates_from_left, fold_gates_from_right, fold_gates_at_random
 )
-from mitiq.zne import execute_with_zne
+from mitiq.zne import execute_with_zne, mitigate_executor, zne_decorator
 
 
 # Default qubit register and circuit for unit tests
@@ -52,3 +52,30 @@ def test_execute_with_zne_bad_arguments():
 
     with pytest.raises(TypeError, match="Argument `scale_noise` must be"):
         execute_with_zne(circ, executor, scale_noise=None)
+
+def test_error_zne_decorator():
+    """Tests that the proper error is raised if the decorator is used without parenthesis."""
+    with pytest.raises(TypeError, match="The decorator must be used with parenthesis"):
+        @zne_decorator
+        def test_executor(circuit):
+            return 0
+
+def test_doc_is_preserved():
+    """Tests that the doc of the original executor is preserved."""
+    
+    def first_executor(circuit):
+        """Doc of the original executor."""
+        return 0
+
+    mit_executor = mitigate_executor(first_executor)
+    assert mit_executor.__doc__ == first_executor.__doc__
+
+    @zne_decorator()
+    def second_executor(circuit):
+        """Doc of the original executor."""
+        return 0
+
+    assert second_executor.__doc__ == first_executor.__doc__
+
+
+

--- a/mitiq/zne.py
+++ b/mitiq/zne.py
@@ -1,6 +1,7 @@
 """High-level zero-noise extrapolation tools."""
 
 from typing import Callable
+from functools import wraps
 
 from mitiq import QPROGRAM
 from mitiq.factories import Factory, RichardsonFactory
@@ -57,6 +58,8 @@ def mitigate_executor(
         factory: Factory object determining the zero-noise extrapolation method.
         scale_noise: Function for scaling the noise of a quantum circuit.
     """
+
+    @wraps(executor)
     def new_executor(qp: QPROGRAM) -> float:
         return execute_with_zne(qp, executor, factory, scale_noise)
     return new_executor
@@ -74,6 +77,12 @@ def zne_decorator(
         factory: Factory object determining the zero-noise extrapolation method.
         scale_noise: Function for scaling the noise of a quantum circuit.
     """
+    
+    # raise an error if the decorator is used without parenthesis
+    if callable(factory):
+        raise TypeError("The decorator must be used with parenthesis even"
+                        " if no explicit arguments are passed, i.e., @zne_decorator().")
+
     def decorator(
         executor: Callable[[QPROGRAM], float]
     ) -> Callable[[QPROGRAM], float]:


### PR DESCRIPTION
This is related to a discussion started in #234.  

1. use `wraps` to preserve the docstring of executors
2. add new tests to `test_zne.py`
3. add `TypeError` if the decorator is used without parenthesis

