### PR TITLE
Preserve register structure in Qiskit conversions

### DIFF
--- a/mitiq/conversions.py
+++ b/mitiq/conversions.py
@@ -150,7 +150,7 @@ def converter(
             return scaled_circuit
 
         # Base conversion back to input type.
-        converted_scaled_circuit = convert_from_mitiq(
+        scaled_circuit = convert_from_mitiq(
             scaled_circuit, input_circuit_type
         )
 
@@ -159,13 +159,13 @@ def converter(
             from mitiq.mitiq_qiskit.conversions import _transform_registers
 
             _transform_registers(
-                converted_scaled_circuit,
+                scaled_circuit,
                 new_qregs=circuit.qregs,
-                new_cregs=circuit.cregs if circuit.cregs else None
+                new_cregs=circuit.cregs if scaled_circuit.cregs else None
             )
-            if circuit.cregs and not converted_scaled_circuit.cregs:
-                converted_scaled_circuit.add_register(*circuit.cregs)
+            if circuit.cregs and not scaled_circuit.cregs:
+                scaled_circuit.add_register(*circuit.cregs)
 
-        return converted_scaled_circuit
+        return scaled_circuit
 
     return new_scaling_function

--- a/mitiq/conversions.py
+++ b/mitiq/conversions.py
@@ -129,7 +129,7 @@ def convert_from_mitiq(circuit: Circuit, conversion_type: str) -> QPROGRAM:
 def converter(
     noise_scaling_function: Callable[..., Any]
 ) -> Callable[..., Any]:
-    """Decorator for handling conversions.
+    """Decorator for handling conversions with noise scaling functions.
 
     Args:
         noise_scaling_function: Function which inputs a cirq.Circuit, modifies
@@ -140,12 +140,32 @@ def converter(
     def new_scaling_function(
         circuit: QPROGRAM, *args: Any, **kwargs: Any
     ) -> QPROGRAM:
+        # Convert to Mitiq representation.
         mitiq_circuit, input_circuit_type = convert_to_mitiq(circuit)
+
+        # Scale the noise in the circuit.
+        scaled_circuit = noise_scaling_function(mitiq_circuit, *args, **kwargs)
+
         if kwargs.get("return_mitiq") is True:
-            return noise_scaling_function(mitiq_circuit, *args, **kwargs)
-        return convert_from_mitiq(
-            noise_scaling_function(mitiq_circuit, *args, **kwargs),
-            input_circuit_type,
+            return scaled_circuit
+
+        # Base conversion back to input type.
+        converted_scaled_circuit = convert_from_mitiq(
+            scaled_circuit, input_circuit_type
         )
+
+        # Keep the same register structure in Qiskit circuits.
+        if input_circuit_type == "qiskit":
+            from mitiq.mitiq_qiskit.conversions import _transform_registers
+
+            _transform_registers(
+                converted_scaled_circuit,
+                new_qregs=circuit.qregs,
+                new_cregs=circuit.cregs if circuit.cregs else None
+            )
+            if circuit.cregs and not converted_scaled_circuit.cregs:
+                converted_scaled_circuit.add_register(*circuit.cregs)
+
+        return converted_scaled_circuit
 
     return new_scaling_function

--- a/mitiq/conversions.py
+++ b/mitiq/conversions.py
@@ -150,9 +150,7 @@ def converter(
             return scaled_circuit
 
         # Base conversion back to input type.
-        scaled_circuit = convert_from_mitiq(
-            scaled_circuit, input_circuit_type
-        )
+        scaled_circuit = convert_from_mitiq(scaled_circuit, input_circuit_type)
 
         # Keep the same register structure in Qiskit circuits.
         if input_circuit_type == "qiskit":
@@ -161,7 +159,7 @@ def converter(
             _transform_registers(
                 scaled_circuit,
                 new_qregs=circuit.qregs,
-                new_cregs=circuit.cregs if scaled_circuit.cregs else None
+                new_cregs=circuit.cregs if scaled_circuit.cregs else None,
             )
             if circuit.cregs and not scaled_circuit.cregs:
                 scaled_circuit.add_register(*circuit.cregs)

--- a/mitiq/mitiq_qiskit/conversions.py
+++ b/mitiq/mitiq_qiskit/conversions.py
@@ -180,7 +180,6 @@ def _transform_registers(
 
     # Map the (qu)bits in operations to the new (qu)bits.
     new_ops = []
-    # print("Iterating through ops and transforming qubits:")
     for op in circuit.data:
         gate, qubits, cbits = op
 

--- a/mitiq/mitiq_qiskit/conversions.py
+++ b/mitiq/mitiq_qiskit/conversions.py
@@ -114,11 +114,13 @@ def _transform_registers(
     new_qregs: Optional[List[qiskit.QuantumRegister]] = None,
     new_cregs: Optional[List[qiskit.ClassicalRegister]] = None,
 ) -> None:
-    """Transforms the quantum registers in the circuit to the new registers.
+    """Transforms the registers in the circuit to the new registers.
 
     Args:
-        circuit: Qiskit circuit with one quantum register and either zero
-            classical registers or 1 or n classical registers of n bits.
+        circuit: Qiskit circuit with one quantum register and either
+            * No classical registers, or
+            * One single classical register of n bits, or
+            * n single-bit classical registers.
         new_qregs: The new quantum registers for the circuit.
         new_cregs: The new classical registers for the circuit.
 
@@ -127,6 +129,8 @@ def _transform_registers(
             * If the input circuit has more than one quantum register.
             * If the number of qubits in the new quantum registers does not
             match the number of qubits in the circuit.
+            * If the input circuit has a classical register with more than one
+            bit.
             * If the number of bits in the new classical registers does not
             match the number of bits in the circuit.
     """

--- a/mitiq/mitiq_qiskit/conversions.py
+++ b/mitiq/mitiq_qiskit/conversions.py
@@ -84,24 +84,6 @@ def _map_bit_index(
     )
 
 
-def _map_cbits(bits, registers, new_register_sizes, new_registers):
-    """Maps bits to new registers. Assumes the input ``bits`` come from
-    n registers, where n is the number of bits.
-    """
-    if len(new_registers) == 0:
-        return bits
-
-    indices = [bit.index for bit in bits]  # Bug: This will always be zero for cbits.
-    mapped_indices = [_map_bit_index(i, new_register_sizes) for i in indices]
-
-    if isinstance(new_registers[0], qiskit.QuantumRegister):
-        Bit = qiskit.circuit.Qubit
-    else:
-        Bit = qiskit.circuit.Clbit
-
-    return [Bit(new_registers[i], j) for i, j in mapped_indices]
-
-
 def _map_bits(bits, registers, new_register_sizes, new_registers):
     """Maps (qu)bits to new registers. Assumes the input ``bits`` come from
     a single register or n registers, where n is the number of bits.

--- a/mitiq/mitiq_qiskit/conversions.py
+++ b/mitiq/mitiq_qiskit/conversions.py
@@ -17,7 +17,7 @@
 Qiskit's circuit representation.
 """
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -84,9 +84,28 @@ def _map_bit_index(
     )
 
 
-def _map_bits(bits, registers, new_register_sizes, new_registers):
+def _map_bits(
+    bits: List[Union[qiskit.circuit.Qubit, qiskit.circuit.Clbit]],
+    registers: List[Union[qiskit.QuantumRegister, qiskit.ClassicalRegister]],
+    new_register_sizes: List[int],
+    new_registers: List[
+        Union[qiskit.QuantumRegister, qiskit.ClassicalRegister]
+    ],
+) -> List[Union[qiskit.circuit.Qubit, qiskit.circuit.Clbit]]:
     """Maps (qu)bits to new registers. Assumes the input ``bits`` come from
     a single register or n registers, where n is the number of bits.
+
+    Args:
+        bits: A list of (qu)bits to map.
+        registers: The registers that the ``bits`` come from.
+        new_register_sizes: The size(s) of the new registers to map to.
+            Note: These can be determined from ``new_registers``, but this
+            helper function is only called from ``_map_bits`` where the sizes
+            are already computed.
+        new_registers: The new registers to map the ``bits`` to .
+
+    Returns:
+        The input ``bits`` mapped to the ``new_registers``.
     """
     if len(new_registers) == 0:
         return bits

--- a/mitiq/mitiq_qiskit/conversions.py
+++ b/mitiq/mitiq_qiskit/conversions.py
@@ -223,6 +223,8 @@ def to_qiskit(
     qiskit_circuit = qiskit.QuantumCircuit.from_qasm_str(to_qasm(circuit))
 
     # Assign register structure.
+    # Note: Output qiskit_circuit has one quantum register and n classical
+    # registers of 1 bit where n is the total number of classical bits.
     if len(qiskit_circuit.cregs) > 0:
         _transform_registers(qiskit_circuit, new_qregs=qregs, new_cregs=cregs)
     else:

--- a/mitiq/mitiq_qiskit/conversions.py
+++ b/mitiq/mitiq_qiskit/conversions.py
@@ -16,9 +16,14 @@
 """Functions to convert between Mitiq's internal circuit representation and
 Qiskit's circuit representation.
 """
+
+from typing import List, Tuple
+
+import numpy as np
+
 import cirq
 from cirq.contrib.qasm_import import circuit_from_qasm
-from qiskit import QuantumCircuit
+import qiskit
 from qiskit.extensions import Barrier
 
 from mitiq.utils import _simplify_circuit_exponents
@@ -27,7 +32,7 @@ from mitiq.utils import _simplify_circuit_exponents
 QASMType = str
 
 
-def _remove_barriers(circuit: QuantumCircuit) -> QuantumCircuit:
+def _remove_barriers(circuit: qiskit.QuantumCircuit) -> qiskit.QuantumCircuit:
     """Returns a copy of the input circuit with all barriers removed.
 
     Args:
@@ -39,6 +44,91 @@ def _remove_barriers(circuit: QuantumCircuit) -> QuantumCircuit:
         if isinstance(gate, Barrier):
             copy.data.remove(instr)
     return copy
+
+
+def _map_qubit_index(
+    qubit_index: int, new_register_sizes: List[int]
+) -> Tuple[int, int]:
+    """Returns the register index and qubit index in this register for the
+    mapped qubit_index.
+
+    Args:
+        qubit_index: Index of qubit in the original register.
+        new_register_sizes: List of sizes of the new registers.
+
+    Example:
+        qubit_index = 3, new_register_sizes = [2, 3]
+        returns (1, 0), meaning the mapped qubit is in the 1st new register and
+        has index 0 in this register.
+    """
+    max_indices_in_registers = np.cumsum(new_register_sizes) - 1
+
+    # Could be faster via bisection.
+    register_index = None
+    for i in range(len(max_indices_in_registers)):
+        if qubit_index <= max_indices_in_registers[i]:
+            register_index = i
+            break
+    assert register_index is not None
+
+    if register_index == 0:
+        return register_index, qubit_index
+
+    return (
+        register_index,
+        qubit_index - max_indices_in_registers[register_index - 1] - 1,
+    )
+
+
+def _transform_quantum_registers(
+    circuit: qiskit.QuantumCircuit, *new_registers: qiskit.QuantumRegister
+) -> None:
+    """Transforms the quantum registers in the circuit to the new registers.
+
+    Args:
+        circuit: Qiskit circuit with one quantum register.
+        new_registers: The quantum registers the circuit will act on.
+
+    Raises:
+        ValueError:
+            * If the input circuit has more than one quantum register.
+            * If the number of qubits in the new registers does not match the
+            number of qubits in the circuit.
+    """
+    if not len(new_registers):
+        return
+
+    if len(circuit.qregs) != 1:
+        raise ValueError(
+            "Input circuit is required to have 1 quantum register but has "
+            f"{len(circuit.qregs)} quantum registers."
+        )
+
+    register_sizes = [qreg.size for qreg in new_registers]
+    nqubits_in_circuit = sum(qreg.size for qreg in circuit.qregs)
+
+    if sum(register_sizes) != nqubits_in_circuit:
+        raise ValueError(
+            f"The circuit has {nqubits_in_circuit} qubits, but the provided "
+            f"registers have {sum(register_sizes)} qubits."
+        )
+
+    circuit.qregs = list(new_registers)
+    new_ops = []
+    for op in circuit.data:
+        gate, qubits, cbits = op
+        qubit_indices = [qubit.index for qubit in qubits]
+        mapped_indices = [
+            _map_qubit_index(index, register_sizes)
+            for index in qubit_indices
+        ]
+        new_qubits = [
+            qiskit.circuit.quantumregister.Qubit(new_registers[i], j)
+            for i, j in mapped_indices
+        ]
+        new_ops.append((gate, new_qubits, cbits))
+
+    circuit.data = new_ops
 
 
 def to_qasm(circuit: cirq.Circuit) -> QASMType:
@@ -55,19 +145,29 @@ def to_qasm(circuit: cirq.Circuit) -> QASMType:
     return circuit.to_qasm()
 
 
-def to_qiskit(circuit: cirq.Circuit) -> QuantumCircuit:
+def to_qiskit(
+    circuit: cirq.Circuit, *registers: qiskit.QuantumRegister
+) -> qiskit.QuantumCircuit:
     """Returns a Qiskit circuit equivalent to the input Mitiq circuit.
 
     Args:
         circuit: Mitiq circuit to convert to a Qiskit circuit.
+        registers: Quantum registers of the returned Qiskit circuit. If none
+            are provided, a single default register is used.
 
     Returns:
         Qiskit.QuantumCircuit object equivalent to the input Mitiq circuit.
     """
-    return QuantumCircuit.from_qasm_str(to_qasm(circuit))
+    # Base conversion.
+    qiskit_circuit = qiskit.QuantumCircuit.from_qasm_str(to_qasm(circuit))
+
+    # Assign register structure.
+    _transform_quantum_registers(qiskit_circuit, *registers)
+
+    return qiskit_circuit
 
 
-def from_qiskit(circuit: QuantumCircuit) -> cirq.Circuit:
+def from_qiskit(circuit: qiskit.QuantumCircuit) -> cirq.Circuit:
     """Returns a Mitiq circuit equivalent to the input Qiskit circuit.
 
     Args:
@@ -88,5 +188,5 @@ def from_qasm(qasm: QASMType) -> cirq.Circuit:
     Returns:
         Mitiq circuit representation equivalent to the input QASM string.
     """
-    qasm = _remove_barriers(QuantumCircuit.from_qasm_str(qasm)).qasm()
+    qasm = _remove_barriers(qiskit.QuantumCircuit.from_qasm_str(qasm)).qasm()
     return circuit_from_qasm(qasm)

--- a/mitiq/mitiq_qiskit/conversions.py
+++ b/mitiq/mitiq_qiskit/conversions.py
@@ -151,8 +151,8 @@ def _transform_registers(
 
     if len(creg_sizes) and sum(creg_sizes) != nbits_in_circuit:
         raise ValueError(
-            f"The circuit has {nqubits_in_circuit} bits, but the provided "
-            f"quantum registers have {sum(qreg_sizes)} bits."
+            f"The circuit has {nbits_in_circuit} bits, but the provided "
+            f"classical registers have {sum(creg_sizes)} bits."
         )
 
     # Assign the new registers.

--- a/mitiq/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Unit tests for conversions between Mitiq circuits and Qiskit circuits."""
-import numpy as np
 import pytest
 
 import cirq

--- a/mitiq/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -128,18 +128,43 @@ def test_to_qiskit_assign_qregs(qreg_sizes):
     cirq_circuit = cirq.testing.random_circuit(
         nbits, n_moments=5, op_density=1, random_state=10
     )
-    print(cirq_circuit)
+
     qregs = [qiskit.QuantumRegister(s) for s in qreg_sizes]
     qiskit_circuit = to_qiskit(cirq_circuit, qregs=qregs)
 
-    print(qiskit_circuit)
     assert qiskit_circuit.qregs == qregs
-
-    new_cirq_circuit = from_qiskit(qiskit_circuit)
-    print(new_cirq_circuit)
+    assert qiskit_circuit.cregs == []
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.unitary(from_qiskit(qiskit_circuit)),
-        cirq.unitary((cirq_circuit)),
+        cirq.unitary(cirq_circuit),
+        atol=1e-5,
+    )
+
+
+@pytest.mark.parametrize("qreg_sizes", [[2], [1, 3, 2], [2, 1], [1, 1, 1]])
+@pytest.mark.parametrize("measure", [True, False])
+@pytest.mark.parametrize("flip_creg", [True, False])
+def test_to_qiskit_assign_qregs_and_cregs(qreg_sizes, measure, flip_creg):
+    nbits = sum(qreg_sizes)
+    cirq_circuit = cirq.testing.random_circuit(
+        nbits, n_moments=5, op_density=1, random_state=10
+    )
+    if measure:
+        cirq_circuit.append(cirq.measure_each(*cirq_circuit.all_qubits()))
+
+    qregs = [qiskit.QuantumRegister(s) for s in qreg_sizes]
+    cregs = [qiskit.ClassicalRegister(s) for s in qreg_sizes]
+    if flip_creg:
+        cregs = cregs[::-1]
+
+    qiskit_circuit = to_qiskit(cirq_circuit, qregs=qregs, cregs=cregs)
+
+    assert qiskit_circuit.qregs == qregs
+    assert qiskit_circuit.cregs == cregs
+
+    cirq.testing.assert_allclose_up_to_global_phase(
+        cirq.unitary(from_qiskit(qiskit_circuit)),
+        cirq.unitary(cirq_circuit),
         atol=1e-5,
     )
 

--- a/mitiq/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -179,7 +179,7 @@ def test_map_bit_index(reg_sizes):
         assert mapped_index == expected_mapped_index
 
         expected_mapped_index += 1
-        if bit_index == sum(reg_sizes[:expected_register_index + 1]) - 1:
+        if bit_index == sum(reg_sizes[: expected_register_index + 1]) - 1:
             expected_register_index += 1
             expected_mapped_index = 0
 

--- a/mitiq/tests/test_conversions.py
+++ b/mitiq/tests/test_conversions.py
@@ -90,3 +90,21 @@ def test_converter(circuit_and_type):
     cirq_scaled = scaling_function(circuit, return_mitiq=True)
     assert isinstance(cirq_scaled, cirq.Circuit)
     assert _equal(cirq_scaled, cirq_circuit)
+
+
+@pytest.mark.parametrize("nbits", [1, 10])
+@pytest.mark.parametrize("measure", [True, False])
+def test_converter_keeps_register_structure_qiskit(nbits, measure):
+    qreg = qiskit.QuantumRegister(nbits)
+    creg = qiskit.ClassicalRegister(nbits)
+    circ = qiskit.QuantumCircuit(qreg, creg)
+    circ.h(qreg)
+
+    if measure:
+        circ.measure(qreg, creg)
+
+    scaled = scaling_function(circ)
+
+    assert scaled.qregs == circ.qregs
+    assert scaled.cregs == circ.cregs
+    assert scaled == circ

--- a/mitiq/zne/scaling/tests/test_folding.py
+++ b/mitiq/zne/scaling/tests/test_folding.py
@@ -1237,6 +1237,8 @@ def test_fold_from_left_with_qiskit_circuits():
         qiskit_circuit, scale_factor=1.0, return_mitiq=False
     )
     assert isinstance(qiskit_folded_circuit, QuantumCircuit)
+    assert qiskit_folded_circuit.qregs == qiskit_circuit.qregs
+    assert qiskit_folded_circuit.cregs == qiskit_circuit.cregs
 
 
 def test_fold_from_right_with_qiskit_circuits():
@@ -1279,6 +1281,8 @@ def test_fold_from_right_with_qiskit_circuits():
         qiskit_circuit, scale_factor=1.0
     )
     assert isinstance(qiskit_folded_circuit, QuantumCircuit)
+    assert qiskit_folded_circuit.qregs == qiskit_circuit.qregs
+    assert qiskit_folded_circuit.cregs == qiskit_circuit.cregs
 
 
 def test_fold_at_random_with_qiskit_circuits():
@@ -1321,6 +1325,8 @@ def test_fold_at_random_with_qiskit_circuits():
         qiskit_circuit, scale_factor=1.0
     )
     assert isinstance(qiskit_folded_circuit, QuantumCircuit)
+    assert qiskit_folded_circuit.qregs == qiskit_circuit.qregs
+    assert qiskit_folded_circuit.cregs == qiskit_circuit.cregs
 
 
 def test_fold_global_with_qiskit_circuits():
@@ -1356,6 +1362,8 @@ def test_fold_global_with_qiskit_circuits():
         qiskit_circuit, scale_factor=2.0, fold_method=fold_gates_from_left
     )
     assert isinstance(folded_qiskit_circuit, QuantumCircuit)
+    assert folded_qiskit_circuit.qregs == qiskit_circuit.qregs
+    assert folded_qiskit_circuit.cregs == qiskit_circuit.cregs
 
 
 def test_fold_left_squash_moments():
@@ -1550,6 +1558,8 @@ def test_fold_local_with_single_qubit_gates_fidelity_one(fold_method, qiskit):
         [ops.TOFFOLI.on(*qreg)] * 3,
     )
     if qiskit:
+        assert folded.qregs == circ.qregs
+        assert folded.cregs == circ.cregs
         folded, _ = convert_to_mitiq(folded)
         assert equal_up_to_global_phase(folded.unitary(), correct.unitary())
     else:
@@ -1597,6 +1607,8 @@ def test_all_gates_folded_at_max_scale_with_fidelities(fold_method, qiskit):
             [ops.TOFFOLI.on(*qreg)] * 3,
         )
         if qiskit:
+            assert folded.qregs == circ.qregs
+            assert folded.cregs == circ.cregs
             folded, _ = convert_to_mitiq(folded)
             assert equal_up_to_global_phase(
                 folded.unitary(), correct.unitary()


### PR DESCRIPTION
Fixes #355 (registers changed when folding Qiskit circuits) and fixes #522 (unused classical registers removed when folding Qiskit circuits). Also fixes #516 which is essentially a duplicate of #355. 

* Qiskit conversions (`to_qiskit`) now have an option to set the quantum and classical registers.
* Folding functions acting on Qiskit circuits now keep the register structure of the input Qiskit circuits.

Example of new behavior:

```python
import qiskit
from mitiq import zne

qreg = qiskit.QuantumRegister(2)
creg = qiskit.ClassicalRegister(2)
circ = qiskit.QuantumCircuit(qreg, creg)

circ.h(qreg)
print(circ)
#          ┌───┐
# q0_0: |0>┤ H ├
#          ├───┤
# q0_1: |0>┤ H ├
#          └───┘
#  c0_0: 0 ═════
#               
#  c0_1: 0 ═════

scaled = zne.scaling.fold_gates_from_left(circ, scale_factor=3)
print(scaled)  # Unused classical registers are now kept + registers are the same.
#          ┌───┐┌───┐┌───┐
# q0_0: |0>┤ H ├┤ H ├┤ H ├
#          ├───┤├───┤├───┤
# q0_1: |0>┤ H ├┤ H ├┤ H ├
#          └───┘└───┘└───┘
#  c0_0: 0 ═══════════════
#                         
#  c0_1: 0 ═══════════════
```

Let me be the first to admit that the `_transform_qubits` function is pretty ugly.