### PR TITLE
Remove initial conversion in execute_with_pec and ignore measurements when sampling

### DIFF
--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -21,7 +21,6 @@ import warnings
 import numpy as np
 
 from mitiq import generate_collected_executor, QPROGRAM
-from mitiq.conversions import convert_to_mitiq
 from mitiq.pec import sample_circuit, OperationRepresentation
 
 
@@ -104,19 +103,17 @@ def execute_with_pec(
         "Optimal resource cost for error mitigation,"
         (https://arxiv.org/abs/2006.12509).
     """
-    circuit, _ = convert_to_mitiq(circuit)
-
     if isinstance(random_state, int):
         random_state = np.random.RandomState(random_state)
-
-    # Get the 1-norm of the circuit quasi-probability representation
-    _, _, norm = sample_circuit(circuit, representations)
 
     if not (0 < precision <= 1):
         raise ValueError(
             "The value of 'precision' should be within the interval (0, 1],"
             f" but precision is {precision}."
         )
+
+    # Get the 1-norm of the circuit quasi-probability representation
+    _, _, norm = sample_circuit(circuit, representations)
 
     # Deduce the number of samples (if not given by the user)
     if not isinstance(num_samples, int):

--- a/mitiq/pec/sampling.py
+++ b/mitiq/pec/sampling.py
@@ -70,8 +70,8 @@ def sample_sequence(
 
     if operation_representation is None:
         raise ValueError(
-            f"Representation of ideal operation {ideal_operation} not found "
-            f"in provided representations."
+            f"Representation of ideal operation \n\n{ideal_operation}\n\n not "
+            "found in provided representations."
         )
 
     # Sample from this representation.
@@ -122,6 +122,10 @@ def sample_circuit(
     sign = 1
     norm = 1.0
     for op in ideal.all_operations():
+        # Ignore all measurements.
+        if cirq.is_measurement(op):
+            continue
+
         imp_seq, loc_sign, loc_norm = sample_sequence(
             cirq.Circuit(op), representations, random_state
         )

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -275,6 +275,9 @@ def test_execute_with_pec_mitigates_noise(circuit, executor, circuit_type):
             base_noise=BASE_NOISE,
             qubits=[cirq.NamedQubit(name) for name in ("q_0", "q_1")],
         )
+        # TODO: PEC with Qiskit is slow.
+        #  See https://github.com/unitaryfund/mitiq/issues/507.
+        circuit, _ = convert_to_mitiq(circuit)
     else:
         reps = pauli_representations
 

--- a/mitiq/pec/tests/test_pec_sampling.py
+++ b/mitiq/pec/tests/test_pec_sampling.py
@@ -38,11 +38,13 @@ from mitiq.pec.utils import _operation_to_choi, _circuit_to_choi
 def test_sample_sequence_cirq():
     circuit = cirq.Circuit(cirq.H(cirq.LineQubit(0)))
 
-    noisy_xop = NoisyOperation.from_cirq(ideal=cirq.X)
-    noisy_zop = NoisyOperation.from_cirq(ideal=cirq.Z)
+    circuit.append(cirq.measure(cirq.LineQubit(0)))
 
     rep = OperationRepresentation(
-        ideal=circuit, basis_expansion={noisy_xop: 0.5, noisy_zop: -0.5},
+        ideal=circuit, basis_expansion={
+            NoisyOperation.from_cirq(ideal=cirq.X): 0.5,
+            NoisyOperation.from_cirq(ideal=cirq.Z): -0.5
+        }
     )
 
     for _ in range(50):
@@ -118,11 +120,14 @@ def test_sample_sequence_cirq_random_state(seed):
         assert np.isclose(new_norm, norm)
 
 
-def test_sample_circuit_cirq():
+@pytest.mark.parametrize("measure", [True, False])
+def test_sample_circuit_cirq(measure):
     circuit = cirq.Circuit(
         cirq.ops.H.on(cirq.LineQubit(0)),
         cirq.ops.CNOT.on(*cirq.LineQubit.range(2)),
     )
+    if measure:
+        circuit.append(cirq.measure_each(*cirq.LineQubit.range(2)))
 
     h_rep = OperationRepresentation(
         ideal=circuit[:1],
@@ -133,7 +138,7 @@ def test_sample_circuit_cirq():
     )
 
     cnot_rep = OperationRepresentation(
-        ideal=circuit[1:],
+        ideal=circuit[1:2],
         basis_expansion={
             NoisyOperation.from_cirq(ideal=cirq.CNOT): 0.7,
             NoisyOperation.from_cirq(ideal=cirq.CZ): -0.7,


### PR DESCRIPTION
Note this bug is not caught by tests because the executors used by tests convert all input circuits then run them.
