### PR TITLE
Add warning for large samples in PEC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add unitary folding API (@rmlarose, gh-429).
 - Add new get methods (for fit errors, extrapolation curve, etc.) to Factory objects (@crazy4pi314, @andreamari, gh-403).
 - Add option to automatically deduce the number of samples in PEC (@andreamari, gh-451).
+- Add warning for large samples in PEC (@sid1993, gh-459).
 
 ## Version 0.3.0 (October 30th, 2020)
 

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -17,10 +17,23 @@
 
 from typing import Optional, Callable, Union, Tuple
 import numpy as np
-from warnings import warn
+import warnings
 from mitiq._typing import QPROGRAM
 from mitiq.pec.utils import DecompositionDict
 from mitiq.pec.sampling import sample_circuit
+
+
+class LargeSampleWarning(Warning):
+    """Warning is raised when PEC sample size is greater than 10 ** 5
+    """
+
+    pass
+
+
+_LARGE_SAMPLE_WARN = (
+    "The number of PEC samples is very large. It may take several minutes."
+    " It may be necessary to reduce 'precision' or 'num_samples'."
+)
 
 
 def execute_with_pec(
@@ -105,10 +118,7 @@ def execute_with_pec(
 
     # Issue warning for very large sample size
     if num_samples > 10 ** 5:
-        warn(
-            "Sample size in PEC is very large.It may take serveral mintues.",
-            UserWarning
-            )
+        warnings.warn(_LARGE_SAMPLE_WARN, LargeSampleWarning)
 
     sampled_circuits = []
     signs = []

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -17,6 +17,7 @@
 
 from typing import Optional, Callable, Union, Tuple
 import numpy as np
+from warnings import warn
 from mitiq._typing import QPROGRAM
 from mitiq.pec.utils import DecompositionDict
 from mitiq.pec.sampling import sample_circuit
@@ -101,6 +102,13 @@ def execute_with_pec(
     # Deduce the number of samples (if not given by the user)
     if not isinstance(num_samples, int):
         num_samples = int((norm / precision) ** 2)
+
+    # Issue warning for very large sample size
+    if num_samples > 10 ** 5:
+        warn(
+            "Sample size in PEC is very large.It may take serveral mintues.",
+            UserWarning
+            )
 
     sampled_circuits = []
     signs = []

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -175,7 +175,7 @@ def test_bad_precision_argument(bad_value: float):
         execute_with_pec(oneq_circ, executor, DECO_DICT, precision=bad_value)
 
 
-@mark.parametrize("num_samples", [100001])
+@mark.parametrize("num_samples", [100001, 105000])
 def test_large_sample_size_warning(num_samples: int):
     """Tests whether a warning is raised when PEC sample size
     is greater than 10 ** 5

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -15,12 +15,12 @@
 
 """Tests related to mitiq.pec.pec functions."""
 
-from pytest import mark, raises
+from pytest import mark, raises, warns
 import numpy as np
 from cirq import Circuit, LineQubit, Y, Z, CNOT
 
 from mitiq.pec.utils import _simple_pauli_deco_dict, DecompositionDict
-from mitiq.pec.pec import execute_with_pec
+from mitiq.pec.pec import execute_with_pec, LargeSampleWarning
 from mitiq.benchmarks.utils import noisy_simulation
 
 # The level of depolarizing noise for the simulated backend
@@ -110,7 +110,7 @@ def test_execute_with_pec_with_different_samples(circuit: Circuit, seed):
     assert np.average(errors_more_samples) < np.average(errors_few_samples)
 
 
-@mark.parametrize("num_samples", [100, 1000, 100001])
+@mark.parametrize("num_samples", [100, 1000])
 def test_execute_with_pec_with_full_output(num_samples: int):
     """Tests that the error associated to the PEC value is returned if
     the option 'full_output' is set to True.
@@ -173,3 +173,21 @@ def test_bad_precision_argument(bad_value: float):
 
     with raises(ValueError, match="The value of 'precision' should"):
         execute_with_pec(oneq_circ, executor, DECO_DICT, precision=bad_value)
+
+
+@mark.parametrize("num_samples", [100001])
+def test_large_sample_size_warning(num_samples: int):
+    """Tests whether a warning is raised when PEC sample size
+    is greater than 10 ** 5
+    """
+    rnd_state = np.random.RandomState(0)
+
+    def fake_exec(circuit: Circuit):
+        """A fake executor which just samples from a normal distribution."""
+        return rnd_state.randn()
+    with warns(
+        LargeSampleWarning,
+         match=r"The number of PEC samples is very large."
+         ):
+        execute_with_pec(
+         oneq_circ, fake_exec, DECO_DICT, num_samples=num_samples)

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -110,7 +110,7 @@ def test_execute_with_pec_with_different_samples(circuit: Circuit, seed):
     assert np.average(errors_more_samples) < np.average(errors_few_samples)
 
 
-@mark.parametrize("num_samples", [100, 1000])
+@mark.parametrize("num_samples", [100, 1000, 100001])
 def test_execute_with_pec_with_full_output(num_samples: int):
     """Tests that the error associated to the PEC value is returned if
     the option 'full_output' is set to True.

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -187,7 +187,7 @@ def test_large_sample_size_warning(num_samples: int):
         return rnd_state.randn()
     with warns(
         LargeSampleWarning,
-         match=r"The number of PEC samples is very large."
+        match=r"The number of PEC samples is very large."
          ):
         execute_with_pec(
          oneq_circ, fake_exec, DECO_DICT, num_samples=num_samples)


### PR DESCRIPTION
Fixes #454

[More details of the fix.](https://github.com/unitaryfund/mitiq/issues/454#issuecomment-735456307)

- Added test for large sample in `test_pec.py`

- Tested UserWarning by removing its filter in `pytest.ini`.
![warning](https://user-images.githubusercontent.com/4842078/100599911-9ebea480-3326-11eb-9c35-d9099197e179.png)

