### PR TITLE
Qiskit package installations

### DIFF
--- a/docs/source/guide/guide-executors.rst
+++ b/docs/source/guide/guide-executors.rst
@@ -366,7 +366,7 @@ behind how this example is available `here <https://quantumcomputing.stackexchan
         # we need to modify the circuit to measure obs in its eigenbasis
         # we do this by appending a unitary operation
         eigvals, U = np.linalg.eigh(obs) # obtains a U s.t. obs = U diag(eigvals) U^dag
-        circ.unitary(np.linalg.inv(U), qubits=range(circ.n_qubits))
+        circ.unitary(np.linalg.inv(U), qubits=range(circ.num_qubits))
 
         circ.measure_all()
 
@@ -446,7 +446,7 @@ This executor can be used for noisy depolarizing simulation.
         # we need to modify the circuit to measure obs in its eigenbasis
         # we do this by appending a unitary operation
         eigvals, U = np.linalg.eigh(obs) # obtains a U s.t. obs = U diag(eigvals) U^dag
-        circ.unitary(np.linalg.inv(U), qubits=range(circ.n_qubits))
+        circ.unitary(np.linalg.inv(U), qubits=range(circ.num_qubits))
 
         circ.measure_all()
 

--- a/mitiq/_about.py
+++ b/mitiq/_about.py
@@ -41,11 +41,9 @@ def about() -> None:
     except ImportError:
         pyquil_version = "Not installed"
     try:
-        from qiskit import __qiskit_version__ as qiskit_version
+        from qiskit import __version__ as qiskit_version
     except ImportError:
-        qiskit_version = {'qiskit-terra': "Not installed",
-                          'qiskit-aer': "Not installed",
-                          'qiskit-ibmq-provider': "Not installed"}
+        qiskit_version = "Not installed"
 
     about_str = f"""
 Mitiq: A Python toolkit for implementing error mitigation on quantum computers

--- a/mitiq/_about.py
+++ b/mitiq/_about.py
@@ -41,9 +41,11 @@ def about() -> None:
     except ImportError:
         pyquil_version = "Not installed"
     try:
-        from qiskit import __version__ as qiskit_version
+        from qiskit import __qiskit_version__ as qiskit_version
     except ImportError:
-        qiskit_version = "Not installed"
+        qiskit_version = {'qiskit-terra': "Not installed",
+                          'qiskit-aer': "Not installed",
+                          'qiskit-ibmq-provider': "Not installed"}
 
     about_str = f"""
 Mitiq: A Python toolkit for implementing error mitigation on quantum computers

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -428,7 +428,7 @@ def test_qiskit_noisy_basis():
         pyquil.gates.H,
         pyquil.gates.CNOT(0, 1),
         qiskit.extensions.HGate,
-        qiskit.extensions.CnotGate,
+        qiskit.extensions.CXGate,
     ),
 )
 def test_noisy_basis_bad_types(element):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cirq==0.10.0.dev20201203012958
 # third-party integration
 pyquil~=2.18.0
 qiskit-aer>0.7
-qiskit-ibmq-provider>0.11
+qiskit-terra>0.17
 
 # to test the code
 pytest~=5.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ cirq==0.10.0.dev20201203012958
 
 # third-party integration
 pyquil~=2.18.0
-qiskit~=0.16.2
+qiskit-aer>0.7
+qiskit-ibmq-provider>0.11
 
 # to test the code
 pytest~=5.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cirq==0.10.0.dev20201203012958
 # third-party integration
 pyquil~=2.18.0
 qiskit-aer>0.7
-qiskit-terra>0.17
+qiskit-ibmq-provider>0.11
 
 # to test the code
 pytest~=5.4.1


### PR DESCRIPTION
Description
-----------
Fixes # 396 (partially)

- Edited `requirements.txt` with information about `qiskit-aer` and `qiskit-ibmq-provider`. Note that `qiskit-terra` is a dependency for `aer` i.e. does not need to be specified. 
- Due to above changes, deprecated `CnotGate` was changed to `CXGate` and deprecated `n_qubits` was changed to `num_qubits`. For more information, see `Table 2 Gate name changes` and `Table 3 new methods` at [this link](https://qiskit.org/documentation/release_notes.html). 

Problem with py36 unit test
-----------
When py36 unit test is run, `pip install -r requirements.txt` gets stuck with [dependency resolution backtracking](https://pip.pypa.io/en/latest/user_guide/#dependency-resolution-backtracking).  
This seems to be an issue with `pip` dependency resolver which was not resolved even when better constraints are specified like `qiskit-terra==0.17.0`. A possible fix could be specifying all dependencies in a `constraint.txt` file. 

Checklist
-----------
Please make sure you have finished the following tasks before requesting a review of the pull request (PR). For more information, please refer to the [Contributor's Guide](../blob/master/CONTRIBUTING.md):

- [x] Contributions to mitiq should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/). You can enforce it easily with [`black`](https://black.readthedocs.io/en/stable/index.html) style and with [`flake8`](http://flake8.pycqa.org) conventions.
- [x] Please add tests to cover your changes, if applicable, and make sure that all new and existing tests pass locally.
- [x] If the behavior of the code has changed or new feature has been added, please also [update the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md).
- [x] Functions and classes have useful [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings and [type hints](https://www.python.org/dev/peps/pep-0484/) in the signature of the objects.
- [x] (Bug fix) The associated issue is referenced above using [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords). If the PR fixes an issue, use the keyword fix/fixes/fixed followed by the issue id. For example, if the PR fixes issue 1184, type "Fixes #1184" (without quotes).
- [ ] The [changelog](https://github.com/unitaryfund/mitiq/blob/master/CHANGELOG.md) is updated, including author and PR number (@username, gh-xxx).
