### PR TITLE
Fix IBMQ guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ dist:
 .PHONY: docs
 docs:
 	make -C docs html
+
+.PHONY: doctest
+doctest:
 	make -C docs doctest
 
 .PHONY: format

--- a/docs/source/guide/guide-ibmq-backends.rst
+++ b/docs/source/guide/guide-ibmq-backends.rst
@@ -20,25 +20,23 @@ Setup: Defining a circuit
 
 First we import Qiskit and mitiq.
 
-.. doctest:: python
+.. testcode:: python
 
     import qiskit
     import mitiq
-    from mitiq.mitiq_qiskit.qiskit_utils import random_identity_circuit
 
 For simplicity, we'll use a random single-qubit circuit with ten gates that compiles to the identity, defined below.
 
-.. code-block:: python
+.. testcode:: python
 
-    >>> circuit = random_identity_circuit(depth=10)
-    >>> print(circuit)
-            ┌───┐┌───┐┌───┐┌───┐┌───┐┌───┐┌───┐┌───┐┌───┐┌───┐┌───┐
-    q_0: |0>┤ Y ├┤ Y ├┤ X ├┤ Z ├┤ Z ├┤ Z ├┤ Z ├┤ X ├┤ X ├┤ Z ├┤ Y ├
-            └───┘└───┘└───┘└───┘└───┘└───┘└───┘└───┘└───┘└───┘└───┘
-     c_0: 0 ═══════════════════════════════════════════════════════
+    qreg, creg = qiskit.QuantumRegister(1), qiskit.ClassicalRegister(1)
+    circuit = qiskit.QuantumCircuit(qreg, creg)
+    for _ in range(10):
+        circuit.x(qreg)
+    circuit.measure(qreg, creg)
 
-Currently this circuit has no measurements, but we will add a measurement below and use the probability of the ground
-state as our observable to mitigate.
+We will use the probability of the ground state as our observable to mitigate, the expectation value of which should
+evaluate to one in the noiseless setting.
 
 .. _high_level_usage:
 
@@ -57,7 +55,7 @@ We define this function in the following code block. Because we are using IBMQ b
 .. note::
     The following code requires a valid IBMQ account. See https://quantum-computing.ibm.com/ for instructions.
 
-.. doctest:: python
+.. testcode:: python
 
     provider = qiskit.IBMQ.load_account()
 
