### PR TITLE
Add mypy type checking to CI, resolve existing issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: dist
 build: check-all docs test-all
 
 .PHONY: check-all
-check-all: check-format check-style
+check-all: check-format check-style check-types
 
 .PHONY: check-format
 check-format:
@@ -14,6 +14,10 @@ check-format:
 .PHONY: check-style
 check-style:
 	flake8
+
+.PHONY: check-types
+check-types:
+	mypy .
 
 .PHONY: clean
 clean:

--- a/mitiq/_about.py
+++ b/mitiq/_about.py
@@ -27,7 +27,10 @@ from scipy import __version__ as scipy_version
 
 import mitiq
 
-MITIQ_INSTALL_PATH = os.path.dirname(inspect.getsourcefile(mitiq))
+MITIQ_SOURCE_FILE = inspect.getsourcefile(mitiq)
+assert MITIQ_SOURCE_FILE
+
+MITIQ_INSTALL_PATH = os.path.dirname(MITIQ_SOURCE_FILE)
 PYTHON_VERSION = sys.version_info[0:3]
 
 

--- a/mitiq/_typing.py
+++ b/mitiq/_typing.py
@@ -28,19 +28,19 @@ which is then handled gracefully by the Union type.
 """
 from typing import Union
 
-from cirq import Circuit
+from cirq import Circuit as _Circuit
 
 try:
-    from pyquil import Program
-except ImportError:
-    Program = Circuit
+    from pyquil import Program as _Program
+except ImportError:  # pragma: no coverage
+    _Program = _Circuit
 
 try:
-    from qiskit import QuantumCircuit
-except ImportError:
-    QuantumCircuit = Circuit
+    from qiskit import QuantumCircuit as _QuantumCircuit
+except ImportError:  # pragma: no coverage
+    _QuantumCircuit = _Circuit
 
-QPROGRAM = Union[Circuit, Program, QuantumCircuit]
+QPROGRAM = Union[_Circuit, _Program, _QuantumCircuit]
 
 SUPPORTED_PROGRAM_TYPES = {
     "cirq": "Circuit",

--- a/mitiq/_typing.py
+++ b/mitiq/_typing.py
@@ -15,27 +15,35 @@
 
 """This file is used to optionally import what program types should be allowed
 by mitiq based on what packages are installed in the environment.
+
+Supported program types:
+    cirq.Circuit
+    pyquil.Program
+    qiskit.QuantumCircuit
+
+When pyquil or qiskit are not available for import, we take advantage of a
+clever hack in the except ImportError block, setting the type alias
+corresponding to the class that we failed to import equal to cirq.Circuit,
+which is then handled gracefully by the Union type.
 """
 from typing import Union
+
+from cirq import Circuit
+
+try:
+    from pyquil import Program
+except ImportError:
+    Program = Circuit
+
+try:
+    from qiskit import QuantumCircuit
+except ImportError:
+    QuantumCircuit = Circuit
+
+QPROGRAM = Union[Circuit, Program, QuantumCircuit]
 
 SUPPORTED_PROGRAM_TYPES = {
     "cirq": "Circuit",
     "pyquil": "Program",
     "qiskit": "QuantumCircuit",
 }
-
-AVAILABLE_PROGRAM_TYPES = {}
-
-for (module, program_type) in SUPPORTED_PROGRAM_TYPES.items():
-    try:
-        exec(f"from {module} import {program_type}")
-        AVAILABLE_PROGRAM_TYPES.update({module: program_type})
-    except ImportError:
-        pass
-
-QPROGRAM = Union[
-    tuple(
-        f"{package}.{circuit}"
-        for package, circuit in AVAILABLE_PROGRAM_TYPES.items()
-    )
-]

--- a/mitiq/benchmarks/maxcut.py
+++ b/mitiq/benchmarks/maxcut.py
@@ -33,7 +33,7 @@ SIMULATOR = DensityMatrixSimulator()
 
 def make_noisy_backend(
     noise: float, obs: np.ndarray
-) -> Callable[[Circuit, int], float]:
+) -> Callable[[Circuit], float]:
     """ Helper function to match mitiq's backend type signature.
 
     Args:
