### PR TITLE
Fix formatting typo and include hyperlinks to documentation objects

### DIFF
--- a/docs/source/guide/guide-hamiltonians.rst
+++ b/docs/source/guide/guide-hamiltonians.rst
@@ -4,7 +4,7 @@
 Defining Hamiltonians as Linear Combinations of Pauli Strings
 *************************************************************
 
-This tutorial shows an example of using Hamiltonians defined as ``cirq.PauliSum``s or similar objects in other
+This tutorial shows an example of using Hamiltonians defined as :class:`~cirq.PauliSum` objects or similar objects in other
 supported frontends. The usage of these Hamiltonian-like objects does not change the interface with ``mitiq``, but we
 show an example for users who prefer these constructions.
 
@@ -34,7 +34,7 @@ First we import libraries for this example.
 Defining the Hamiltonian
 ########################
 
-Now we define the Hamiltonian as a ``cirq.PauliSum`` by defining the Pauli strings :math:`X_1 Z_2` and :math:`Y_1` then
+Now we define the Hamiltonian as a :class:`~cirq.PauliSum` by defining the Pauli strings :math:`X_1 Z_2` and :math:`Y_1` then
 taking a linear combination of these to create the Hamiltonian above.
 
 .. testcode:: python
@@ -57,7 +57,7 @@ By printing the Hamiltonian we see:
     >>> print(ham)
     1.500*X(0)*Z(1)-0.700*Y(1)
 
-Note that we could have created the Hamiltonian by directly defining a ``cirq.PauliSum`` with the coefficients.
+Note that we could have created the Hamiltonian by directly defining a :class:`~cirq.PauliSum` with the coefficients.
 
 
 Using the Hamiltonian in the executor
@@ -93,7 +93,7 @@ value. In the code block below, we show how to define this function and return t
         ).real
 
 This executor inputs a Hamiltonian as well as a noise value, adds noise, then uses the
-``cirq.PauliSum.expectation_from_density_matrix`` method to return the expectation value.
+:meth:`cirq.PauliSum.expectation_from_density_matrix` method to return the expectation value.
 
 The remaining interface is as usual with ``mitiq``. For the sake of example, we show an application mitigating the
 expectation value of :math:`H` with an example ansatz at different noise levels.
@@ -130,8 +130,8 @@ We now compute expectation values of :math:`H` using the ``executor`` as follows
     expvals = [executor(ansatz(gamma=np.pi), ham, p) for p in pvals]
 
 We can compute mitigated expectation values at these same noise levels by running the following. Here, we use a
-``LinearFactory`` and use the ``partial`` function to update the ``executor`` for each noise value. The latter point
-ensures ``this_executor`` has the correct signature (input circuit, output float) to use with ``execute_with_zne``.
+:class:`.LinearFactory` and use the ``partial`` function to update the ``executor`` for each noise value. The latter point
+ensures ``this_executor`` has the correct signature (input circuit, output float) to use with :func:`.execute_with_zne`.
 
 .. testcode:: python
 
@@ -172,7 +172,7 @@ As we can see, the mitigated expectation values are closer, on average, to the t
 Sampling
 ########
 
-Finally, we note that :math:`\langle H \rangle` can be estimated by sampling using the ``cirq.PauliSumCollector``. An
+Finally, we note that :math:`\langle H \rangle` can be estimated by sampling using the :class:`cirq.PauliSumCollector`. An
 example of a ``sampling_executor`` which uses this is shown below.
 
 .. testcode:: python


### PR DESCRIPTION
Description
-----------
Close #433 by replacing double ticks+"s" without space with hyperlinks that make the objects referenced in the guide tutorial clickable (classes, methods, functions ``:func:`function_x```) etc. Using intersphinx ("~") and shorthand link (".") for internal objects in Mitiq. 

Checklist
-----------
Please make sure you have finished the following tasks before requesting a review of the pull request (PR). For more information, please refer to the [Contributor's Guide](../blob/master/CONTRIBUTING.md):

- [x] Contributions to mitiq should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/). You can enforce it easily with [`black`](https://black.readthedocs.io/en/stable/index.html) style and with [`flake8`](http://flake8.pycqa.org) conventions.
- [ ] Please add tests to cover your changes, if applicable, and make sure that all new and existing tests pass locally.
- [ ] If the behavior of the code has changed or new feature has been added, please also [update the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md).
- [x] Functions and classes have useful [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings and [type hints](https://www.python.org/dev/peps/pep-0484/) in the signature of the objects.
- [ ] (Bug fix) The associated issue is referenced above using [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords). If the PR fixes an issue, use the keyword fix/fixes/fixed followed by the issue id. For example, if the PR fixes issue 1184, type "Fixes #1184" (without quotes).
- [ ] The [changelog](https://github.com/unitaryfund/mitiq/blob/master/CHANGELOG.md) is updated, including author and PR number (@username, gh-xxx).