@@ -68,10 +66,7 @@ We define this function in the following code block. Because we are using IBMQ b
             circuit: Circuit to run.
             shots: Number of times to execute the circuit to compute the expectation value.
         """
-        # (1) Add measurements to the circuit
-        circuit.measure(circuit.qregs[0], circuit.cregs[0])
-
-        # (2) Run the circuit
+        # Run the circuit
         job = qiskit.execute(
             experiments=circuit,
             # Change backend=provider.get_backend("ibmq_armonk") to run on hardware
@@ -80,7 +75,7 @@ We define this function in the following code block. Because we are using IBMQ b
             shots=shots
         )
 
-        # (3) Convert from raw measurement counts to the expectation value
+        # Convert from raw measurement counts to the expectation value
         counts = job.result().get_counts()
         if counts.get("0") is None:
             expectation_value = 0.
@@ -91,7 +86,7 @@ We define this function in the following code block. Because we are using IBMQ b
 At this point, the circuit can be executed to return a mitigated expectation value by running ``mitiq.execute_with_zne``,
 as follows.
 
-.. doctest:: python
+.. testcode:: python
 
     mitigated = mitiq.execute_with_zne(circuit, armonk_executor)
 
@@ -110,17 +105,17 @@ By default, noise is scaled by locally folding gates at random, and the default 
 To specify a different extrapolation technique, we can pass a different ``Factory`` object to ``execute_with_zne``. The
 following code block shows an example of using linear extrapolation with five different (noise) scale factors.
 
-.. doctest:: python
+.. testcode:: python
 
     linear_factory = mitiq.zne.inference.LinearFactory(scale_factors=[1.0, 1.5, 2.0, 2.5, 3.0])
-    mitigated = mitiq.execute_with_zne(circuit, armonk_executor, fac=linear_factory)
+    mitigated = mitiq.execute_with_zne(circuit, armonk_executor, factory=linear_factory)
 
 To specify a different noise scaling method, we can pass a different function for the argument ``scale_noise``. This
 function should input a circuit and scale factor and return a circuit. The following code block shows an example of
 scaling noise by folding gates starting from the left (instead of at random, the default behavior for
 ``mitiq.execute_with_zne``).
 
-.. doctest:: python
+.. testcode:: python
 
     mitigated = mitiq.execute_with_zne(circuit, armonk_executor, scale_noise=mitiq.zne.scaling.fold_gates_from_left)
 
@@ -138,16 +133,16 @@ IBMQ backend.
 
 First, we define the Cirq circuit.
 
-.. doctest:: python
+.. testcode:: python
 
     import cirq
 
-    qbit = cirq.GridQubit(0, 0)
-    cirq_circuit = cirq.Circuit(cirq.ops.H.on(qbit)
+    qbit = cirq.LineQubit(0)
+    cirq_circuit = cirq.Circuit([cirq.X(qbit)] * 10, cirq.measure(qbit))
 
 Now, we simply add a line to our executor function which converts from a Cirq circuit to a Qiskit circuit.
 
-.. doctest:: python
+.. testcode:: python
 
     from mitiq.mitiq_qiskit.conversions import to_qiskit
 
@@ -157,7 +152,7 @@ Now, we simply add a line to our executor function which converts from a Cirq ci
 
 After this, we can use ``mitiq.execute_with_zne`` in the same way as above.
 
-.. doctest:: python
+.. testcode:: python
 
     mitigated = mitiq.execute_with_zne(cirq_circuit, cirq_armonk_executor)
 
@@ -175,26 +170,14 @@ example explains the code in the previous section in more detail.
 First, we define factors to scale the circuit length by and fold the circuit using the ``fold_gates_at_random``
 local folding method.
 
-.. doctest:: python
-
-    depth = 10
-    circuit = random_identity_circuit(depth=depth)
+.. testcode:: python
 
     scale_factors = [1., 1.5, 2., 2.5, 3.]
     folded_circuits = [
-            mitiq.zne.scaling.fold_local(
-            circuit, scale, method=mitiq.zne.scaling.fold_gates_at_random
-        ) for scale in scale_factors
+            mitiq.zne.scaling.fold_gates_at_random(circuit, scale)
+            for scale in scale_factors
     ]
 
-We now add the observables we want to measure to the circuit. Here we use a single observable
-:math:`\Pi_0 \equiv |0\rangle \langle0|` -- i.e., the probability of measuring the ground state -- but other observables
-can be used.
-
-.. doctest:: python
-
-    for folded_circuit in folded_circuits:
-        folded_circuit.measure(folded_circuit.qregs[0], folded_circuit.cregs[0])
 
 For a noiseless simulation, the expectation of this observable should be 1.0 because our circuit compiles to the identity.
 For noisy simulation, the value will be smaller than one. Because folding introduces more gates and thus more noise,
@@ -206,7 +189,7 @@ In the code block below, we setup our connection to IBMQ backends.
 .. note::
     The following code requires a valid IBMQ account. See https://quantum-computing.ibm.com/ for instructions.
 
-.. code-block:: python
+.. doctest:: python
 
     provider = qiskit.IBMQ.load_account()
     print("Available backends:", *provider.backends(), sep="\n")
@@ -215,7 +198,7 @@ Depending on your IBMQ account, this print statement will display different avai
 example of executing the folded circuits using the IBMQ Armonk single qubit backend. Depending on what backends are
 available, you may wish to choose a different backend by changing the ``backend_name`` below.
 
-.. code-block:: python
+.. testcode:: python
 
     shots = 8192
     backend_name = "ibmq_armonk"
@@ -236,7 +219,7 @@ available, you may wish to choose a different backend by changing the ``backend_
 Once the job has finished executing, we can convert the raw measurement statistics to observable values by running the
 following code block.
 
-.. doctest:: python
+.. testcode:: python
 
     all_counts = [job.result().get_counts(i) for i in range(len(folded_circuits))]
     expectation_values = [counts.get("0") / shots for counts in all_counts]


### PR DESCRIPTION
There were several issues in the IBMQ guide due to doctest not actually running the code. This PR fixes them, ensures the code is tested, and adds a separate doctest target to the Makefile. 

Thanks to @purva-thakre for pointing this out in https://github.com/unitaryfund/mitiq/pull/485#discussion_r551486468!