### PR TITLE
Update notebook version in requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
 ## Version 0.4.0 (In Development)
 
 ### All Changes
-
-- Add refernce to review paper in docs (@willzeng, gh-423).
+- Update notebook version in requirements to resolve vulnerability found by security bot.(@nathanshammah, gh-445) 
+- Add reference to review paper in docs (@willzeng, gh-423).
 - Add unitary folding API (@rmlarose, gh-429).
 - Add new get methods (for fit errors, extrapolation curve, etc.) to Factory objects (@crazy4pi314, @andreamari, gh-403).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ mypy~=0.782
 
 # to run examples
 matplotlib~=3.2.1
-notebook~=6.0.3
+notebook~=6.1.5
 
 # to build and test the documentation
 # see docs/requirements.txt for more non-essential dependencies


### PR DESCRIPTION
Description
-----------
Update notebook version in requirements to v.~=6.1.5 as according to a Github security bot there is a vulnerability of moderate severity.

Checklist
-----------
Please make sure you have finished the following tasks before requesting a review of the pull request (PR). For more information, please refer to the [Contributor's Guide](../blob/master/CONTRIBUTING.md):

- [ ] Contributions to mitiq should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/). You can enforce it easily with [`black`](https://black.readthedocs.io/en/stable/index.html) style and with [`flake8`](http://flake8.pycqa.org) conventions.
- [ ] Please add tests to cover your changes, if applicable, and make sure that all new and existing tests pass locally.
- [ ] If the behavior of the code has changed or new feature has been added, please also [update the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md).
- [ ] Functions and classes have useful [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings and [type hints](https://www.python.org/dev/peps/pep-0484/) in the signature of the objects.
- [ ] (Bug fix) The associated issue is referenced above using [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords). If the PR fixes an issue, use the keyword fix/fixes/fixed followed by the issue id. For example, if the PR fixes issue 1184, type "Fixes #1184" (without quotes).
- [ ] The [changelog](https://github.com/unitaryfund/mitiq/blob/master/CHANGELOG.md) is updated, including author and PR number (@username, gh-xxx).
