### PR TITLE
Add minimal documentation for PEC in the Getting Started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ## Version 0.5.0 (In Development)
 
 ### All Changes
+
+- Add minimal documentation for PEC in the Getting Started (@andreamari, gh-532)
 - Optionally return a dictionary with all pec data in execute_with_pec (@andreamari, gh-518)
 - Added local_depolarizing_representations and Choi-based tests (@andreamari, gh-502)
 - Added new `plot_data` and `plot_fit` methods for factories(@crazy4pi314 @elmandouh, gh-333)

--- a/docs/source/apidoc.rst
+++ b/docs/source/apidoc.rst
@@ -72,15 +72,11 @@ Sampling from a Noisy Decomposition of an Ideal Operation
 .. automodule:: mitiq.pec.sampling
    :members:
 
-Probabilistic Error Cancellation (Utilities)
+Probabilistic Error Cancellation Types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. automodule:: mitiq.pec.utils
+.. automodule:: mitiq.pec.types.types
    :members:
 
-Utils
------
-.. automodule:: mitiq.utils
-   :members:
 
 Zero Noise Extrapolation
 ------------------------

--- a/docs/source/guide/guide-error-mitigation.rst
+++ b/docs/source/guide/guide-error-mitigation.rst
@@ -81,6 +81,8 @@ of when zero-noise extrapolation is effective, and how effective it is, is the s
 
 In Mitiq, this technique is implemented in the module :mod:`mitiq.zne`.
 
+.. _guide_qem_pec:
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Probabilistic error cancellation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/guide/guide-getting-started.rst
+++ b/docs/source/guide/guide-getting-started.rst
@@ -160,8 +160,8 @@ It is easy to try different ones.
 
     Mitigated error with linear ZNE: 0.00769
 
-You can use bult-in methods from factories like :func:`~mitiq.zne.inference.Factory.plot_data`
-and :func:`~mitiq.zne.inference.Factory.plot_fit` to plot the noise scale factors v. the expectation
+You can use bult-in methods from factories like :meth:`~mitiq.zne.inference.Factory.plot_data`
+and :meth:`~mitiq.zne.inference.Factory.plot_fit` to plot the noise scale factors v. the expectation
 value returned by the executor.
 
 .. testcode::
@@ -306,14 +306,19 @@ noisy operations (right-hand-side of the printed output).
 We can now implement PEC by importing the function :func:`~mitiq.pec.pec.execute_with_pec` from the 
 :mod:`~mitiq.pec.pec` module.
 
-.. testcode::
+.. testcode:: python
 
     from mitiq.pec import execute_with_pec
 
     SEED = 0
     exact_result = 1
     noisy_result = executor(circuit)
-    pec_result = execute_with_pec(circuit, executor, [x_representation], random_state=SEED)
+    pec_result = execute_with_pec(
+        circuit,
+        executor,
+        representations=[x_representation],
+        random_state=SEED,
+    )
 
     print(f"Error without mitigation: {abs(exact_result - noisy_result):.{3}}")
     print(f"Error with mitigation (PEC): {abs(exact_result - pec_result):.{3}}")

--- a/docs/source/guide/guide-getting-started.rst
+++ b/docs/source/guide/guide-getting-started.rst
@@ -56,7 +56,7 @@ with depolarizing noise and returns the expectation value of
         rho = SIMULATOR.simulate(circuit).final_density_matrix
         return np.real(rho[0,0])
 
-Now we consider a simple example: single-qubit circuit with an even
+Now we consider a simple example: a single-qubit circuit with an even
 number of X gates. By construction, the ideal expectation value should be
 1, but the noisy expectation value will be slightly different.
 
@@ -81,7 +81,7 @@ Error Mitigation with Zero-Noise Extrapolation
 ----------------------------------------------
 
 Zero-noise extrapolation can be easily implemented by importing the function
-``execute_with_zne`` from the ``mitiq.zne`` module.
+:func:`~mitiq.zne.zne.execute_with_zne` from the :mod:`~mitiq.zne.zne` module.
 
 .. testcode::
 
