### PR TITLE
Add option to automatically deduce the number of samples in PEC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add reference to review paper in docs (@willzeng, gh-423).
 - Add unitary folding API (@rmlarose, gh-429).
 - Add new get methods (for fit errors, extrapolation curve, etc.) to Factory objects (@crazy4pi314, @andreamari, gh-403).
+- Add option to automatically deduce the number of samples in PEC (@andreamari, gh-451).
 
 ## Version 0.3.0 (October 30th, 2020)
 

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -26,12 +26,13 @@ def execute_with_pec(
     circuit: QPROGRAM,
     executor: Callable[[QPROGRAM], float],
     decomposition_dict: DecompositionDict,
+    precision: float = 0.03,
     num_samples: Optional[int] = None,
     random_state: Optional[Union[int, np.random.RandomState]] = None,
     full_output: bool = False,
 ) -> Union[float, Tuple[float, float]]:
     """Evaluates the expectation value associated to the input circuit
-    using probabilistic error cancellation (PEC) [Temme2017]_.
+    using probabilistic error cancellation (PEC) [Temme2017]_ [Endo2018]_.
 
     This function implements PEC by:
 
@@ -50,10 +51,13 @@ def execute_with_pec(
             quasi-probability representation of the ideal operations (those
             which are part of the input circuit).
         num_samples: The number of noisy circuits to be sampled for PEC.
-            If equal to None, it is deduced from the amount of "negativity"
-            of the quasi-probability representation of the input circuit.
-            Note: the latter feature is not yet implemented and num_samples
-            is just set to 1000 if not specified.
+            If not given, this is deduced from the argument 'precision'.
+        precision: The desired estimation precision (assuming the observable
+            is bounded by 1). The number of samples is deduced according
+            to the formula (one_norm / precision) ** 2, where 'one_norm'
+            is related to the negativity of the quasi-probability
+            representation [Temme2017]_. If 'num_samples' is explicitly set
+            by the user, 'precision' is ignored and has no effect.
         random_state: Seed for sampling circuits.
         full_output: If False only the average PEC value is returned.
             If True an estimate of the associated error is returned too.
@@ -83,16 +87,24 @@ def execute_with_pec(
         (https://arxiv.org/abs/2006.12509).
     """
 
-    # TODO gh-413: Add option to automatically deduce the number of PEC samples
-    if not num_samples:
-        num_samples = 1000
+    # Get the 1-norm of the circuit quasi-probability representation
+    _, _, norm = sample_circuit(circuit, decomposition_dict)
+
+    if not (0 < precision <= 1):
+        raise ValueError(
+            "The value of 'precision' should be within the interval (0, 1],"
+            f" but precision is {precision}."
+        )
+
+    # Deduce the number of samples (if not given by the user)
+    if not isinstance(num_samples, int):
+        num_samples = int((norm / precision) ** 2)
 
     sampled_circuits = []
     signs = []
 
     for _ in range(num_samples):
-        # Note: the norm is the same for each sample.
-        sampled_circuit, sign, norm = sample_circuit(
+        sampled_circuit, sign, _ = sample_circuit(
             circuit, decomposition_dict, random_state
         )
         sampled_circuits.append(sampled_circuit)
@@ -102,7 +114,7 @@ def execute_with_pec(
     # Execute all the circuits
     exp_values = [executor(circ) for circ in sampled_circuits]
 
-    # Evaluate unbiased estimators [Temme2017], [Endo2018], [Takagi2020]
+    # Evaluate unbiased estimators [Temme2017] [Endo2018] [Takagi2020]
     unbiased_estimators = [norm * s * val for s, val in zip(signs, exp_values)]
 
     pec_value = np.average(unbiased_estimators)


### PR DESCRIPTION
Description
-----------
Fixes #413
It adds a new option for `execute_with_pec` which is called `precision`.
If `num_samples` is not given by the user, it is automatically deduced from the one-norm of the quasi-distribution of the circuit according to the formula:
`num_samples = (one_norm / precision) ** 2`

Checklist
-----------
- [x] Contributions to mitiq should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/). You can enforce it easily with [`black`](https://black.readthedocs.io/en/stable/index.html) style and with [`flake8`](http://flake8.pycqa.org) conventions.
- [x] Please add tests to cover your changes, if applicable, and make sure that all new and existing tests pass locally.
- [ ] If the behavior of the code has changed or new feature has been added, please also [update the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md).
- [x] Functions and classes have useful [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings and [type hints](https://www.python.org/dev/peps/pep-0484/) in the signature of the objects.
- [x] (Bug fix) The associated issue is referenced above using [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords). If the PR fixes an issue, use the keyword fix/fixes/fixed followed by the issue id. For example, if the PR fixes issue 1184, type "Fixes #1184" (without quotes).
- [x] The [changelog](https://github.com/unitaryfund/mitiq/blob/master/CHANGELOG.md) is updated, including author and PR number (@username, gh-xxx).
