### PR TITLE
Fix and refactor RB circuits function

### DIFF
--- a/docs/source/guide/guide-executors.rst
+++ b/docs/source/guide/guide-executors.rst
@@ -545,35 +545,35 @@ Below is an example to use TensorFlow Quantum to simulate a bit-flip channel:
         nM = len(circ.moments)
         nQ = len(circ.all_qubits())
 
-        # Create array of symbolic variables and reshape to natural circuit parameterization
+        # Create array of symbolic variables and reshape to natural circuit parameterization.
         h = sympy.symbols(''.join(['h_{0} '.format(i) for i in range(nM * nQ)]), positive=True)
         h_array = np.asarray(h).reshape((nQ, nM))
 
-        # Symbolicly add X gates to the input circuit
+        # Symbolically add X gates to the input circuit.
         noisy_circuit = Circuit()
         for i, moment in enumerate(circ.moments):
             noisy_circuit.append(moment)
             for j, q in enumerate(circ.all_qubits()):
                 noisy_circuit.append(cirq.rx(h_array[j, i]).on(q))
 
-        # rotations will be pi w/ prob p, 0 w/ prob 1-p
+        # Rotations will be pi w/ prob p, 0 w/ prob 1 - p.
         vals = [np.reshape((np.random.rand(nQ, nM) < p) * np.pi, (1, nQ * nM)) for _ in range(num_monte_carlo)]
 
-        # needs to be a rank 2 tensor
+        # Needs to be a rank 2 tensor.
         vals = np.squeeze(vals)
         if num_monte_carlo == 1:
             vals = [vals]
 
-        # Instantiate tfq layer for computing state vector
+        # Instantiate tfq layer for computing state vector.
         state = tfq.layers.State()
 
-        # Execute monte carlo sim with symbolic values specified by vals
+        # Execute monte carlo sim with symbolic values specified by vals.
         out = state(noisy_circuit, symbol_names=h, symbol_values=vals).to_tensor()
 
-        # Fancy way of computing and summing individual density operators, follwed by averaging
+        # Fancy way of computing and summing individual density operators, followed by averaging.
         dm = tf.tensordot(tf.transpose(out), tf.math.conj(out), axes=[[1], [0]]).numpy() / num_monte_carlo
 
-        # return measurement of 0 state
+        # Return measurement of 0 state.
         return np.real(dm[0, 0])
 
 .. testcode::
@@ -581,12 +581,12 @@ Below is an example to use TensorFlow Quantum to simulate a bit-flip channel:
 
     if tfq_exists:
         import cirq
-        from mitiq.benchmarks import randomized_benchmarking
+        from mitiq.benchmarks import generate_rb_circuits
 
-        circ = randomized_benchmarking.rb_circuits(1, [20], 1)[0]
+        circ = generate_rb_circuits(1, 20, 1)[0]
 
         # Need to make sure the qubits are cirq.GridQubit
-        circ=circ.transform_qubits(lambda q: cirq.GridQubit.rect(1, 1)[0])
+        circ = circ.transform_qubits(lambda q: cirq.GridQubit.rect(1, 1)[0])
 
         out = stochastic_bit_flip_simulation(circ, 0.001)
         assert 0.5 < out < 1

--- a/mitiq/benchmarks/__init__.py
+++ b/mitiq/benchmarks/__init__.py
@@ -12,3 +12,5 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from mitiq.benchmarks.randomized_benchmarking import generate_rb_circuits

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -13,10 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Contains methods used for testing mitiq's performance on randomized
-benchmarking circuits.
-"""
-from typing import List, Optional
+"""Functions for generating randomized benchmarking circuits."""
+from typing import List
 import numpy as np
 
 from cirq.experiments.qubit_characterizations import (
@@ -35,51 +33,43 @@ CFD_MAT_1Q = np.array([_gate_seq_to_mats(gates) for gates in C1])
 
 def rb_circuits(
     n_qubits: int,
-    num_cliffords: List[int],
-    trials: int,
-    qubit_labels: Optional[List[int]] = None,
+    num_cliffords: int,
+    trials: int = 1,
 ) -> List[Circuit]:
-    """Generates a set of randomized benchmarking circuits, i.e. circuits that
+    """Returns a list of randomized benchmarking circuits, i.e. circuits that
     are equivalent to the identity.
 
     Args:
         n_qubits: The number of qubits. Can be either 1 or 2
-        num_cliffords: A list of numbers of Clifford group elements in the
-            random circuits. This is proportional to the eventual depth per
-            circuit.
+        num_cliffords: The number of Clifford group elements in the
+            random circuits. This is proportional to the depth per circuit.
         trials: The number of random circuits at each num_cfd.
 
     Returns:
         A list of randomized benchmarking circuits.
     """
