### PR TITLE
Add basic compilation facilities, don't relabel qubits

### DIFF
--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -34,7 +34,10 @@ CFD_MAT_1Q = np.array([_gate_seq_to_mats(gates) for gates in C1])
 
 
 def rb_circuits(
-    n_qubits: int, num_cliffords: List[int], trials: int, qubit_labels: Optional[List[int]] = None,
+    n_qubits: int,
+    num_cliffords: List[int],
+    trials: int,
+    qubit_labels: Optional[List[int]] = None,
 ) -> List[Circuit]:
     """Generates a set of randomized benchmarking circuits, i.e. circuits that
     are equivalent to the identity.

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -16,7 +16,7 @@
 """Contains methods used for testing mitiq's performance on randomized
 benchmarking circuits.
 """
-from typing import List
+from typing import List, Optional
 import numpy as np
 
 from cirq.experiments.qubit_characterizations import (
@@ -26,7 +26,7 @@ from cirq.experiments.qubit_characterizations import (
     _gate_seq_to_mats,
     _two_qubit_clifford_matrices,
 )
-from cirq import NamedQubit, Circuit
+from cirq import LineQubit, Circuit
 
 CLIFFORDS = _single_qubit_cliffords()
 C1 = CLIFFORDS.c1_in_xy
@@ -34,7 +34,7 @@ CFD_MAT_1Q = np.array([_gate_seq_to_mats(gates) for gates in C1])
 
 
 def rb_circuits(
-    n_qubits: int, num_cliffords: List[int], trials: int
+    n_qubits: int, num_cliffords: List[int], trials: int, qubit_labels: Optional[List[int]] = None,
 ) -> List[Circuit]:
     """Generates a set of randomized benchmarking circuits, i.e. circuits that
     are equivalent to the identity.