@@ -143,8 +143,8 @@ error-mitigated version.
 The default implementation uses Richardson extrapolation to extrapolate the
 expectation value to the zero noise limit :cite:`Temme_2017_PRL`. ``Mitiq``
 comes equipped with other extrapolation methods as well. Different methods of
-extrapolation are packaged into ``Factory`` objects. It is easy to try
-different ones.
+extrapolation are packaged into :class:`~mitiq.zne.inference.Factory` objects.
+It is easy to try different ones.
 
 .. testcode::
 
@@ -160,9 +160,9 @@ different ones.
 
     Mitigated error with linear ZNE: 0.00769
 
-You can use bult-in methods from factories like ``plot_data`` and ``plot_fit`` 
-to plot the noise scale factors v. the expectation value returned by the
-executor.
+You can use bult-in methods from factories like :func:`~mitiq.zne.inference.Factory.plot_data`
+and :func:`~mitiq.zne.inference.Factory.plot_fit` to plot the noise scale factors v. the expectation
+value returned by the executor.
 
 .. testcode::
 
@@ -172,7 +172,7 @@ executor.
     :width: 600
     :alt: factory data from executor.
 
-You can read more about the ``Factory`` objects that are built into ``mitiq``
+You can read more about the :class:`~mitiq.zne.inference.Factory` objects that are built into ``mitiq``
 and how to create your own :ref:`here <guide-factories>`.
 
 Another key step in zero-noise extrapolation is to choose how your circuit is
@@ -265,7 +265,7 @@ We can then use this backend for our mitigation.
     assert abs(exact - mitigated) < abs(exact - unmitigated)
 
 Note that we don't need to even redefine factories for different stacks. Once
-you have a ``Factory`` it can be used with different front and backends.
+you have a :class:`~mitiq.zne.inference.Factory` it can be used with different front and backends.
 
 Error Mitigation with Probabilistic Error Cancellation
 ------------------------------------------------------
@@ -299,12 +299,12 @@ whose representation in the presence of depolarizing noise can be obtained as fo
 
     0: ───X─── = 1.010*0: ───X───-0.003*0: ───X───X───-0.003*0: ───X───Y───-0.003*0: ───X───Z───
 
-The result above is an :class:`OperationRepresentation` object which contains the information for 
+The result above is an :class:`~mitiq.pec.types.types.OperationRepresentation` object which contains the information for 
 representing the ideal operation X (left-hand-side of the printed output) as a linear combination of
 noisy operations (right-hand-side of the printed output). 
 
-We can now implement PEC by importing the function ``execute_with_pec`` from the 
-``mitiq.pec`` module.
+We can now implement PEC by importing the function :func:`~mitiq.pec.pec.execute_with_pec` from the 
+:mod:`~mitiq.pec.pec` module.
 
 .. testcode::
 

--- a/docs/source/guide/guide-getting-started.rst
+++ b/docs/source/guide/guide-getting-started.rst
@@ -273,7 +273,7 @@ For example, we can implement Probabilistic Error Cancellation (PEC) by using th
 and the same Cirq circuit (``circuit``) that we have already defined in the section
 :ref:`Multi-platform Framework <multi_platform_framework>`.
 
-PEC requires the a good knowledge of the noise model and of the noise strength acting on the system.
+PEC requires a good knowledge of the noise model and of the noise strength acting on the system.
 In particular for each operation of the circuit, we need to build a quasi-probability representation of the 
 ideal unitary gate expanded in a basis of noisy implementable operations. For more details behind the theory of PEC see
 the :ref:`Probabilistic Error Cancellation <guide_qem_pec>` section.

--- a/docs/source/guide/guide-getting-started.rst
+++ b/docs/source/guide/guide-getting-started.rst
@@ -7,10 +7,10 @@ Getting Started
 Improving the performance of your quantum programs is only a few lines of
 code away.
 