-    rb_circuits = []
-    for num in num_cliffords:
-        qid0 = qubit_labels[0] if qubit_labels else 0
-        qubit1 = LineQubit(qid0)
-        if n_qubits == 1:
-            rb_circuits = [
-                _random_single_q_clifford(qubit1, num, C1, CFD_MAT_1Q,)
-                for _ in range(trials)
-            ]
-        elif n_qubits == 2:
-            qid1 = qubit_labels[1] if qubit_labels else 1
-            qubit2 = LineQubit(qid1)
-            cfd_matrices = _two_qubit_clifford_matrices(
-                qubit1, qubit2, CLIFFORDS,  # type: ignore
-            )
-            rb_circuits = [
-                _random_two_q_clifford(
-                    qubit1,  # type: ignore
-                    qubit2,  # type: ignore
-                    num,
-                    cfd_matrices,
-                    CLIFFORDS,
-                )
-                for _ in range(trials)
-            ]
-        else:
-            raise ValueError(
-                "Only generates RB circuits on one or two "
-                f"qubits not {n_qubits}."
-            )
-    return rb_circuits
+    if n_qubits not in (1, 2):
+        raise ValueError(
+            "Only generates RB circuits on one or two "
+            f"qubits not {n_qubits}."
+        )
+    qubits = LineQubit.range(n_qubits)
+
+    if n_qubits == 1:
+        return [
+            _random_single_q_clifford(*qubits, num_cliffords, C1, CFD_MAT_1Q)
+            for _ in range(trials)
+        ]
+
+    cfd_matrices = _two_qubit_clifford_matrices(
+        *qubits, CLIFFORDS,  # type: ignore
+    )
+    return [
+        _random_two_q_clifford(
+            *qubits,  # type: ignore
+            num_cliffords,
+            cfd_matrices,
+            CLIFFORDS,
+        )
+        for _ in range(trials)
+    ]

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -31,7 +31,7 @@ C1 = CLIFFORDS.c1_in_xy
 CFD_MAT_1Q = np.array([_gate_seq_to_mats(gates) for gates in C1])
 
 
