### PR TITLE
Remove obsolete "very low-level usage"

### DIFF
--- a/docs/source/guide/guide-zne.rst
+++ b/docs/source/guide/guide-zne.rst
@@ -551,11 +551,8 @@ Advanced usage of a factory
    may find this content useful to understand how a factory object actually
    works at a deeper level.
 
-In this advanced section we present a *low-level usage* and a *very-low-level usage* of a factory.
-Again, for simplicity, we solve the same zero-noise extrapolation problem that we have just considered
-in the previous sections.
-
-Eventually we will also discuss how the user can easily define a custom factory class.
+In this advanced section we present a low-level usage of a factory and we
+also discuss how the user can easily define a custom factory class.
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Description
-----------
Fix a sentence in the docs related to factories: avoid mentioning the `very low-level usage` since we removed that part from the docs. 