@@ -44,7 +44,7 @@ def make_noisy_backend(
         A mitiq backend function.
     """
 
-    def noisy_backend(circ: Circuit):
+    def noisy_backend(circ: Circuit) -> float:
         return noisy_simulation(circ, noise, obs)
 
     return noisy_backend
@@ -76,7 +76,7 @@ def make_maxcut(
     """
     # get the list of unique nodes from the list of edges
     nodes = list({node for edge in graph for node in edge})
-    nodes = range(max(nodes) + 1)
+    nodes = list(range(max(nodes) + 1))
 
     # one qubit per node
     qreg = [NamedQubit(str(nn)) for nn in nodes]

--- a/mitiq/benchmarks/random_circuits.py
+++ b/mitiq/benchmarks/random_circuits.py
@@ -23,6 +23,7 @@ from cirq import NamedQubit, Circuit
 from mitiq import execute_with_zne
 from mitiq._typing import QPROGRAM
 from mitiq.zne.inference import Factory
+from mitiq.zne.scaling import fold_gates_at_random
 from mitiq.benchmarks.utils import noisy_simulation
 
 
@@ -61,7 +62,7 @@ def rand_circuit_zne(
     trials: int,
     noise: float,
     fac: Factory = None,
-    scale_noise: Callable[[QPROGRAM, float], QPROGRAM] = None,
+    scale_noise: Callable[[QPROGRAM, float], QPROGRAM] = fold_gates_at_random,
     op_density: float = 0.99,
     silent: bool = True,
     seed: Optional[int] = None,

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -54,17 +54,26 @@ def rb_circuits(
         qubit1 = NamedQubit("0")
         if n_qubits == 1:
             rb_circuits = [
-                _random_single_q_clifford(qubit1, num, C1, CFD_MAT_1Q)  # type: ignore
+                _random_single_q_clifford(
+                    qubit1,  # type: ignore
+                    num,
+                    C1,
+                    CFD_MAT_1Q,
+                )
                 for _ in range(trials)
             ]
         elif n_qubits == 2:
             qubit2 = NamedQubit("1")
             cfd_matrices = _two_qubit_clifford_matrices(
-                qubit1, qubit2, CLIFFORDS  # type: ignore
+                qubit1, qubit2, CLIFFORDS,  # type: ignore
             )
             rb_circuits = [
                 _random_two_q_clifford(
-                    qubit1, qubit2, num, cfd_matrices, CLIFFORDS  # type: ignore
+                    qubit1,  # type: ignore
+                    qubit2,  # type: ignore
+                    num,
+                    cfd_matrices,
+                    CLIFFORDS,
                 )
                 for _ in range(trials)
             ]

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -54,17 +54,17 @@ def rb_circuits(
         qubit1 = NamedQubit("0")
         if n_qubits == 1:
             rb_circuits = [
-                _random_single_q_clifford(qubit1, num, C1, CFD_MAT_1Q)
+                _random_single_q_clifford(qubit1, num, C1, CFD_MAT_1Q)  # type: ignore
                 for _ in range(trials)
             ]
         elif n_qubits == 2:
             qubit2 = NamedQubit("1")
             cfd_matrices = _two_qubit_clifford_matrices(
-                qubit1, qubit2, CLIFFORDS
+                qubit1, qubit2, CLIFFORDS  # type: ignore
             )
             rb_circuits = [
                 _random_two_q_clifford(
-                    qubit1, qubit2, num, cfd_matrices, CLIFFORDS
+                    qubit1, qubit2, num, cfd_matrices, CLIFFORDS  # type: ignore
                 )
                 for _ in range(trials)
             ]

--- a/mitiq/benchmarks/utils.py
+++ b/mitiq/benchmarks/utils.py
@@ -14,9 +14,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Utility functions for benchmarking."""
+from typing import cast
+
 import numpy as np
 
-from cirq import Circuit, depolarize, DensityMatrixSimulator
+from cirq import Circuit, depolarize, DensityMatrixSimulator, DensityMatrixTrialResult
 
 SIMULATOR = DensityMatrixSimulator()
 
@@ -33,7 +35,8 @@ def noisy_simulation(circ: Circuit, noise: float, obs: np.ndarray) -> float:
         The observable's expectation value.
     """
     circuit = circ.with_noise(depolarize(p=noise))
-    rho = SIMULATOR.simulate(circuit).final_density_matrix
+    result = cast(DensityMatrixTrialResult, SIMULATOR.simulate(circuit))
+    rho = result.final_density_matrix
     # measure the expectation by taking the trace of the density matrix
     expectation = np.real(np.trace(rho @ obs))
     return expectation

--- a/mitiq/benchmarks/utils.py
+++ b/mitiq/benchmarks/utils.py
@@ -18,7 +18,12 @@ from typing import cast
 
 import numpy as np
 
-from cirq import Circuit, depolarize, DensityMatrixSimulator, DensityMatrixTrialResult
+from cirq import (
+    Circuit,
+    depolarize,
+    DensityMatrixSimulator,
+    DensityMatrixTrialResult,
+)
 
 SIMULATOR = DensityMatrixSimulator()
 

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -812,6 +812,13 @@ class PolyExpFactory(BatchedFactory):
         )
 
 
+# Keep a log of the optimization process storing:
+# noise value(s), expectation value(s), parameters, and zero limit
+OptimizationHistory = List[
+    Tuple[List[Dict[str, float]], List[float], List[float], float]
+]
+
+
 class AdaExpFactory(Factory):
     """Factory object implementing an adaptive zero-noise extrapolation
     algorithm assuming an exponential ansatz y(x) = a + b * exp(-c * x),
@@ -880,11 +887,7 @@ class AdaExpFactory(Factory):
         self.asymptote = asymptote
         self.avoid_log = avoid_log
         self.max_scale_factor = max_scale_factor
-        # Keep a log of the optimization process storing:
-        # noise value(s), expectation value(s), parameters, and zero limit
-        self.history: List[
-            Tuple[List[Dict[str, float]], List[float], List[float], float]
-        ] = []
+        self.history: OptimizationHistory = []
 
     def next(self) -> Dict[str, float]:
         """Returns a dictionary of parameters to execute a circuit at."""

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -27,11 +27,11 @@ from mitiq import QPROGRAM
 from mitiq.utils import _are_close_dict
 
 
-def _instack_to_scale_factors(instack: dict) -> List[float]:
+def _instack_to_scale_factors(instack: List[Dict[str, float]]) -> List[float]:
     """Extracts a list of scale factors from a list of dictionaries."""
-    if all([isinstance(params, dict) for params in instack]):
-        return [params["scale_factor"] for params in instack]
-    return instack
+    if not all(isinstance(params, dict) for params in instack):
+        raise ValueError("instack must be a list of dictionaries")
+    return [params["scale_factor"] for params in instack]
 
 
 class ExtrapolationError(Exception):
@@ -106,7 +106,7 @@ def mitiq_curve_fit(
             # replace OptimizeWarning with ExtrapolationWarning
             if warn.category is OptimizeWarning:
                 warn.category = ExtrapolationWarning
-                warn.message = _EXTR_WARN
+                warn.message = _EXTR_WARN  # type: ignore
             # re-raise all warnings
             warnings.warn_explicit(
                 warn.message, warn.category, warn.filename, warn.lineno
@@ -144,7 +144,7 @@ def mitiq_polyfit(
         # replace RankWarning with ExtrapolationWarning
         if warn.category is RankWarning:
             warn.category = ExtrapolationWarning
-            warn.message = _EXTR_WARN
+            warn.message = _EXTR_WARN  # type: ignore
         # re-raise all warnings
         warnings.warn_explicit(
             warn.message, warn.category, warn.filename, warn.lineno
@@ -171,9 +171,9 @@ class Factory(ABC):
         particular extrapolation algorithm and can be added to the "__init__"
         method of the associated derived class.
         """
-        self._instack = []
-        self._outstack = []
-        self.opt_params = []
+        self._instack: List[Dict[str, float]] = []
+        self._outstack: List[float] = []
+        self.opt_params: List[float] = []
 
     def push(self, instack_val: dict, outstack_val: float) -> None:
         """Appends "instack_val" to "self._instack" and "outstack_val" to
@@ -196,7 +196,7 @@ class Factory(ABC):
         return np.array(self._outstack)
 
     @abstractmethod
-    def next(self) -> float:
+    def next(self) -> Dict[str, float]:
         """Returns a dictionary of parameters to execute a circuit at."""
         raise NotImplementedError
 
@@ -221,9 +221,7 @@ class Factory(ABC):
         self.opt_params = []
 
     def iterate(
-        self,
-        noise_to_expval: Callable[[float], float],
-        max_iterations: int = 100,
+        self, noise_to_expval: Callable[..., float], max_iterations: int = 100,
     ) -> "Factory":
         """Evaluates a sequence of expectation values until enough
         data is collected (or iterations reach "max_iterations").
@@ -265,7 +263,7 @@ class Factory(ABC):
     def run(
         self,
         qp: QPROGRAM,
-        executor: Callable[[QPROGRAM], float],
+        executor: Callable[..., float],
         scale_noise: Callable[[QPROGRAM, float], QPROGRAM],
         num_to_average: int = 1,
         max_iterations: int = 100,
@@ -884,9 +882,9 @@ class AdaExpFactory(Factory):
         self.max_scale_factor = max_scale_factor
         # Keep a log of the optimization process storing:
         # noise value(s), expectation value(s), parameters, and zero limit
-        self.history = (
-            []
-        )  # type: List[Tuple[List[float], List[float], List[float], float]]
+        self.history: List[
+            Tuple[List[Dict[str, float]], List[float], List[float], float]
+        ] = []
 
     def next(self) -> Dict[str, float]:
         """Returns a dictionary of parameters to execute a circuit at."""

--- a/mitiq/zne/zne.py
+++ b/mitiq/zne/zne.py
@@ -97,7 +97,7 @@ def zne_decorator(
     factory: Factory = None,
     scale_noise: Callable[[QPROGRAM, float], QPROGRAM] = fold_gates_at_random,
     num_to_average: int = 1,
-) -> Callable[[QPROGRAM], float]:
+) -> Callable[[Callable[[QPROGRAM], float]], Callable[[QPROGRAM], float]]:
     """Decorator which adds error mitigation to an executor function, i.e., a
     function which executes a quantum circuit with an arbitrary backend and
     returns an expectation value.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pytest~=5.4.1
 pytest-cov~=2.8.1
 flake8~=3.7.9
 black~=19.10b0
+mypy~=0.782
 
 # to run examples
 matplotlib~=3.2.1


### PR DESCRIPTION
Note the change to `_typing.py`.

Goal for this PR is to get basic mypy checks working, might follow-up with the `--strict` option in a future PR.

Will need to rebase after #324 is merged and make sure the tests pass.

Fixes #253.