-def rb_circuits(
+def generate_rb_circuits(
     n_qubits: int,
     num_cliffords: int,
     trials: int = 1,

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -32,9 +32,7 @@ CFD_MAT_1Q = np.array([_gate_seq_to_mats(gates) for gates in C1])
 
 
 def generate_rb_circuits(
-    n_qubits: int,
-    num_cliffords: int,
-    trials: int = 1,
+    n_qubits: int, num_cliffords: int, trials: int = 1,
 ) -> List[Circuit]:
     """Returns a list of randomized benchmarking circuits, i.e. circuits that
     are equivalent to the identity.

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -15,7 +15,6 @@
 
 """Functions for generating randomized benchmarking circuits."""
 from typing import List
-import numpy as np
 
 from cirq.experiments.qubit_characterizations import (
     _single_qubit_cliffords,
@@ -25,10 +24,6 @@ from cirq.experiments.qubit_characterizations import (
     _two_qubit_clifford_matrices,
 )
 from cirq import LineQubit, Circuit
-
-CLIFFORDS = _single_qubit_cliffords()
-C1 = CLIFFORDS.c1_in_xy
-CFD_MAT_1Q = np.array([_gate_seq_to_mats(gates) for gates in C1])
 
 
 def generate_rb_circuits(
@@ -52,22 +47,27 @@ def generate_rb_circuits(
             f"qubits not {n_qubits}."
         )
     qubits = LineQubit.range(n_qubits)
+    cliffords = _single_qubit_cliffords()
 
     if n_qubits == 1:
+
+        c1 = cliffords.c1_in_xy
+        cfd_mat_1q = [_gate_seq_to_mats(gates) for gates in c1]
+
         return [
-            _random_single_q_clifford(*qubits, num_cliffords, C1, CFD_MAT_1Q)
+            _random_single_q_clifford(*qubits, num_cliffords, c1, cfd_mat_1q)
             for _ in range(trials)
         ]
 
     cfd_matrices = _two_qubit_clifford_matrices(
-        *qubits, CLIFFORDS,  # type: ignore
+        *qubits, cliffords,  # type: ignore
     )
     return [
         _random_two_q_clifford(
             *qubits,  # type: ignore
             num_cliffords,
             cfd_matrices,
-            CLIFFORDS,
+            cliffords,
         )
         for _ in range(trials)
     ]

--- a/mitiq/benchmarks/tests/test_randomized_benchmaking.py
+++ b/mitiq/benchmarks/tests/test_randomized_benchmaking.py
@@ -18,7 +18,7 @@ import pytest
 from itertools import product
 import numpy as np
 
-from mitiq.benchmarks.randomized_benchmarking import rb_circuits
+from mitiq.benchmarks.randomized_benchmarking import generate_rb_circuits
 from mitiq.zne.inference import (
     LinearFactory,
     RichardsonFactory,
@@ -51,21 +51,15 @@ FACTORIES = [
 ]
 
 
-def test_rb_circuits():
-    depths = range(2, 10, 2)
+@pytest.mark.parametrize("n_qubits", (1, 2))
+def test_rb_circuits(n_qubits):
+    depth = 10
 
     # test single qubit RB
     for trials in [2, 3]:
-        circuits = rb_circuits(n_qubits=1, num_cliffords=depths, trials=trials)
-        for qc in circuits:
-            # we check the ground state population to ignore any global phase
-            wvf = qc.final_wavefunction()
-            zero_prob = abs(wvf[0] ** 2)
-            assert np.isclose(zero_prob, 1)
-
-    # test two qubit RB
-    for trials in [2, 3]:
-        circuits = rb_circuits(n_qubits=2, num_cliffords=depths, trials=trials)
+        circuits = generate_rb_circuits(
+            n_qubits=n_qubits, num_cliffords=depth, trials=trials
+        )
         for qc in circuits:
             # we check the ground state population to ignore any global phase
             wvf = qc.final_wavefunction()
@@ -77,9 +71,8 @@ def test_rb_circuits():
     ["scale_noise", "fac"], product(SCALE_FUNCTIONS, FACTORIES)
 )
 def test_random_benchmarks(scale_noise, fac):
-    depths = [2, 4]
     trials = 3
-    circuits = rb_circuits(n_qubits=2, num_cliffords=depths, trials=trials)
+    circuits = generate_rb_circuits(n_qubits=2, num_cliffords=4, trials=trials)
     noise = 0.01
     obs = np.diag([1, 0, 0, 0])
 

--- a/mitiq/mitiq_pyquil/tests/test_zne_mitiq_pyquil.py
+++ b/mitiq/mitiq_pyquil/tests/test_zne_mitiq_pyquil.py
@@ -31,7 +31,7 @@ from mitiq.mitiq_pyquil.pyquil_utils import (
     ground_state_expectation,
 )
 from mitiq.mitiq_pyquil.conversions import to_pyquil
-from mitiq.benchmarks.randomized_benchmarking import rb_circuits
+from mitiq.benchmarks.randomized_benchmarking import generate_rb_circuits
 
 TEST_DEPTH = 30
 
@@ -46,7 +46,7 @@ def random_one_qubit_identity_circuit(num_cliffords: int) -> pyquil.Program:
         circuit: Quantum circuit as a :class:`pyquil.Program` object.
     """
     return to_pyquil(
-        rb_circuits(n_qubits=1, num_cliffords=[num_cliffords], trials=1)[0]
+        generate_rb_circuits(n_qubits=1, num_cliffords=[num_cliffords], trials=1)[0]
     )
 
 

--- a/mitiq/mitiq_pyquil/tests/test_zne_mitiq_pyquil.py
+++ b/mitiq/mitiq_pyquil/tests/test_zne_mitiq_pyquil.py
@@ -46,7 +46,9 @@ def random_one_qubit_identity_circuit(num_cliffords: int) -> pyquil.Program:
         circuit: Quantum circuit as a :class:`pyquil.Program` object.
     """
     return to_pyquil(
-        generate_rb_circuits(n_qubits=1, num_cliffords=[num_cliffords], trials=1)[0]
+        *generate_rb_circuits(
+            n_qubits=1, num_cliffords=num_cliffords, trials=1
+        )
     )
 
 

--- a/mitiq/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/mitiq_qiskit/qiskit_utils.py
@@ -39,7 +39,9 @@ def random_one_qubit_identity_circuit(num_cliffords: int) -> QuantumCircuit:
         circuit: Quantum circuit as a :class:`qiskit.QuantumCircuit` object.
     """
     return to_qiskit(
-        generate_rb_circuits(n_qubits=1, num_cliffords=[num_cliffords], trials=1)[0]
+        *generate_rb_circuits(
+            n_qubits=1, num_cliffords=num_cliffords, trials=1
+        )
     )
 
 

--- a/mitiq/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/mitiq_qiskit/qiskit_utils.py
@@ -23,7 +23,7 @@ from qiskit.providers.aer.noise.errors.standard_errors import (
     depolarizing_error,
 )
 
-from mitiq.benchmarks.randomized_benchmarking import rb_circuits
+from mitiq.benchmarks.randomized_benchmarking import generate_rb_circuits
 from mitiq.mitiq_qiskit.conversions import to_qiskit
 
 BACKEND = Aer.get_backend("qasm_simulator")
@@ -39,7 +39,7 @@ def random_one_qubit_identity_circuit(num_cliffords: int) -> QuantumCircuit:
         circuit: Quantum circuit as a :class:`qiskit.QuantumCircuit` object.
     """
     return to_qiskit(
-        rb_circuits(n_qubits=1, num_cliffords=[num_cliffords], trials=1)[0]
+        generate_rb_circuits(n_qubits=1, num_cliffords=[num_cliffords], trials=1)[0]
     )
 
 


### PR DESCRIPTION
Fixes #538 and changes the behavior of this function to only accept one int for `num_cliffords`. I've never had a use case for multiple values for this argument, and I've always been confused to why it needed to be a list.

Also removes the `qubit_labels` argument because (i) it was never used as far as I can tell and (ii) a proper implementation of this should accept any qubit type, but `qubit_labels` assumed `LineQubit`s.