### PR TITLE
Correct typos in CONTRIBUTING_DOCS.md and ZNE guide

### DIFF
--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -110,11 +110,12 @@ classes and functions to add, to comment them, as well as exclude them.
 
 #### Build the documentation locally
 - To build the documentation, from `bash`, move to the `docs` folder and run
+
 ```bash
 sphinx-build -b html source build
 ```
 this generates the `docs/build` folder. This folder is not kept track of in the
- github repository, as `docs/build` is present in the `.gitignore` file.
+github repository, as `docs/build` is present in the `.gitignore` file.
 
 
 The `html` and `latex`  and `pdf` files will be automatically created in the

--- a/docs/source/guide/guide-zne.rst
+++ b/docs/source/guide/guide-zne.rst
@@ -418,7 +418,7 @@ In this case the factory will pass the number of shots from the `shot_list` to t
 `executor` should support a `shots` keyword argument, otherwise the shot values will go unused.
 
 ------------------------------------------------------
-Using batched executors with :class:`.BatchedFactory`s
+Using batched executors with :class:`.BatchedFactory`
 ------------------------------------------------------
 
 As mentioned, :class:`.BatchedFactory` objects are such that all circuits to execute can be precomputed. This is in


### PR DESCRIPTION
Description
-----------
Code block for building documentation locally is not showing up as a code block in [documentation](https://mitiq.readthedocs.io/en/v0.1.0/contributing_docs.html#build-the-documentation-locally). This fixes the typo.  

Also fixes a typo when class `BatchedFactory` is called [here](https://mitiq.readthedocs.io/en/latest/guide/guide-zne.html#using-batched-executors-with-class-batchedfactory-s). 