-This getting started shows examples using cirq
-`cirq <https://cirq.readthedocs.io/en/stable/index.html>`_ and
-`qiskit <https://qiskit.org/>`_. We'll first test ``mitiq`` by running
-against the noisy simulator built into ``cirq``. The qiskit example works
+This getting started shows examples using
+`Cirq <https://cirq.readthedocs.io/en/stable/index.html>`_ and
+`Qiskit <https://qiskit.org/>`_. We'll first test Mitiq by running
+against the noisy simulator built into Cirq. The Qiskit example works
 similarly as you will see in :ref:`Zero-Noise Extrapolation with Qiskit <qiskit_getting_started>`.
 
 
@@ -19,17 +19,17 @@ similarly as you will see in :ref:`Zero-Noise Extrapolation with Qiskit <qiskit_
 Multi-platform Framework
 ------------------------
 
-In ``mitiq``, a "back-end" is a function that executes quantum programs. A
-"front-end" is a library/language that constructs quantum programs. ``mitiq``
+In Mitiq, a "back-end" is a function that executes quantum programs. A
+"front-end" is a library/language that constructs quantum programs. Mitiq
 lets you mix and match these. For example, you could write a quantum program in
-``qiskit`` and then execute it using a ``cirq`` backend, or vice versa.
+Qiskit and then execute it using a Cirq backend, or vice versa.
 
 Back-ends are abstracted to user-defined functions called *executors* that
 always accept a quantum program, sometimes accept other arguments, and always
 return an expectation value as a float. You can see some examples of different
 executors for common packages :ref:`here <guide-executors>` and in this
 getting started. If your quantum programming interface of choice can be used
-to make a Python function with this type, then it can be used with mitiq.
+to make a Python function with this type, then it can be used with Mitiq.
 
 Let us define a simple ``executor`` function which simulates a Cirq circuit
 with depolarizing noise and returns the expectation value of
@@ -75,7 +75,7 @@ number of X gates. By construction, the ideal expectation value should be
     Error in noisy simulation: 0.0387
 
 This shows the impact of noise on the final expectation value (without error mitigation).
-Now let's use ``mitiq`` to improve this performance.
+Now let's use Mitiq to improve this performance.
 
 Error Mitigation with Zero-Noise Extrapolation
 ----------------------------------------------
@@ -101,7 +101,7 @@ Zero-noise extrapolation can be easily implemented by importing the function
     Error with mitigation (ZNE): 0.000232
     Mitigation (ZNE) provides a 167.1 factor of improvement.
 
-You can also use ``mitiq`` to wrap your backend execution function into an
+You can also use Mitiq to wrap your backend execution function into an
 error-mitigated version.
 
 .. testcode::
@@ -119,11 +119,11 @@ error-mitigated version.
 .. _partial-note:
 
 .. note::
-   As shown here, ``mitiq`` wraps executor functions that have a specific type:
+   As shown here, Mitiq wraps executor functions that have a specific type:
    they take quantum programs as input and return expectation values. However,
    one often has an execution function with other arguments such as the number of
    shots, the observable to measure, or the noise level of a noisy simulation.
-   It is still easy to use these with mitiq by using partial function application.
+   It is still easy to use these with Mitiq by using partial function application.
    Here's a pseudo-code example:
 
    .. code-block::
@@ -141,7 +141,7 @@ error-mitigated version.
 
 
 The default implementation uses Richardson extrapolation to extrapolate the
-expectation value to the zero noise limit :cite:`Temme_2017_PRL`. ``Mitiq``
+expectation value to the zero noise limit :cite:`Temme_2017_PRL`. Mitiq
 comes equipped with other extrapolation methods as well. Different methods of
 extrapolation are packaged into :class:`~mitiq.zne.inference.Factory` objects.
 It is easy to try different ones.
@@ -172,12 +172,12 @@ value returned by the executor.
     :width: 600
     :alt: factory data from executor.
 
-You can read more about the :class:`~mitiq.zne.inference.Factory` objects that are built into ``mitiq``
+You can read more about the :class:`~mitiq.zne.inference.Factory` objects that are built into Mitiq
 and how to create your own :ref:`here <guide-factories>`.
 
 Another key step in zero-noise extrapolation is to choose how your circuit is
 transformed to scale the noise. You can read more about the noise scaling
-methods built into ``mitiq`` and how to create your
+methods built into Mitiq and how to create your
 own :ref:`here <guide-folding>`.
 
 .. _qiskit_getting_started:
@@ -185,10 +185,10 @@ own :ref:`here <guide-folding>`.
 Zero-Noise Extrapolation with Qiskit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``Mitiq`` is designed to be agnostic to the stack that you are using. Thus for
-``qiskit`` things work in the same manner as before. Since we are now using ``qiskit``,
-we want to run the error mitigated programs on a qiskit backend. Let's define
-the new backend that accepts ``qiskit`` circuits. In this case it is a simulator,
+Mitiq is designed to be agnostic to the stack that you are using. Thus for
+Qiskit things work in the same manner as before. Since we are now using Qiskit,
+we want to run the error mitigated programs on a Qiskit backend. Let's define
+the new backend that accepts Qiskit circuits. In this case it is a simulator,
 but you could also use a QPU.
 
 .. testcode::
@@ -273,7 +273,7 @@ Error Mitigation with Probabilistic Error Cancellation
 In *Mitiq*, it is very easy to switch between different error mitigation methods.
 
 For example, we can implement Probabilistic Error Cancellation (PEC) by using the same execution function (``executor``)
-and the same *Cirq* circuit (``circuit``) that we have already defined in the section
+and the same Cirq circuit (``circuit``) that we have already defined in the section
 :ref:`Multi-platform Framework <multi_platform_framework>`.
 
 Differently from ZNE, PEC requires the knowledge of the noise model and of the noise strength acting on the system.

--- a/docs/source/guide/guide-getting-started.rst
+++ b/docs/source/guide/guide-getting-started.rst
@@ -296,9 +296,9 @@ whose representation in the presence of depolarizing noise can be obtained as fo
 
     0: ───X─── = 1.010*0: ───X───-0.003*0: ───X───X───-0.003*0: ───X───Y───-0.003*0: ───X───Z───
 
-The result above is an :class:`~mitiq.pec.types.types.OperationRepresentation` object which contains the information for 
-representing the ideal operation X (left-hand-side of the printed output) as a linear combination of
-noisy operations (right-hand-side of the printed output). 
+The result above is an :class:`~mitiq.pec.types.types.OperationRepresentation` object which contains
+the information for representing the ideal operation X (left-hand-side of the printed output)
+as a linear combination of noisy operations (right-hand-side of the printed output). 
 
 We can now implement PEC by importing the function :func:`~mitiq.pec.pec.execute_with_pec` from the 
 :mod:`~mitiq.pec.pec` module.
@@ -319,7 +319,6 @@ We can now implement PEC by importing the function :func:`~mitiq.pec.pec.execute
 
     print(f"Error without mitigation: {abs(exact_result - noisy_result):.{3}}")
     print(f"Error with mitigation (PEC): {abs(exact_result - pec_result):.{3}}")