@@ -51,7 +51,8 @@ def rb_circuits(
     """
     rb_circuits = []
     for num in num_cliffords:
-        qubit1 = NamedQubit("0")
+        qid0 = qubit_labels[0] if qubit_labels else 0
+        qubit1 = LineQubit(qid0)
         if n_qubits == 1:
             rb_circuits = [
                 _random_single_q_clifford(
@@ -63,7 +64,8 @@ def rb_circuits(
                 for _ in range(trials)
             ]
         elif n_qubits == 2:
-            qubit2 = NamedQubit("1")
+            qid1 = qubit_labels[1] if qubit_labels else 1
+            qubit2 = LineQubit(qid1)
             cfd_matrices = _two_qubit_clifford_matrices(
                 qubit1, qubit2, CLIFFORDS,  # type: ignore
             )

--- a/mitiq/mitiq_pyquil/compiler.py
+++ b/mitiq/mitiq_pyquil/compiler.py
@@ -25,6 +25,7 @@ from typing import Tuple
 
 import numpy as np
 
+from cirq import match_global_phase
 from pyquil.gates import RX, RZ, CZ, I, XY
 from pyquil.quil import Program
 from pyquil.quilbase import Gate
@@ -213,44 +214,10 @@ def _Z(q: int) -> Program:
     return p
 
 
-# This function is taken from cirq. License: apache 2.
-def match_global_phase(
-    a: np.ndarray, b: np.ndarray
-) -> Tuple[np.ndarray, np.ndarray]:
-    """
-    Phases the given matrices so that they agree on the phase of one entry.
-    To maximize precision, the position with the largest entry from one of the
-    matrices is used when attempting to compute the phase difference between
-    the two matrices.
-    :param a: The first matrix
-    :param b: The second matrix
-    :return: A tuple (a', b') where a' == b' implies a == b*exp(i t) for some t
-    """
-
-    # Not much point when they have different shapes.
-    if a.shape != b.shape:
-        return a, b  # pragma: no coverage
-
-    # Find the entry with the largest magnitude in one of the matrices.
-    k = max(np.ndindex(*a.shape), key=lambda t: abs(b[t]))
-
-    def dephase(v):
-        r = np.real(v)
-        i = np.imag(v)
-
-        # Avoid introducing floating point error when axis-aligned.
-        if i == 0:
-            return -1 if r < 0 else 1
-        if r == 0:
-            return 1j if i < 0 else -1j
-
-        return np.exp(-1j * np.arctan2(i, r))
-
-    # Zero the phase at this entry in both matrices.
-    return a * dephase(a[k]), b * dephase(b[k])
-
-
 def is_magic_angle(angle: float) -> bool:
+    """
+    Checks to see if an angle is 0, +/-pi/2, or +/-pi.
+    """
     return (
         np.isclose(np.abs(angle), pi / 2)
         or np.isclose(np.abs(angle), pi)

--- a/mitiq/mitiq_pyquil/compiler.py
+++ b/mitiq/mitiq_pyquil/compiler.py
@@ -242,16 +242,13 @@ def basic_compile(program: Program) -> Program:
 
     for inst in program:
         if isinstance(inst, Gate):
-            angle_param = None
-            if len(inst.params) > 0:
-                angle_param = inst.params[0]
-
             if inst.name == "CCNOT":
                 new_prog += _CCNOT(*inst.qubits)
             elif inst.name == "CNOT":
                 new_prog += _CNOT(*inst.qubits)
             # NB: we haven't implemented CPHASE00/01/10
             elif inst.name == "CPHASE":
+                angle_param = inst.params[0]
                 new_prog += _CPHASE(angle_param, *inst.qubits)
             elif inst.name == "CZ":
                 new_prog += CZ(*inst.qubits)  # remove dag modifiers
@@ -262,17 +259,21 @@ def basic_compile(program: Program) -> Program:
             elif inst.name == "ISWAP":
                 new_prog += _ISWAP(*inst.qubits)  # remove dag modifiers
             elif inst.name == "PHASE":
+                angle_param = inst.params[0]
                 new_prog += _PHASE(angle_param, inst.qubits[0])
             elif inst.name == "RX":
+                angle_param = inst.params[0]
                 if is_magic_angle(inst.params[0]):
                     # in case dagger
                     new_prog += RX(angle_param, inst.qubits[0])
                 else:
                     new_prog += _RX(angle_param, inst.qubits[0])
             elif inst.name == "RY":
+                angle_param = inst.params[0]
                 new_prog += _RY(angle_param, inst.qubits[0])
             elif inst.name == "RZ":
                 # in case dagger
+                angle_param = inst.params[0]
                 new_prog += RZ(angle_param, inst.qubits[0])
             elif inst.name == "S":
                 new_prog += _S(inst.qubits[0])
@@ -284,6 +285,7 @@ def basic_compile(program: Program) -> Program:
             elif inst.name == "X":
                 new_prog += _X(inst.qubits[0])
             elif inst.name == "XY":
+                angle_param = inst.params[0]
                 new_prog += XY(angle_param, *inst.qubits)
             elif inst.name == "Y":
                 new_prog += _Y(inst.qubits[0])

--- a/mitiq/mitiq_pyquil/compiler.py
+++ b/mitiq/mitiq_pyquil/compiler.py
@@ -218,9 +218,9 @@ def _Z(q: int) -> Program:
 
 
 # This function is taken from cirq. License: apache 2.
-def match_global_phase(a: np.ndarray,
-                       b: np.ndarray
-                       ) -> Tuple[np.ndarray, np.ndarray]:
+def match_global_phase(
+    a: np.ndarray, b: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
     """
     Phases the given matrices so that they agree on the phase of one entry.
     To maximize precision, the position with the largest entry from one of the
@@ -255,9 +255,11 @@ def match_global_phase(a: np.ndarray,
 
 
 def is_magic_angle(angle: float) -> bool:
-    return (np.isclose(np.abs(angle), pi / 2)
-            or np.isclose(np.abs(angle), pi)
-            or np.isclose(angle, 0.0))
+    return (
+        np.isclose(np.abs(angle), pi / 2)
+        or np.isclose(np.abs(angle), pi)
+        or np.isclose(angle, 0.0)
+    )
 
 
 def basic_compile(program: Program) -> Program:
@@ -282,54 +284,56 @@ def basic_compile(program: Program) -> Program:
         if isinstance(inst, Gate):
             # TODO: this is only a stopgap while the noisy QVM does not support modifiers.
             # dagger this gate if odd number of daggers. Ignore controlled for now.
-            needs_dagger = inst.modifiers.count('DAGGER') % 2 == 1
+            needs_dagger = inst.modifiers.count("DAGGER") % 2 == 1
             angle_param = None
             if len(inst.params) > 0:
                 angle_param = inst.params[0]
                 if needs_dagger:
                     angle_param = -angle_param
 
-            if 'CONTROLLED' in inst.modifiers:
-                raise ValueError("Controlled gates are not currently supported.")
+            if "CONTROLLED" in inst.modifiers:
+                raise ValueError(
+                    "Controlled gates are not currently supported."
+                )
 
-            if inst.name == 'CCNOT':
+            if inst.name == "CCNOT":
                 new_prog += _CCNOT(*inst.qubits)
-            elif inst.name == 'CNOT':
+            elif inst.name == "CNOT":
                 new_prog += _CNOT(*inst.qubits)
             # NB: we haven't implemented CPHASE00/01/10
-            elif inst.name == 'CPHASE':
+            elif inst.name == "CPHASE":
                 new_prog += _CPHASE(angle_param, *inst.qubits)
-            elif inst.name == 'CZ':
+            elif inst.name == "CZ":
                 new_prog += CZ(*inst.qubits)  # remove dag modifiers
             elif inst.name == "H":
                 new_prog += _H(inst.qubits[0])
-            elif inst.name == 'I':
+            elif inst.name == "I":
                 new_prog += I(inst.qubits[0])  # remove dag modifiers
-            elif inst.name == 'ISWAP':
+            elif inst.name == "ISWAP":
                 new_prog += _ISWAP(*inst.qubits)  # remove dag modifiers
-            elif inst.name == 'PHASE':
+            elif inst.name == "PHASE":
                 new_prog += _PHASE(angle_param, inst.qubits[0])
-            elif inst.name == 'RX':
+            elif inst.name == "RX":
                 if is_magic_angle(inst.params[0]):
                     # in case dagger
                     new_prog += RX(angle_param, inst.qubits[0])
                 else:
                     new_prog += _RX(angle_param, inst.qubits[0])
-            elif inst.name == 'RY':
+            elif inst.name == "RY":
                 new_prog += _RY(angle_param, inst.qubits[0])
-            elif inst.name == 'RZ':
+            elif inst.name == "RZ":
                 # in case dagger
                 new_prog += RZ(angle_param, inst.qubits[0])
-            elif inst.name == 'S':
+            elif inst.name == "S":
                 new_prog += _S(inst.qubits[0], needs_dagger)
             # NB: we haven't implemented CSWAP or PSWAP
-            elif inst.name == 'SWAP':
+            elif inst.name == "SWAP":
                 new_prog += _SWAP(*inst.qubits)
-            elif inst.name == 'T':
+            elif inst.name == "T":
                 new_prog += _T(inst.qubits[0], needs_dagger)
             elif inst.name == "X":
                 new_prog += _X(inst.qubits[0])
-            elif inst.name == 'XY':
+            elif inst.name == "XY":
                 new_prog += XY(angle_param, *inst.qubits)
             elif inst.name == "Y":
                 new_prog += _Y(inst.qubits[0])
@@ -337,7 +341,7 @@ def basic_compile(program: Program) -> Program:
                 new_prog += _Z(inst.qubits[0])
             elif inst.name in [gate.name for gate in new_prog.defined_gates]:
                 if needs_dagger and inst.name not in daggered_defgates:
-                    new_prog.defgate(inst.name + 'DAG', inst.matrix.T.conj())
+                    new_prog.defgate(inst.name + "DAG", inst.matrix.T.conj())
                     daggered_defgates.append(inst.name)
                 new_prog += inst
             else:
@@ -347,12 +351,12 @@ def basic_compile(program: Program) -> Program:
             new_prog += inst
 
     new_prog.native_quil_metadata = {
-        'final_rewiring': None,
-        'gate_depth': None,
-        'gate_volume': None,
-        'multiqubit_gate_depth': None,
-        'program_duration': None,
-        'program_fidelity': None,
-        'topological_swaps': 0,
+        "final_rewiring": None,
+        "gate_depth": None,
+        "gate_volume": None,
+        "multiqubit_gate_depth": None,
+        "program_duration": None,
+        "program_fidelity": None,
+        "topological_swaps": 0,
     }
     return new_prog

--- a/mitiq/mitiq_pyquil/compiler.py
+++ b/mitiq/mitiq_pyquil/compiler.py
@@ -21,11 +21,9 @@ and modified to support a larger gateset (e.g. CPHASE).
 """
 
 from math import pi
-from typing import Tuple
 
 import numpy as np
 
-from cirq import match_global_phase
 from pyquil.gates import RX, RZ, CZ, I, XY
 from pyquil.quil import Program
 from pyquil.quilbase import Gate

--- a/mitiq/mitiq_pyquil/compiler.py
+++ b/mitiq/mitiq_pyquil/compiler.py
@@ -228,7 +228,7 @@ def match_global_phase(
     the two matrices.
     :param a: The first matrix
     :param b: The second matrix
-    :return: A tuple (a', b') where a' == b' implies a == b*exp(i t) for some t.
+    :return: A tuple (a', b') where a' == b' implies a == b*exp(i t) for some t
     """
 
     # Not much point when they have different shapes.
@@ -266,13 +266,14 @@ def basic_compile(program: Program) -> Program:
     """
     A rudimentary but predictable compiler.
 
-    No rewiring or optimization is done by this compilation step. There may be some gates that
-    are not yet supported. Gates defined in the input program are included without change in the
-    output program.
+    No rewiring or optimization is done by this compilation step. There may be
+    some gates that are not yet supported. Gates defined in the input program
+    are included without change in the output program.
 
-    :param program: a program to be compiled to native quil with simple replacements.
-    :return: a program with some of the input non-native quil gates replaced with basic native quil
-        gate implementations.
+    :param program: A program to be compiled to native quil with simple
+        replacements.
+    :return: A program with some of the input non-native quil gates replaced
+        with basic native quil gate implementations.
     """
     new_prog = Program()
     new_prog.num_shots = program.num_shots
@@ -282,8 +283,8 @@ def basic_compile(program: Program) -> Program:
 
     for inst in program:
         if isinstance(inst, Gate):
-            # TODO: this is only a stopgap while the noisy QVM does not support modifiers.
-            # dagger this gate if odd number of daggers. Ignore controlled for now.
+            # Dagger this gate if odd number of daggers.
+            # Ignore controlled for now.
             needs_dagger = inst.modifiers.count("DAGGER") % 2 == 1
             angle_param = None
             if len(inst.params) > 0:

--- a/mitiq/mitiq_pyquil/compiler.py
+++ b/mitiq/mitiq_pyquil/compiler.py
@@ -1,0 +1,358 @@
+# Copyright (C) 2020 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Provides a utility basic_compile to allow for running on QCS without
+using quilc, as quilc will optimize away unitary folding.
+
+NB: Copied in large part from rigetti/forest-benchmarking (Apache-2.0)
+and modified to support a larger gateset (e.g. CPHASE).
+"""
+
+from math import pi
+from typing import Tuple
+
+import numpy as np
+
+from pyquil.gates import RX, RZ, CZ, I, XY
+from pyquil.quil import Program
+from pyquil.quilbase import Gate
+
+
+def _CCNOT(q0: int, q1: int, q2: int) -> Program:
+    """
+    A CCNOT in terms of RX(+-pi/2), RZ(theta), and CZ
+
+    .. note:
+        Don't control this gate.
+    """
+    p = Program()
+    p.inst(_H(q2))
+    p.inst(_CNOT(q1, q2))
+    p.inst(_T(q2, dagger=True))
+    p.inst(_SWAP(q1, q2))
+    p.inst(_CNOT(q0, q1))
+    p.inst(_T(q1))
+    p.inst(_CNOT(q2, q1))
+    p.inst(_T(q1, dagger=True))
+    p.inst(_CNOT(q0, q1))
+    p.inst(_SWAP(q1, q2))
+    p.inst(_T(q1))
+    p.inst(_T(q2))
+    p.inst(_CNOT(q0, q1))
+    p.inst(_H(q2))
+    p.inst(_T(q0))
+    p.inst(_T(q1, dagger=True))
+    p.inst(_CNOT(q0, q1))
+    return p
+
+
+def _CNOT(q0: int, q1: int) -> Program:
+    """
+    A CNOT in terms of RX(+-pi/2), RZ(theta), and CZ
+
+    .. note:
+        This uses two of :py:func:`_H`, so it picks up twice the global phase.
+        Don't control this gate.
+    """
+    p = Program()
+    p.inst(_H(q1))
+    p.inst(CZ(q0, q1))
+    p.inst(_H(q1))
+    return p
+
+
+def _CPHASE(angle: float, q0: int, q1: int) -> Program:
+    """
+    from quilc:
+
+    (define-compiler CPHASE-to-CNOT ((CPHASE-gate ("CPHASE" (alpha) p q)))
+        (inst "CNOT" ()                            p q)
+        (inst "RZ"   (list (param-* alpha -0.5d0)) q)
+        (inst "CNOT" ()                            p q)
+        (inst "RZ"   (list (param-* alpha  0.5d0)) q)
+        (inst "RZ"   (list (param-* alpha  0.5d0)) p))
+    """
+    p = Program()
+    p.inst(_CNOT(q0, q1))
+    p.inst(RZ(-0.5 * angle, q1))
+    p.inst(_CNOT(q0, q1))
+    p.inst(RZ(0.5 * angle, q1))
+    p.inst(RZ(0.5 * angle, q0))
+    return p
+
+
+def _H(q: int) -> Program:
+    """
+    A Hadamard in terms of RX(+-pi/2) and RZ(theta)
+
+    .. note:
+        This introduces a different global phase! Don't control this gate.
+    """
+    p = Program()
+    p.inst(_RY(-np.pi / 2, q))
+    p.inst(RZ(np.pi, q))
+    return p
+
+
+def _ISWAP(q0: int, q1: int) -> Program:
+    """
+    An ISWAP as an XY(pi). Of course, assumes XY is available.
+    """
+    p = Program()
+    p += XY(np.pi, q0, q1)
+    return p
+
+
+def _PHASE(angle: float, q: int) -> Program:
+    """
+    from quilc:
+
+    (define-compiler PHASE-to-RZ ((phase-gate ("PHASE" (alpha) q)))
+       (inst "RZ" `(,alpha) q))
+    """
+    p = Program()
+    p += RZ(angle, q)
+    return p
+
+
+def _RX(angle: float, q: int) -> Program:
+    """
+    A RX in terms of native RX(+-pi/2) and RZ gates.
+    """
+    p = Program()
+    p += RZ(pi / 2, q)
+    p += RX(pi / 2, q)
+    p += RZ(angle, q)
+    p += RX(-pi / 2, q)
+    p += RZ(-pi / 2, q)
+    return p
+
+
+def _RY(angle: float, q: int) -> Program:
+    """
+    A RY in terms of RX(+-pi/2) and RZ(theta)
+    """
+    p = Program()
+    p += RX(pi / 2, q)
+    p += RZ(angle, q)
+    p += RX(-pi / 2, q)
+    return p
+
+
+def _S(q: int, dagger: bool = False) -> Program:
+    """
+    An S in terms of RZ(theta)
+    """
+    if dagger:
+        return Program(RZ(-np.pi / 2, q))
+    else:
+        return Program(RZ(np.pi / 2, q))
+
+
+def _SWAP(q0: int, q1: int) -> Program:
+    """
+    A SWAP in terms of _CNOT
+
+    .. note:
+        This uses :py:func:`_CNOT`, so it picks up a global phase.
+        Don't control this gate.
+
+    """
+    p = Program()
+    p.inst(_CNOT(q0, q1))
+    p.inst(_CNOT(q1, q0))
+    p.inst(_CNOT(q0, q1))
+    return p
+
+
+def _T(q: int, dagger: bool = False) -> Program:
+    """
+    A T in terms of RZ(theta)
+    """
+    if dagger:
+        return Program(RZ(-np.pi / 4, q))
+    else:
+        return Program(RZ(np.pi / 4, q))
+
+
+def _X(q: int) -> Program:
+    """
+    An X in terms of RX(pi)
+
+    .. note:
+        This introduces a global phase! Don't control this gate.
+    """
+    p = Program()
+    p += RX(np.pi, q)
+    return p
+
+
+def _Y(q: int) -> Program:
+    """
+    A Y in terms of _RY
+    """
+    p = Program()
+    p += _RY(np.pi, q)
+    return p
+
+
+def _Z(q: int) -> Program:
+    """
+    A Z in terms of RZ
+    """
+    p = Program()
+    p += RZ(np.pi, q)
+    return p
+
+
+# This function is taken from cirq. License: apache 2.
+def match_global_phase(a: np.ndarray,
+                       b: np.ndarray
+                       ) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Phases the given matrices so that they agree on the phase of one entry.
+    To maximize precision, the position with the largest entry from one of the
+    matrices is used when attempting to compute the phase difference between
+    the two matrices.
+    :param a: The first matrix
+    :param b: The second matrix
+    :return: A tuple (a', b') where a' == b' implies a == b*exp(i t) for some t.
+    """
+
+    # Not much point when they have different shapes.
+    if a.shape != b.shape:
+        return a, b
+
+    # Find the entry with the largest magnitude in one of the matrices.
+    k = max(np.ndindex(*a.shape), key=lambda t: abs(b[t]))
+
+    def dephase(v):
+        r = np.real(v)
+        i = np.imag(v)
+
+        # Avoid introducing floating point error when axis-aligned.
+        if i == 0:
+            return -1 if r < 0 else 1
+        if r == 0:
+            return 1j if i < 0 else -1j
+
+        return np.exp(-1j * np.arctan2(i, r))
+
+    # Zero the phase at this entry in both matrices.
+    return a * dephase(a[k]), b * dephase(b[k])
+
+
+def is_magic_angle(angle: float) -> bool:
+    return (np.isclose(np.abs(angle), pi / 2)
+            or np.isclose(np.abs(angle), pi)
+            or np.isclose(angle, 0.0))
+
+
+def basic_compile(program: Program) -> Program:
+    """
+    A rudimentary but predictable compiler.
+
+    No rewiring or optimization is done by this compilation step. There may be some gates that
+    are not yet supported. Gates defined in the input program are included without change in the
+    output program.
+
+    :param program: a program to be compiled to native quil with simple replacements.
+    :return: a program with some of the input non-native quil gates replaced with basic native quil
+        gate implementations.
+    """
+    new_prog = Program()
+    new_prog.num_shots = program.num_shots
+    new_prog.inst(program.defined_gates)
+
+    daggered_defgates = []
+
+    for inst in program:
+        if isinstance(inst, Gate):
+            # TODO: this is only a stopgap while the noisy QVM does not support modifiers.
+            # dagger this gate if odd number of daggers. Ignore controlled for now.
+            needs_dagger = inst.modifiers.count('DAGGER') % 2 == 1
+            angle_param = None
+            if len(inst.params) > 0:
+                angle_param = inst.params[0]
+                if needs_dagger:
+                    angle_param = -angle_param
+
+            if 'CONTROLLED' in inst.modifiers:
+                raise ValueError("Controlled gates are not currently supported.")
+
+            if inst.name == 'CCNOT':
+                new_prog += _CCNOT(*inst.qubits)
+            elif inst.name == 'CNOT':
+                new_prog += _CNOT(*inst.qubits)
+            # NB: we haven't implemented CPHASE00/01/10
+            elif inst.name == 'CPHASE':
+                new_prog += _CPHASE(angle_param, *inst.qubits)
+            elif inst.name == 'CZ':
+                new_prog += CZ(*inst.qubits)  # remove dag modifiers
+            elif inst.name == "H":
+                new_prog += _H(inst.qubits[0])
+            elif inst.name == 'I':
+                new_prog += I(inst.qubits[0])  # remove dag modifiers
+            elif inst.name == 'ISWAP':
+                new_prog += _ISWAP(*inst.qubits)  # remove dag modifiers
+            elif inst.name == 'PHASE':
+                new_prog += _PHASE(angle_param, inst.qubits[0])
+            elif inst.name == 'RX':
+                if is_magic_angle(inst.params[0]):
+                    # in case dagger
+                    new_prog += RX(angle_param, inst.qubits[0])
+                else:
+                    new_prog += _RX(angle_param, inst.qubits[0])
+            elif inst.name == 'RY':
+                new_prog += _RY(angle_param, inst.qubits[0])
+            elif inst.name == 'RZ':
+                # in case dagger
+                new_prog += RZ(angle_param, inst.qubits[0])
+            elif inst.name == 'S':
+                new_prog += _S(inst.qubits[0], needs_dagger)
+            # NB: we haven't implemented CSWAP or PSWAP
+            elif inst.name == 'SWAP':
+                new_prog += _SWAP(*inst.qubits)
+            elif inst.name == 'T':
+                new_prog += _T(inst.qubits[0], needs_dagger)
+            elif inst.name == "X":
+                new_prog += _X(inst.qubits[0])
+            elif inst.name == 'XY':
+                new_prog += XY(angle_param, *inst.qubits)
+            elif inst.name == "Y":
+                new_prog += _Y(inst.qubits[0])
+            elif inst.name == "Z":
+                new_prog += _Z(inst.qubits[0])
+            elif inst.name in [gate.name for gate in new_prog.defined_gates]:
+                if needs_dagger and inst.name not in daggered_defgates:
+                    new_prog.defgate(inst.name + 'DAG', inst.matrix.T.conj())
+                    daggered_defgates.append(inst.name)
+                new_prog += inst
+            else:
+                raise ValueError(f"Unknown gate instruction {inst}")
+
+        else:
+            new_prog += inst
+
+    new_prog.native_quil_metadata = {
+        'final_rewiring': None,
+        'gate_depth': None,
+        'gate_volume': None,
+        'multiqubit_gate_depth': None,
+        'program_duration': None,
+        'program_fidelity': None,
+        'topological_swaps': 0,
+    }
+    return new_prog

--- a/mitiq/mitiq_pyquil/conversions.py
+++ b/mitiq/mitiq_pyquil/conversions.py
@@ -16,7 +16,7 @@
 """Functions to convert between Mitiq's internal circuit representation and
 pyQuil's circuit representation (Quil programs).
 """
-from cirq import Circuit
+from cirq import Circuit, LineQubit
 from pyquil import Program
 
 from cirq.contrib.quil_import import circuit_from_quil
@@ -33,6 +33,12 @@ def to_quil(circuit: Circuit) -> QuilType:
     Returns:
         QuilType: Quil string equivalent to the input Mitiq circuit.
     """
+    max_qubit = max(circuit.all_qubits())
+    # if we are using LineQubits, keep the qubit labeling the same
+    if isinstance(max_qubit, LineQubit):
+        qubit_range = max_qubit.x + 1
+        return circuit.to_quil(qubit_order=LineQubit.range(qubit_range))
+    # otherwise, use the default ordering (starting from zero)
     return circuit.to_quil()
 
 

--- a/mitiq/mitiq_pyquil/tests/test_conversions_pyquil.py
+++ b/mitiq/mitiq_pyquil/tests/test_conversions_pyquil.py
@@ -93,3 +93,13 @@ def test_to_pyquil_from_pyquil_almost_all_gates():
     number of measurements are equivalent)."""
     p = Program(MEASURELESS_QUIL_PROGRAM)
     assert p.out() == to_pyquil(from_pyquil(p)).out()
+
+
+def test_to_pyquil_from_pyquil_not_starting_at_zero():
+    p = Program()
+    p += X(10)
+    p += Y(11)
+    p += Z(12)
+    p += CNOT(10, 11)
+    p += CZ(11, 12)
+    assert p.out() == to_pyquil(from_pyquil(p)).out()

--- a/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
+++ b/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
@@ -47,6 +47,7 @@ from pyquil.gates import (
     Z,
 )
 from pyquil.quil import Program
+from pyquil.simulation.tools import program_unitary
 
 from mitiq.mitiq_pyquil.compiler import (
     basic_compile,
@@ -65,14 +66,6 @@ from mitiq.mitiq_pyquil.compiler import (
     match_global_phase,
 )
 
-try:
-    from pyquil.simulation.tools import program_unitary
-
-    unitary_tools = True
-except ImportError:
-    unitary_tools = False
-
-
 def assert_all_close_up_to_global_phase(
     actual, desired, rtol: float = 1e-7, atol: float = 0
 ):
@@ -90,7 +83,6 @@ def test_basic_compile_defgate():
     assert p == basic_compile(p)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_CCNOT():
     for perm in itertools.permutations([0, 1, 2]):
         u1 = program_unitary(Program(CCNOT(*perm)), n_qubits=3)
@@ -98,7 +90,6 @@ def test_CCNOT():
         assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_CNOT():
     u1 = program_unitary(Program(CNOT(0, 1)), n_qubits=2)
     u2 = program_unitary(_CNOT(0, 1), n_qubits=2)
@@ -109,7 +100,6 @@ def test_CNOT():
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_CPHASE():
     for theta in np.linspace(-2 * np.pi, 2 * np.pi):
         u1 = program_unitary(Program(CPHASE(theta, 0, 1)), n_qubits=2)
@@ -121,14 +111,12 @@ def test_CPHASE():
         assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_H():
     u1 = program_unitary(Program(H(0)), n_qubits=1)
     u2 = program_unitary(_H(0), n_qubits=1)
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_ISWAP():
     u1 = program_unitary(Program(ISWAP(0, 1)), n_qubits=2)
     u2 = program_unitary(_ISWAP(0, 1), n_qubits=2)
@@ -139,7 +127,6 @@ def test_ISWAP():
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_RX():
     for theta in np.linspace(-2 * np.pi, 2 * np.pi):
         p = Program(RX(theta, 0))
@@ -148,7 +135,6 @@ def test_RX():
         assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_RY():
     for theta in np.linspace(-2 * np.pi, 2 * np.pi):
         u1 = program_unitary(Program(RY(theta, 0)), n_qubits=1)
@@ -156,14 +142,12 @@ def test_RY():
         assert_all_close_up_to_global_phase(u1, u2)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_S():
     u1 = program_unitary(Program(S(0)), n_qubits=1)
     u2 = program_unitary(_S(0), n_qubits=1)
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_SWAP():
     u1 = program_unitary(Program(SWAP(0, 1)), n_qubits=2)
     u2 = program_unitary(_SWAP(0, 1), n_qubits=2)
@@ -174,21 +158,18 @@ def test_SWAP():
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_T():
     u1 = program_unitary(Program(T(0)), n_qubits=1)
     u2 = program_unitary(_T(0), n_qubits=1)
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_X():
     u1 = program_unitary(Program(X(0)), n_qubits=1)
     u2 = program_unitary(_X(0), n_qubits=1)
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_XY():
     for theta in np.linspace(-2 * np.pi, 2 * np.pi):
         p = Program(XY(theta, 0, 1))
@@ -202,14 +183,12 @@ def test_XY():
         assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_Y():
     u1 = program_unitary(Program(Y(0)), n_qubits=1)
     u2 = program_unitary(_Y(0), n_qubits=1)
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_Z():
     u1 = program_unitary(Program(Z(0)), n_qubits=1)
     u2 = program_unitary(_Z(0), n_qubits=1)
@@ -299,7 +278,6 @@ def prog_length(request):
     return request.param
 
 
-@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_random_progs(n_qubits, prog_length):
     for repeat_i in range(10):
         prog = _generate_random_program(n_qubits=n_qubits, length=prog_length)

--- a/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
+++ b/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
@@ -1,0 +1,238 @@
+# Copyright (C) 2020 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""NB: Copied in large part from rigetti/forest-benchmarking (Apache-2.0)
+and modified to test a larger gateset.
+"""
+
+import inspect
+import random
+import itertools
+from math import pi
+
+import numpy as np
+import pytest
+
+from pyquil.gates import *
+from pyquil.quil import Program
+
+from mitiq.mitiq_pyquil.compiler import (basic_compile, _CCNOT, _CNOT, _CPHASE, _H,
+                                         _ISWAP, _RY, _S, _SWAP, _T, _X, _Y, _Z,
+                                         match_global_phase)
+
+try:
+    from pyquil.simulation.tools import program_unitary
+    unitary_tools = True
+except ImportError:
+    unitary_tools = False
+
+
+def assert_all_close_up_to_global_phase(actual, desired, rtol: float = 1e-7, atol: float = 0):
+    actual, desired = match_global_phase(actual, desired)
+    np.testing.assert_allclose(actual, desired, rtol=rtol, atol=atol)
+
+
+def test_basic_compile_defgate():
+    p = Program()
+    p.inst(RX(pi, 0))
+    p.defgate("test", [[0, 1], [1, 0]])
+    p.inst(("test", 2))
+    p.inst(RZ(pi / 2, 0))
+
+    assert p == basic_compile(p)
+
+
+@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+def test_CCNOT():
+    for perm in itertools.permutations([0, 1, 2]):
+        u1 = program_unitary(Program(CCNOT(*perm)), n_qubits=3)
+        u2 = program_unitary(_CCNOT(*perm), n_qubits=3)
+        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+def test_CNOT():
+    u1 = program_unitary(Program(CNOT(0, 1)), n_qubits=2)
+    u2 = program_unitary(_CNOT(0, 1), n_qubits=2)
+    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+    u1 = program_unitary(Program(CNOT(1, 0)), n_qubits=2)
+    u2 = program_unitary(_CNOT(1, 0), n_qubits=2)
+    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+def test_CPHASE():
+    for theta in np.linspace(-2 * np.pi, 2 * np.pi):
+        u1 = program_unitary(Program(CPHASE(theta, 0, 1)), n_qubits=2)
+        u2 = program_unitary(_CPHASE(theta, 0, 1), n_qubits=2)
+        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+        u1 = program_unitary(Program(CPHASE(theta, 1, 0)), n_qubits=2)
+        u2 = program_unitary(_CPHASE(theta, 1, 0), n_qubits=2)
+        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+def test_H():
+    u1 = program_unitary(Program(H(0)), n_qubits=1)
+    u2 = program_unitary(_H(0), n_qubits=1)
+    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+def test_ISWAP():
+    u1 = program_unitary(Program(ISWAP(0, 1)), n_qubits=2)
+    u2 = program_unitary(_ISWAP(0, 1), n_qubits=2)
+    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+    u1 = program_unitary(Program(ISWAP(1, 0)), n_qubits=2)
+    u2 = program_unitary(_ISWAP(1, 0), n_qubits=2)
+    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+def test_RY():
+    for theta in np.linspace(-2 * np.pi, 2 * np.pi):
+        u1 = program_unitary(Program(RY(theta, 0)), n_qubits=1)
+        u2 = program_unitary(_RY(theta, 0), n_qubits=1)
+        assert_all_close_up_to_global_phase(u1, u2)
+
+
+@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+def test_S():
+    u1 = program_unitary(Program(S(0)), n_qubits=1)
+    u2 = program_unitary(_S(0), n_qubits=1)
+    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+def test_SWAP():
+    u1 = program_unitary(Program(SWAP(0, 1)), n_qubits=2)
+    u2 = program_unitary(_SWAP(0, 1), n_qubits=2)
+    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+    u1 = program_unitary(Program(SWAP(1, 0)), n_qubits=2)
+    u2 = program_unitary(_SWAP(1, 0), n_qubits=2)
+    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+def test_T():
+    u1 = program_unitary(Program(T(0)), n_qubits=1)
+    u2 = program_unitary(_T(0), n_qubits=1)
+    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+def test_X():
+    u1 = program_unitary(Program(X(0)), n_qubits=1)
+    u2 = program_unitary(_X(0), n_qubits=1)
+    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+def test_Y():
+    u1 = program_unitary(Program(Y(0)), n_qubits=1)
+    u2 = program_unitary(_Y(0), n_qubits=1)
+    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+def test_Z():
+    u1 = program_unitary(Program(Z(0)), n_qubits=1)
+    u2 = program_unitary(_Z(0), n_qubits=1)
+    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+# Note to developers: unsupported gates are commented out.
+QUANTUM_GATES = {'I': I,
+                 'X': X,
+                 'Y': Y,
+                 'Z': Z,
+                 'H': H,
+                 'S': S,
+                 'T': T,
+                 'PHASE': PHASE,
+                 'RX': RX,
+                 'RY': RY,
+                 'RZ': RZ,
+                 'CZ': CZ,
+                 'CNOT': CNOT,
+                 'CCNOT': CCNOT,
+                 # 'CPHASE00': CPHASE00,
+                 # 'CPHASE01': CPHASE01,
+                 # 'CPHASE10': CPHASE10,
+                 'CPHASE': CPHASE,
+                 'SWAP': SWAP,
+                 # 'CSWAP': CSWAP,
+                 'ISWAP': ISWAP,
+                 # 'PSWAP': PSWAP
+                 }
+
+
+def _generate_random_program(n_qubits, length):
+    """Randomly sample gates and arguments (qubits, angles)"""
+    if n_qubits < 3:
+        raise ValueError("Please request n_qubits >= 3 so we can use 3-qubit gates.")
+
+    gates = list(QUANTUM_GATES.values())
+    prog = Program()
+    for _ in range(length):
+        gate = random.choice(gates)
+        possible_qubits = set(range(n_qubits))
+        sig = inspect.signature(gate)
+
+        param_vals = []
+        for param in sig.parameters:
+            if param in ['qubit', 'q1', 'q2', 'control',
+                         'control1', 'control2', 'target', 'target_1', 'target_2',
+                         'classical_reg']:
+                param_val = random.choice(list(possible_qubits))
+                possible_qubits.remove(param_val)
+            elif param == 'angle':
+                # TODO: support rx(theta)
+                if gate == RX:
+                    param_val = random.choice([-1, -0.5, 0, 0.5, 1]) * pi
+                else:
+                    param_val = random.uniform(-2 * pi, 2 * pi)
+            else:
+                raise ValueError("Unknown gate parameter {}".format(param))
+
+            param_vals.append(param_val)
+
+        prog += gate(*param_vals)
+
+    return prog
+
+
+@pytest.fixture(params=list(range(3, 5)))
+def n_qubits(request):
+    return request.param
+
+
+@pytest.fixture(params=[2, 50, 67])
+def prog_length(request):
+    return request.param
+
+
+@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+def test_random_progs(n_qubits, prog_length):
+    for repeat_i in range(10):
+        prog = _generate_random_program(n_qubits=n_qubits, length=prog_length)
+        u1 = program_unitary(prog, n_qubits=n_qubits)
+        u2 = program_unitary(basic_compile(prog), n_qubits=n_qubits)
+
+        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)

--- a/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
+++ b/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
@@ -25,7 +25,25 @@ from math import pi
 import numpy as np
 import pytest
 
-from pyquil.gates import *
+from pyquil.gates import (
+    CCNOT,
+    CNOT,
+    CPHASE,
+    CZ,
+    H,
+    I,
+    ISWAP,
+    PHASE,
+    RX,
+    RY,
+    RZ,
+    S,
+    SWAP,
+    T,
+    X,
+    Y,
+    Z,
+)
 from pyquil.quil import Program
 
 from mitiq.mitiq_pyquil.compiler import (

--- a/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
+++ b/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
@@ -28,18 +28,34 @@ import pytest
 from pyquil.gates import *
 from pyquil.quil import Program
 
-from mitiq.mitiq_pyquil.compiler import (basic_compile, _CCNOT, _CNOT, _CPHASE, _H,
-                                         _ISWAP, _RY, _S, _SWAP, _T, _X, _Y, _Z,
-                                         match_global_phase)
+from mitiq.mitiq_pyquil.compiler import (
+    basic_compile,
+    _CCNOT,
+    _CNOT,
+    _CPHASE,
+    _H,
+    _ISWAP,
+    _RY,
+    _S,
+    _SWAP,
+    _T,
+    _X,
+    _Y,
+    _Z,
+    match_global_phase,
+)
 
 try:
     from pyquil.simulation.tools import program_unitary
+
     unitary_tools = True
 except ImportError:
     unitary_tools = False
 
 
-def assert_all_close_up_to_global_phase(actual, desired, rtol: float = 1e-7, atol: float = 0):
+def assert_all_close_up_to_global_phase(
+    actual, desired, rtol: float = 1e-7, atol: float = 0
+):
     actual, desired = match_global_phase(actual, desired)
     np.testing.assert_allclose(actual, desired, rtol=rtol, atol=atol)
 
@@ -54,7 +70,7 @@ def test_basic_compile_defgate():
     assert p == basic_compile(p)
 
 
-@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_CCNOT():
     for perm in itertools.permutations([0, 1, 2]):
         u1 = program_unitary(Program(CCNOT(*perm)), n_qubits=3)
@@ -62,7 +78,7 @@ def test_CCNOT():
         assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_CNOT():
     u1 = program_unitary(Program(CNOT(0, 1)), n_qubits=2)
     u2 = program_unitary(_CNOT(0, 1), n_qubits=2)
@@ -73,7 +89,7 @@ def test_CNOT():
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_CPHASE():
     for theta in np.linspace(-2 * np.pi, 2 * np.pi):
         u1 = program_unitary(Program(CPHASE(theta, 0, 1)), n_qubits=2)
@@ -85,14 +101,14 @@ def test_CPHASE():
         assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_H():
     u1 = program_unitary(Program(H(0)), n_qubits=1)
     u2 = program_unitary(_H(0), n_qubits=1)
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_ISWAP():
     u1 = program_unitary(Program(ISWAP(0, 1)), n_qubits=2)
     u2 = program_unitary(_ISWAP(0, 1), n_qubits=2)
@@ -103,7 +119,7 @@ def test_ISWAP():
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_RY():
     for theta in np.linspace(-2 * np.pi, 2 * np.pi):
         u1 = program_unitary(Program(RY(theta, 0)), n_qubits=1)
@@ -111,14 +127,14 @@ def test_RY():
         assert_all_close_up_to_global_phase(u1, u2)
 
 
-@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_S():
     u1 = program_unitary(Program(S(0)), n_qubits=1)
     u2 = program_unitary(_S(0), n_qubits=1)
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_SWAP():
     u1 = program_unitary(Program(SWAP(0, 1)), n_qubits=2)
     u2 = program_unitary(_SWAP(0, 1), n_qubits=2)
@@ -129,28 +145,28 @@ def test_SWAP():
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_T():
     u1 = program_unitary(Program(T(0)), n_qubits=1)
     u2 = program_unitary(_T(0), n_qubits=1)
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_X():
     u1 = program_unitary(Program(X(0)), n_qubits=1)
     u2 = program_unitary(_X(0), n_qubits=1)
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_Y():
     u1 = program_unitary(Program(Y(0)), n_qubits=1)
     u2 = program_unitary(_Y(0), n_qubits=1)
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
-@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_Z():
     u1 = program_unitary(Program(Z(0)), n_qubits=1)
     u2 = program_unitary(_Z(0), n_qubits=1)
@@ -158,35 +174,38 @@ def test_Z():
 
 
 # Note to developers: unsupported gates are commented out.
-QUANTUM_GATES = {'I': I,
-                 'X': X,
-                 'Y': Y,
-                 'Z': Z,
-                 'H': H,
-                 'S': S,
-                 'T': T,
-                 'PHASE': PHASE,
-                 'RX': RX,
-                 'RY': RY,
-                 'RZ': RZ,
-                 'CZ': CZ,
-                 'CNOT': CNOT,
-                 'CCNOT': CCNOT,
-                 # 'CPHASE00': CPHASE00,
-                 # 'CPHASE01': CPHASE01,
-                 # 'CPHASE10': CPHASE10,
-                 'CPHASE': CPHASE,
-                 'SWAP': SWAP,
-                 # 'CSWAP': CSWAP,
-                 'ISWAP': ISWAP,
-                 # 'PSWAP': PSWAP
-                 }
+QUANTUM_GATES = {
+    "I": I,
+    "X": X,
+    "Y": Y,
+    "Z": Z,
+    "H": H,
+    "S": S,
+    "T": T,
+    "PHASE": PHASE,
+    "RX": RX,
+    "RY": RY,
+    "RZ": RZ,
+    "CZ": CZ,
+    "CNOT": CNOT,
+    "CCNOT": CCNOT,
+    # 'CPHASE00': CPHASE00,
+    # 'CPHASE01': CPHASE01,
+    # 'CPHASE10': CPHASE10,
+    "CPHASE": CPHASE,
+    "SWAP": SWAP,
+    # 'CSWAP': CSWAP,
+    "ISWAP": ISWAP,
+    # 'PSWAP': PSWAP
+}
 
 
 def _generate_random_program(n_qubits, length):
     """Randomly sample gates and arguments (qubits, angles)"""
     if n_qubits < 3:
-        raise ValueError("Please request n_qubits >= 3 so we can use 3-qubit gates.")
+        raise ValueError(
+            "Please request n_qubits >= 3 so we can use 3-qubit gates."
+        )
 
     gates = list(QUANTUM_GATES.values())
     prog = Program()
@@ -197,12 +216,21 @@ def _generate_random_program(n_qubits, length):
 
         param_vals = []
         for param in sig.parameters:
-            if param in ['qubit', 'q1', 'q2', 'control',
-                         'control1', 'control2', 'target', 'target_1', 'target_2',
-                         'classical_reg']:
+            if param in [
+                "qubit",
+                "q1",
+                "q2",
+                "control",
+                "control1",
+                "control2",
+                "target",
+                "target_1",
+                "target_2",
+                "classical_reg",
+            ]:
                 param_val = random.choice(list(possible_qubits))
                 possible_qubits.remove(param_val)
-            elif param == 'angle':
+            elif param == "angle":
                 # TODO: support rx(theta)
                 if gate == RX:
                     param_val = random.choice([-1, -0.5, 0, 0.5, 1]) * pi
@@ -228,7 +256,7 @@ def prog_length(request):
     return request.param
 
 
-@pytest.mark.skipif(not unitary_tools, reason='Requires unitary_tools')
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_random_progs(n_qubits, prog_length):
     for repeat_i in range(10):
         prog = _generate_random_program(n_qubits=n_qubits, length=prog_length)

--- a/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
+++ b/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
@@ -25,6 +25,7 @@ from math import pi
 import numpy as np
 import pytest
 
+from cirq import equal_up_to_global_phase
 from pyquil.gates import (
     CCNOT,
     CNOT,
@@ -63,14 +64,7 @@ from mitiq.mitiq_pyquil.compiler import (
     _X,
     _Y,
     _Z,
-    match_global_phase,
 )
-
-def assert_all_close_up_to_global_phase(
-    actual, desired, rtol: float = 1e-7, atol: float = 0
-):
-    actual, desired = match_global_phase(actual, desired)
-    np.testing.assert_allclose(actual, desired, rtol=rtol, atol=atol)
 
 
 def test_basic_compile_defgate():
@@ -87,44 +81,44 @@ def test_CCNOT():
     for perm in itertools.permutations([0, 1, 2]):
         u1 = program_unitary(Program(CCNOT(*perm)), n_qubits=3)
         u2 = program_unitary(_CCNOT(*perm), n_qubits=3)
-        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+        assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 def test_CNOT():
     u1 = program_unitary(Program(CNOT(0, 1)), n_qubits=2)
     u2 = program_unitary(_CNOT(0, 1), n_qubits=2)
-    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+    assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
     u1 = program_unitary(Program(CNOT(1, 0)), n_qubits=2)
     u2 = program_unitary(_CNOT(1, 0), n_qubits=2)
-    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+    assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 def test_CPHASE():
     for theta in np.linspace(-2 * np.pi, 2 * np.pi):
         u1 = program_unitary(Program(CPHASE(theta, 0, 1)), n_qubits=2)
         u2 = program_unitary(_CPHASE(theta, 0, 1), n_qubits=2)
-        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+        assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
         u1 = program_unitary(Program(CPHASE(theta, 1, 0)), n_qubits=2)
         u2 = program_unitary(_CPHASE(theta, 1, 0), n_qubits=2)
-        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+        assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 def test_H():
     u1 = program_unitary(Program(H(0)), n_qubits=1)
     u2 = program_unitary(_H(0), n_qubits=1)
-    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+    assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 def test_ISWAP():
     u1 = program_unitary(Program(ISWAP(0, 1)), n_qubits=2)
     u2 = program_unitary(_ISWAP(0, 1), n_qubits=2)
-    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+    assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
     u1 = program_unitary(Program(ISWAP(1, 0)), n_qubits=2)
     u2 = program_unitary(_ISWAP(1, 0), n_qubits=2)
-    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+    assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 def test_RX():
@@ -132,42 +126,42 @@ def test_RX():
         p = Program(RX(theta, 0))
         u1 = program_unitary(p, n_qubits=1)
         u2 = program_unitary(basic_compile(p), n_qubits=1)
-        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+        assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 def test_RY():
     for theta in np.linspace(-2 * np.pi, 2 * np.pi):
         u1 = program_unitary(Program(RY(theta, 0)), n_qubits=1)
         u2 = program_unitary(_RY(theta, 0), n_qubits=1)
-        assert_all_close_up_to_global_phase(u1, u2)
+        assert equal_up_to_global_phase(u1, u2)
 
 
 def test_S():
     u1 = program_unitary(Program(S(0)), n_qubits=1)
     u2 = program_unitary(_S(0), n_qubits=1)
-    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+    assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 def test_SWAP():
     u1 = program_unitary(Program(SWAP(0, 1)), n_qubits=2)
     u2 = program_unitary(_SWAP(0, 1), n_qubits=2)
-    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+    assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
     u1 = program_unitary(Program(SWAP(1, 0)), n_qubits=2)
     u2 = program_unitary(_SWAP(1, 0), n_qubits=2)
-    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+    assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 def test_T():
     u1 = program_unitary(Program(T(0)), n_qubits=1)
     u2 = program_unitary(_T(0), n_qubits=1)
-    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+    assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 def test_X():
     u1 = program_unitary(Program(X(0)), n_qubits=1)
     u2 = program_unitary(_X(0), n_qubits=1)
-    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+    assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 def test_XY():
@@ -175,24 +169,24 @@ def test_XY():
         p = Program(XY(theta, 0, 1))
         u1 = program_unitary(p, n_qubits=2)
         u2 = program_unitary(basic_compile(p), n_qubits=2)
-        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+        assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
         p = Program(XY(theta, 1, 0))
         u1 = program_unitary(p, n_qubits=2)
         u2 = program_unitary(basic_compile(p), n_qubits=2)
-        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+        assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 def test_Y():
     u1 = program_unitary(Program(Y(0)), n_qubits=1)
     u2 = program_unitary(_Y(0), n_qubits=1)
-    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+    assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 def test_Z():
     u1 = program_unitary(Program(Z(0)), n_qubits=1)
     u2 = program_unitary(_Z(0), n_qubits=1)
-    assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+    assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 # Note to developers: unsupported gates are commented out.
@@ -283,8 +277,7 @@ def test_random_progs(n_qubits, prog_length):
         prog = _generate_random_program(n_qubits=n_qubits, length=prog_length)
         u1 = program_unitary(prog, n_qubits=n_qubits)
         u2 = program_unitary(basic_compile(prog), n_qubits=n_qubits)
-
-        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+        assert equal_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 def test_unsupported_gate():

--- a/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
+++ b/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
@@ -29,6 +29,7 @@ from pyquil.gates import (
     CCNOT,
     CNOT,
     CPHASE,
+    CSWAP,
     CZ,
     H,
     I,
@@ -41,6 +42,7 @@ from pyquil.gates import (
     SWAP,
     T,
     X,
+    XY,
     Y,
     Z,
 )
@@ -53,6 +55,7 @@ from mitiq.mitiq_pyquil.compiler import (
     _CPHASE,
     _H,
     _ISWAP,
+    _RX,
     _RY,
     _S,
     _SWAP,
@@ -138,6 +141,15 @@ def test_ISWAP():
 
 
 @pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
+def test_RX():
+    for theta in np.linspace(-2 * np.pi, 2 * np.pi):
+        p = Program(RX(theta, 0))
+        u1 = program_unitary(p, n_qubits=1)
+        u2 = program_unitary(basic_compile(p), n_qubits=1)
+        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
 def test_RY():
     for theta in np.linspace(-2 * np.pi, 2 * np.pi):
         u1 = program_unitary(Program(RY(theta, 0)), n_qubits=1)
@@ -175,6 +187,20 @@ def test_X():
     u1 = program_unitary(Program(X(0)), n_qubits=1)
     u2 = program_unitary(_X(0), n_qubits=1)
     assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+@pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
+def test_XY():
+    for theta in np.linspace(-2 * np.pi, 2 * np.pi):
+        p = Program(XY(theta, 0, 1))
+        u1 = program_unitary(p, n_qubits=2)
+        u2 = program_unitary(basic_compile(p), n_qubits=2)
+        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+        p = Program(XY(theta, 1, 0))
+        u1 = program_unitary(p, n_qubits=2)
+        u2 = program_unitary(basic_compile(p), n_qubits=2)
+        assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
 
 
 @pytest.mark.skipif(not unitary_tools, reason="Requires unitary_tools")
@@ -282,3 +308,13 @@ def test_random_progs(n_qubits, prog_length):
         u2 = program_unitary(basic_compile(prog), n_qubits=n_qubits)
 
         assert_all_close_up_to_global_phase(u1, u2, atol=1e-12)
+
+
+def test_unsupported_gate():
+    with pytest.raises(ValueError):
+        basic_compile(Program(CSWAP(0, 1, 2)))
+
+
+def test_other_instructions():
+    p = Program("DECLARE ro BIT[2]")
+    assert p == basic_compile(p)

--- a/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
+++ b/mitiq/mitiq_pyquil/tests/test_pyquil_compiler.py
@@ -55,7 +55,6 @@ from mitiq.mitiq_pyquil.compiler import (
     _CPHASE,
     _H,
     _ISWAP,
-    _RX,
     _RY,
     _S,
     _SWAP,


### PR DESCRIPTION
While trying to gather QCS data using mitiq, I remembered (the hard way) that there is no way to "just nativize" when using the Quil compiler, and thus we need a facility to perform nativization without optimization. Fortunately, `forest-benchmarking` had a partially-implemented utility for this (but rather than depend on it, which itself has a heavy set of dependencies, I chose to copy it over). Unfortunately, we lose a lot of the really powerful features that quilc offers by doing this, including automatic qubit rewiring. This is a draft PR because I'm going to test it on QCS to see if it works as intended. If this ends up being a nice tool, might try to get it merged into pyquil.

Additionally updates `to_quil` to keep the qubit labeling the same (which does not happen by default in Cirq) using a little `QubitOrder` hack. Maybe this could end up in Cirq?

Together, these two enhancements should allow us to perform error mitigation on QCS.