### PR TITLE
Add static extrapolate method to all factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This marks the first public release of Mitiq on a stable version.
 
 ### All Changes
 
+- Add static extrapolate method to all factories (@andreamari, gh-352).
 - Add the ``angle`` module for parameter noise scaling (@yhindy, gh-288).
 - Add to the documentation instructions for maintainers to make a new release (@nathanshammah, gh-332).
 - Add basic compilation facilities, don't relabel qubits (@karalekas, gh-324).

--- a/docs/source/guide/guide-zne.rst
+++ b/docs/source/guide/guide-zne.rst
@@ -442,9 +442,37 @@ corresponds to a statistical inference based on the measured data.
    Error with richardson_fac: 0.0070
    Error with poly_fac: 0.0110
 
----------------------------
+Behind the scenes, a factory object collects different expectation values at different scale factors.
+After running a factory, this information can be accessed with appropriate *get* methods. For example:
+
+.. testcode::
+
+   scale_factors = poly_fac.get_scale_factors()
+   print("Scale factors:", scale_factors)
+   exp_values = poly_fac.get_expectation_values()
+   print("Expectation values:", np.round(exp_values, 2))
+
+.. testoutput::
+
+   Scale factors: [1. 2. 3. 4.]
+   Expectation values: [0.88 0.79 0.72 0.67]
+
+If the user has manually evaluated a list of expectation values associated to a list of scale factors, the
+simplest way to estimate the corresponding zero-noise limit is to directly call the static `extrapolate` method of the 
+desired factory class (in this case initializing a factory object is unnecessary).  For example:
+
+.. testcode::
+
+   zero_limit = PolyFactory.extrapolate(scale_factors, exp_values, order=2)
+   print(f"Error with PolyFactory.extrapolate method: {abs(exact - zero_limit):.4f}")
+
+.. testoutput::
+
+   Error with PolyFactory.extrapolate method: 0.0110
+
+---------------------------------------------
 Advanced usage of a factory
----------------------------
+---------------------------------------------
 
 .. note::
    This section can be safely skipped by all the readers who are interested