-
 
 .. testoutput::
 

--- a/docs/source/guide/guide-getting-started.rst
+++ b/docs/source/guide/guide-getting-started.rst
@@ -91,15 +91,12 @@ Zero-noise extrapolation can be easily implemented by importing the function
     
     print(f"Error without mitigation: {abs(exact_result - noisy_result):.{3}}")
     print(f"Error with mitigation (ZNE): {abs(exact_result - mitigated_result):.{3}}")
-    
-    ratio = abs((exact_result - noisy_result) / (exact_result - mitigated_result))
-    print(f"Mitigation (ZNE) provides a {ratio:.{4}} factor of improvement.")
+
 
 .. testoutput::
 
     Error without mitigation: 0.0387
     Error with mitigation (ZNE): 0.000232
-    Mitigation (ZNE) provides a 167.1 factor of improvement.
 
 You can also use Mitiq to wrap your backend execution function into an
 error-mitigated version.
@@ -322,12 +319,9 @@ We can now implement PEC by importing the function :func:`~mitiq.pec.pec.execute
 
     print(f"Error without mitigation: {abs(exact_result - noisy_result):.{3}}")
     print(f"Error with mitigation (PEC): {abs(exact_result - pec_result):.{3}}")
-    
-    ratio = abs((exact_result - noisy_result) / (exact_result - pec_result))
-    print(f"Mitigation (PEC) provides a {ratio:.{3}} factor of improvement.")
+
 
 .. testoutput::
 
     Error without mitigation: 0.0387
     Error with mitigation (PEC): 0.00364
-    Mitigation (PEC) provides a 10.6 factor of improvement.

--- a/docs/source/guide/guide-getting-started.rst
+++ b/docs/source/guide/guide-getting-started.rst
@@ -273,7 +273,7 @@ For example, we can implement Probabilistic Error Cancellation (PEC) by using th
 and the same Cirq circuit (``circuit``) that we have already defined in the section
 :ref:`Multi-platform Framework <multi_platform_framework>`.
 
-Differently from ZNE, PEC requires the knowledge of the noise model and of the noise strength acting on the system.
+PEC requires the a good knowledge of the noise model and of the noise strength acting on the system.
 In particular for each operation of the circuit, we need to build a quasi-probability representation of the 
 ideal unitary gate expanded in a basis of noisy implementable operations. For more details behind the theory of PEC see
 the :ref:`Probabilistic Error Cancellation <guide_qem_pec>` section.

--- a/docs/source/guide/guide-getting-started.rst
+++ b/docs/source/guide/guide-getting-started.rst
@@ -303,7 +303,7 @@ as a linear combination of noisy operations (right-hand-side of the printed outp
 We can now implement PEC by importing the function :func:`~mitiq.pec.pec.execute_with_pec` from the 
 :mod:`~mitiq.pec.pec` module.
 
-.. testcode:: python
+.. testcode::
 
     from mitiq.pec import execute_with_pec
 

--- a/docs/source/guide/guide-getting-started.rst
+++ b/docs/source/guide/guide-getting-started.rst
@@ -283,7 +283,7 @@ whose representation in the presence of depolarizing noise can be obtained as fo
 
 .. testcode::
 
-    from mitiq.pec.representations import represent_operation_with_local_depolarizing_noise
+    from mitiq.pec import represent_operation_with_local_depolarizing_noise
 
     x_representation = represent_operation_with_local_depolarizing_noise(
         ideal_operation=Circuit(X(qubit)), 

--- a/docs/source/guide/guide-getting-started.rst
+++ b/docs/source/guide/guide-getting-started.rst
@@ -11,95 +11,95 @@ This getting started shows examples using cirq
 `cirq <https://cirq.readthedocs.io/en/stable/index.html>`_ and
 `qiskit <https://qiskit.org/>`_. We'll first test ``mitiq`` by running
 against the noisy simulator built into ``cirq``. The qiskit example works
