### PR TITLE
Corrects typo of CnotGate in qiskit.extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ custom types for noisy operations, noisy bases, and decompositions in PEC. It al
 to the documentation, seeding options for PEC sampling functions, and bug fixes for a few non-deterministic test failures.
 
 ### All Changes
-
+- Corrects typo of CnotGate in qiskit.extensions (@purva-thakre, gh-482)
 - Add reference to review paper in docs (@willzeng, gh-423).
 - Add unitary folding API to RTD (@rmlarose, gh-429).
 - Add theory subsection on PEC in docs (@elmandouh, gh-428).

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -428,7 +428,7 @@ def test_qiskit_noisy_basis():
         pyquil.gates.H,
         pyquil.gates.CNOT(0, 1),
         qiskit.extensions.HGate,
-        qiskit.extensions.CnotGate,
+        qiskit.extensions.CXGate,
     ),
 )
 def test_noisy_basis_bad_types(element):


### PR DESCRIPTION
Description
-----------
Replaced `CnotGate` by `CXGate` in `pytest.mark.parametrize` for `qiskit.extensions`. There is no attribute called `CnotGate` in `qiskit.extensions`. 