--- a/docs/source/guide/guide-zne.rst
+++ b/docs/source/guide/guide-zne.rst
@@ -470,6 +470,8 @@ desired factory class (in this case initializing a factory object is unnecessary
 
    Error with PolyFactory.extrapolate method: 0.0110
 
+Both the zero-noise value and the optimal parameters of the fit can be returned from `extrapolate` by specifying `full_output = True`.
+
 ---------------------------------------------
 Advanced usage of a factory
 ---------------------------------------------

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -27,13 +27,6 @@ from mitiq import QPROGRAM
 from mitiq.utils import _are_close_dict
 
 
-def _instack_to_scale_factors(instack: List[Dict[str, float]]) -> List[float]:
-    """Extracts a list of scale factors from a list of dictionaries."""
-    if not all(isinstance(params, dict) for params in instack):
-        raise ValueError("instack must be a list of dictionaries")
-    return [params["scale_factor"] for params in instack]
-
-
 class ExtrapolationError(Exception):
     """Error raised by :class:`.Factory` objects when
     the extrapolation fit fails.

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -441,18 +441,24 @@ def test_few_scale_factors_error():
         _ = PolyFactory(X_VALS, order=10)
 
 
-def test_too_few_points_for_polyfit_error():
-    """Test that the correct error is raised if data is not enough to fit."""
+def test_too_few_points_for_polyfit_warning():
+    """Test that the correct warning is raised if data is not enough to fit."""
     fac = PolyFactory(X_VALS, order=2)
     fac._instack = [
         {"scale_factor": 1.0, "shots": 100},
         {"scale_factor": 2.0, "shots": 100},
     ]
     fac._outstack = [1.0, 2.0]
-    with raises(ExtrapolationError, match=r"Extrapolation order is too high."):
+    with warns(
+        ExtrapolationWarning,
+        match=r"The extrapolation fit may be ill-conditioned.",
+    ):
         fac.reduce()
     # test also the static "extrapolate" method.
-    with raises(ExtrapolationError, match=r"Extrapolation order is too high."):
+    with warns(
+        ExtrapolationWarning,
+        match=r"The extrapolation fit may be ill-conditioned.",
+    ):
         PolyFactory.extrapolate([1.0, 2.0], [1.0, 2.0], order=2)
 
 

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -582,3 +582,16 @@ def test_push_after_already_reduced_warning():
     fac.push({"scale_factor": 1.0}, 2.0)
     fac.push({"scale_factor": 2.0}, 1.0)
     assert np.isclose(3.0, fac.reduce())
+
+
+def test_full_output_keyword():
+    """Tests the full_output keyword in extrapolate method."""
+    zlim = LinearFactory.extrapolate([1, 2], [1, 2])
+    assert np.isclose(zlim, 0.0)
+    zlim, opt_params = LinearFactory.extrapolate(
+        [1, 2], [1, 2], full_output=True
+    )
+    assert len(opt_params) == 2
+    assert np.isclose(zlim, 0.0)
+    assert np.isclose(0.0, opt_params[1])
+    assert np.isclose(1.0, opt_params[0])

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -557,3 +557,22 @@ def test_shot_list_errors():
         PolyFactory(X_VALS, order=2, shot_list=[1, 2])
     with raises(TypeError, match=r"valid iterator of integers"):
         PolyFactory(X_VALS, order=2, shot_list=[1.0, 2])
+
+
+def test_push_after_already_reduced_warning():
+    """Tests a warning is raised if new data is pushed in a factory
+    which was already reduced."""
+    fac = LinearFactory([1, 2])
+    fac.push({"scale_factor": 1.0}, 1.0)
+    fac.push({"scale_factor": 2.0}, 2.0)
+    fac.reduce()
+    with warns(
+        ExtrapolationWarning,
+        match=r"You are pushing new data into a factory object",
+    ):
+        fac.push({"scale_factor": 3.0}, 3.0)
+    # Assert no warning is raised when .reset() is used
+    fac.reset()
+    fac.push({"scale_factor": 1.0}, 2.0)
+    fac.push({"scale_factor": 2.0}, 1.0)
+    assert np.isclose(3.0, fac.reduce())

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -449,8 +449,11 @@ def test_too_few_points_for_polyfit_error():
         {"scale_factor": 2.0, "shots": 100},
     ]
     fac._outstack = [1.0, 2.0]
-    with raises(ValueError, match=r"Extrapolation order is too high."):
+    with raises(ExtrapolationError, match=r"Extrapolation order is too high."):
         fac.reduce()
+    # test also the static "extrapolate" method.
+    with raises(ExtrapolationError, match=r"Extrapolation order is too high."):
+        PolyFactory.extrapolate([1.0, 2.0], [1.0, 2.0], order=2)
 
 
 def test_failing_fit_error():
@@ -462,6 +465,11 @@ def test_failing_fit_error():
         ExtrapolationError, match=r"The extrapolation fit failed to converge."
     ):
         fac.reduce()
+    # test also the static "extrapolate" method.
+    with raises(
+        ExtrapolationError, match=r"The extrapolation fit failed to converge."
+    ):
+        ExpFactory.extrapolate(X_VALS, [1.0, 2.0, 1.0, 2.0, 1.0])
 
 
 @mark.parametrize("fac", [LinearFactory([1, 1, 1]), ExpFactory([1, 1, 1])])
@@ -474,6 +482,12 @@ def test_failing_fit_warnings(fac):
         match=r"The extrapolation fit may be ill-conditioned.",
     ):
         fac.reduce()
+    # test also the static "extrapolate" method.
+    with warns(
+        ExtrapolationWarning,
+        match=r"The extrapolation fit may be ill-conditioned.",
+    ):
+        fac.extrapolate([1, 1, 1, 1], [1.0, 1.0, 1.0, 1.0])
 
 
 def test_iteration_warnings():


### PR DESCRIPTION
Description
-----------
Fix #342.

Adds a static `extrapolate` method to all factories. So, if necessary, one can directly extrapolate without instantiating a factory object.
E.g. `zero_limig = RichardsonFactory.extrapolate(scale_factors, exp_values)`

It also adds a flag `self._already_reduced` which is used to raise a warning when new data is pushed to a factory which was already "reduced".

Checklist
-----------
Please make sure you have finished the following tasks before requesting a review of the pull request (PR). For more information, please refer to the [Contributor's Guide](../blob/master/CONTRIBUTING.md):

- [x] Contributions to mitiq should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/). You can enforce it easily with [`black`][black] style and with [`flake8`][flake8] conventions.
- [x] Please add tests to cover your changes, if applicable, and make sure that all new and existing tests pass locally.
- [x] If the behavior of the code has changed or new feature has been added, please also [update the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md).
- [x] Functions and classes have useful [Google-style][google] docstrings and [type hints][hints] in the signature of the objects.
- [x] (Bug fix) The associated issue is referenced above using [auto-close keywords][auto-close]. If the PR fixes an issue, use the keyword fix/fixes/fixed followed by the issue id. For example, if the PR fixes issue 1184, type "Fixes #1184" (without quotes).
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).