-similarly as you will see in :ref:`Qiskit Mitigation <qiskit_getting_started>`.
+similarly as you will see in :ref:`Zero-Noise Extrapolation with Qiskit <qiskit_getting_started>`.
 
+
+.. _multi_platform_framework:
 
 Multi-platform Framework
-----------------------------------------------
+------------------------
+
 In ``mitiq``, a "back-end" is a function that executes quantum programs. A
 "front-end" is a library/language that constructs quantum programs. ``mitiq``
 lets you mix and match these. For example, you could write a quantum program in
 ``qiskit`` and then execute it using a ``cirq`` backend, or vice versa.
 
-Back-ends are abstracted to functions called ``executors`` that always accept
-a quantum program, sometimes accept other arguments, and always
+Back-ends are abstracted to user-defined functions called *executors* that
+always accept a quantum program, sometimes accept other arguments, and always
 return an expectation value as a float. You can see some examples of different
 executors for common packages :ref:`here <guide-executors>` and in this
 getting started. If your quantum programming interface of choice can be used
 to make a Python function with this type, then it can be used with mitiq.
 
-
-Error Mitigation with Zero-Noise Extrapolation
-----------------------------------------------
-
-We define some functions that make it simpler to simulate noise in
-``cirq``. These don't have to do with ``mitiq`` directly.
+Let us define a simple ``executor`` function which simulates a Cirq circuit
+with depolarizing noise and returns the expectation value of
+:math:`|00...\rangle \langle00...|`.
 
 .. testcode::
 
     import numpy as np
