### PR TITLE
Use cirq v0.9.0 instead of cirq-unstable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### All Changes
 
 - Fix broken links on the website (@erkska, gh-400).
+- Use cirq v0.9.0 instead of cirq-unstable (@karalekas, gh-402).
+
 ## Version 0.2.0 (October 4th, 2020)
 
 ### Announcements

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy~=1.18.1
 scipy~=1.4.1
-cirq-unstable==0.9.0.dev20200813185757
+cirq==0.9.0
 
 # third-party integration
 pyquil~=2.18.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         # note: this should be a subset of requirements.txt
         "numpy~=1.18.1",
         "scipy~=1.4.1",
-        "cirq-unstable==0.9.0.dev20200813185757",
+        "cirq==0.9.0",
     ],
     extras_require={
         'development': set(requirements),


### PR DESCRIPTION
Description
-----------

Pretty straightforward. Fixes #390.

Checklist
-----------

- [x] The [changelog](https://github.com/unitaryfund/mitiq/blob/master/CHANGELOG.md) is updated, including author and PR number (@username, gh-xxx).