-    from cirq import Circuit, depolarize
-    from cirq import LineQubit, X, DensityMatrixSimulator
+    from cirq import Circuit, depolarize, DensityMatrixSimulator
 
     SIMULATOR = DensityMatrixSimulator()
-    # 0.1% depolarizing noise
-    NOISE = 0.001
+    # 1% depolarizing noise
+    NOISE_LEVEL = 0.01
 
-    def noisy_simulation(circ: Circuit) -> float:
-        """ Simulates a circuit with depolarizing noise at level NOISE.
+    def executor(circ: Circuit) -> float:
+        """ Simulates a circuit with depolarizing noise at level NOISE_LEVEL.
         Args:
-            circ: The quantum program as a cirq object.
+            circ: The quantum program as a Cirq object.
 
         Returns:
-            The expectation value of the |0> state.
+            The expectation value of the ground state projector.
         """
-        circuit = circ.with_noise(depolarize(p=NOISE))
+        circuit = circ.with_noise(depolarize(p=NOISE_LEVEL))
         rho = SIMULATOR.simulate(circuit).final_density_matrix
-        # define the computational basis observable
-        obs = np.diag([1, 0])
-        expectation = np.real(np.trace(rho @ obs))
-        return expectation
+        return np.real(rho[0,0])
 
-Now we can look at our example. We'll test single qubit circuits with even
-numbers of X gates. As there are an even number of X gates, they should all
-evaluate to an expectation of 1 in the computational basis if there was no
-noise.
+Now we consider a simple example: single-qubit circuit with an even
+number of X gates. By construction, the ideal expectation value should be
+1, but the noisy expectation value will be slightly different.
 
 .. testcode::
 
     from cirq import Circuit, LineQubit, X
 
-    qbit = LineQubit(0)
-    circ = Circuit(X(qbit) for _ in range(80))
-    unmitigated = noisy_simulation(circ)
-    exact = 1
-    print(f"Error in simulation is {exact - unmitigated:.{3}}")
+    qubit = LineQubit(0)
+    circuit = Circuit(X(qubit) for _ in range(6))
+    noisy_result = executor(circuit)
+    exact_result = 1
+    print(f"Error in noisy simulation: {abs(exact_result - noisy_result):.{3}}")
 
 .. testoutput::
 
-    Error in simulation is 0.0506
+    Error in noisy simulation: 0.0387
 
-This shows the impact the noise has had. Let's use ``mitiq`` to improve this
-performance.
+This shows the impact of noise on the final expectation value (without error mitigation).
+Now let's use ``mitiq`` to improve this performance.
+
+Error Mitigation with Zero-Noise Extrapolation
+----------------------------------------------
+
+Zero-noise extrapolation can be easily implemented by importing the function
+``execute_with_zne`` from the ``mitiq.zne`` module.
 
 .. testcode::
 
     from mitiq import execute_with_zne
 
-    mitigated = execute_with_zne(circ, noisy_simulation)
-    print(f"Error in simulation is {exact - mitigated:.{3}}")
+    mitigated_result = execute_with_zne(circuit, executor)
+    
+    print(f"Error without mitigation: {abs(exact_result - noisy_result):.{3}}")
+    print(f"Error with mitigation (ZNE): {abs(exact_result - mitigated_result):.{3}}")
+    
+    ratio = abs((exact_result - noisy_result) / (exact_result - mitigated_result))
+    print(f"Mitigation (ZNE) provides a {ratio:.{4}} factor of improvement.")
 
 .. testoutput::
 
-    Error in simulation is 0.000519
-
-.. testcode::
-
-    print(f"Mitigation provides a {(exact - unmitigated) / (exact - mitigated):.{3}} factor of improvement.")
-
-.. testoutput::
-
-    Mitigation provides a 97.6 factor of improvement.
+    Error without mitigation: 0.0387
+    Error with mitigation (ZNE): 0.000232
+    Mitigation (ZNE) provides a 167.1 factor of improvement.
 
 You can also use ``mitiq`` to wrap your backend execution function into an
 error-mitigated version.
@@ -108,13 +108,13 @@ error-mitigated version.
 
     from mitiq import mitigate_executor
 
-    run_mitigated = mitigate_executor(noisy_simulation)
-    mitigated = run_mitigated(circ)
-    print(round(mitigated,5))
+    run_mitigated = mitigate_executor(executor)
+    mitigated_result = run_mitigated(circuit)
+    print(round(mitigated_result, 5))
 
 .. testoutput::
 
-    0.99948
+    0.99977
 
 .. _partial-note:
 
@@ -136,7 +136,7 @@ error-mitigated version.
       # takes a quantum program
       mitigated = execute_with_zne(circ, partial(shot_executor, n_shots=100))
 
-   You can read more about functools partial application
+   You can read more about ``functools`` partial application
    `here <https://docs.python.org/3/library/functools.html#functools.partial>`_.
 
 
@@ -152,12 +152,13 @@ different ones.
     from mitiq.zne.inference import LinearFactory
 
     fac = LinearFactory(scale_factors=[1.0, 2.0, 2.5])
-    linear = execute_with_zne(circ, noisy_simulation, factory=fac)
-    print(f"Mitigated error with the linear method is {exact - linear:.{3}}")
+    linear_zne_result = execute_with_zne(circuit, executor, factory=fac)
+    abs_error = abs(exact_result - linear_zne_result)
+    print(f"Mitigated error with linear ZNE: {abs_error:.{3}}")
 
 .. testoutput::
 
-    Mitigated error with the linear method is 0.00638
+    Mitigated error with linear ZNE: 0.00769
 
 You can use bult-in methods from factories like ``plot_data`` and ``plot_fit`` 
 to plot the noise scale factors v. the expectation value returned by the
@@ -181,8 +182,8 @@ own :ref:`here <guide-folding>`.
 
 .. _qiskit_getting_started:
 
-Qiskit Mitigation
---------------------------
+Zero-Noise Extrapolation with Qiskit
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``Mitiq`` is designed to be agnostic to the stack that you are using. Thus for
 ``qiskit`` things work in the same manner as before. Since we are now using ``qiskit``,
@@ -200,7 +201,7 @@ but you could also use a QPU.
     from qiskit.providers.aer.noise.errors.standard_errors import depolarizing_error
 
     # 0.1% depolarizing noise
-    NOISE = 0.001
+    QISKIT_NOISE = 0.001
 
     QISKIT_SIMULATOR = qiskit.Aer.get_backend("qasm_simulator")
 
@@ -221,7 +222,10 @@ but you could also use a QPU.
 
         # we assume a depolarizing error for each
         # gate of the standard IBM basis
-        noise_model.add_all_qubit_quantum_error(depolarizing_error(NOISE, 1), ["u1", "u2", "u3"])
+        noise_model.add_all_qubit_quantum_error(
+            depolarizing_error(QISKIT_NOISE, 1),
+            ["u1", "u2", "u3"],
+        )
 
         # execution of the experiment
         job = qiskit.execute(
@@ -262,3 +266,63 @@ We can then use this backend for our mitigation.
 
 Note that we don't need to even redefine factories for different stacks. Once
 you have a ``Factory`` it can be used with different front and backends.
+
+Error Mitigation with Probabilistic Error Cancellation
+------------------------------------------------------
+
+In *Mitiq*, it is very easy to switch between different error mitigation methods.
+
+For example, we can implement Probabilistic Error Cancellation (PEC) by using the same execution function (``executor``)
+and the same *Cirq* circuit (``circuit``) that we have already defined in the section
+:ref:`Multi-platform Framework <multi_platform_framework>`.
+
+Differently from ZNE, PEC requires the knowledge of the noise model and of the noise strength acting on the system.
+In particular for each operation of the circuit, we need to build a quasi-probability representation of the 
+ideal unitary gate expanded in a basis of noisy implementable operations. For more details on PEC see
+the :ref:`Probabilistic Error Cancellation <guide_qem_pec>` section.
+
+In our simple case, ``circuit`` corresponds to the repetition of the same X gate,
+whose representation in the presence of depolarizing noise can be obtained as follows:
+
+.. testcode::
+
+    from mitiq.pec.representations import represent_operation_with_local_depolarizing_noise
+
+    x_representation = represent_operation_with_local_depolarizing_noise(
+        ideal_operation=Circuit(X(qubit)), 
+        noise_level=NOISE_LEVEL,
+    )
+
+    print(x_representation)
+
+.. testoutput::
+
+    0: ───X─── = 1.010*0: ───X───-0.003*0: ───X───X───-0.003*0: ───X───Y───-0.003*0: ───X───Z───
+
+The result above is an :class:`OperationRepresentation` object which contains the information for 
+representing the ideal operation X (left-hand-side of the printed output) as a linear combination of
+noisy operations (right-hand-side of the printed output). 
+
+We can now implement PEC by importing the function ``execute_with_pec`` from the 
+``mitiq.pec`` module.
+
+.. testcode::
+
+    from mitiq.pec import execute_with_pec
+
+    SEED = 0
+    exact_result = 1
+    noisy_result = executor(circuit)
+    pec_result = execute_with_pec(circuit, executor, [x_representation], random_state=SEED)
+
+    print(f"Error without mitigation: {abs(exact_result - noisy_result):.{3}}")
+    print(f"Error with mitigation (PEC): {abs(exact_result - pec_result):.{3}}")
+    
+    ratio = abs((exact_result - noisy_result) / (exact_result - pec_result))
+    print(f"Mitigation (PEC) provides a {ratio:.{3}} factor of improvement.")
+
+.. testoutput::
+
+    Error without mitigation: 0.0387
+    Error with mitigation (PEC): 0.00364
+    Mitigation (PEC) provides a 10.6 factor of improvement.

--- a/mitiq/pec/__init__.py
+++ b/mitiq/pec/__init__.py
@@ -16,3 +16,7 @@
 from mitiq.pec.types import NoisyOperation, NoisyBasis, OperationRepresentation
 from mitiq.pec.sampling import sample_sequence, sample_circuit
 from mitiq.pec.pec import execute_with_pec
+from mitiq.pec.representations import (
+    represent_operation_with_global_depolarizing_noise,
+    represent_operation_with_local_depolarizing_noise,
+)


### PR DESCRIPTION
Description
-----------
Partially Fixes #393 by adding PEC to the Getting Started section.  In the future we will probably need a dedicated section outside the Getting Started, in the same way as we already have a dedicated section for ZNE.

Checklist
-----------
Please make sure you have finished the following tasks before requesting a review of the pull request (PR). For more information, please refer to the [Contributor's Guide](../blob/master/CONTRIBUTING.md):

- [x] Contributions to mitiq should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/). You can enforce it easily with [`black`](https://black.readthedocs.io/en/stable/index.html) style and with [`flake8`](http://flake8.pycqa.org) conventions.
- [x] Please add tests to cover your changes, if applicable, and make sure that all new and existing tests pass locally.
- [x] If the behavior of the code has changed or new feature has been added, please also [update the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md).
- [x] Functions and classes have useful [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings and [type hints](https://www.python.org/dev/peps/pep-0484/) in the signature of the objects.
- [x] (Bug fix) The associated issue is referenced above using [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords). If the PR fixes an issue, use the keyword fix/fixes/fixed followed by the issue id. For example, if the PR fixes issue 1184, type "Fixes #1184" (without quotes).
- [x] The [changelog](https://github.com/unitaryfund/mitiq/blob/master/CHANGELOG.md) is updated, including author and PR number (@username, gh-xxx).
