### PR TITLE
Retain measurement order when folding Qiskit circuits

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 79
-exclude = __init__.py, mitiq_pyquil/__init__.py, mitiq_qiskit/__init__.py
+exclude = __init__.py, build, docs/build

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,6 @@
 # third-party integration
 pyquil~=2.18.0
-qiskit~=0.16.2
+qiskit~=0.23.2
 
 # to test the code
 pytest~=5.4.1

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,6 @@
 # third-party integration
 pyquil~=2.18.0
-qiskit~=0.23.2
+qiskit~=0.16.2
 
 # to test the code
 pytest~=5.4.1

--- a/mitiq/conversions.py
+++ b/mitiq/conversions.py
@@ -154,7 +154,10 @@ def converter(
 
         # Keep the same register structure and measurement order with Qiskit.
         if input_circuit_type == "qiskit":
-            from mitiq.mitiq_qiskit.conversions import _transform_registers, _measurement_order
+            from mitiq.mitiq_qiskit.conversions import (
+                _transform_registers,
+                _measurement_order,
+            )
 
             scaled_circuit.remove_final_measurements()
             _transform_registers(

--- a/mitiq/conversions.py
+++ b/mitiq/conversions.py
@@ -152,10 +152,11 @@ def converter(
         # Base conversion back to input type.
         scaled_circuit = convert_from_mitiq(scaled_circuit, input_circuit_type)
 
-        # Keep the same register structure in Qiskit circuits.
+        # Keep the same register structure and measurement order with Qiskit.
         if input_circuit_type == "qiskit":
-            from mitiq.mitiq_qiskit.conversions import _transform_registers
+            from mitiq.mitiq_qiskit.conversions import _transform_registers, _measurement_order
 
+            scaled_circuit.remove_final_measurements()
             _transform_registers(
                 scaled_circuit,
                 new_qregs=circuit.qregs,
@@ -163,6 +164,9 @@ def converter(
             )
             if circuit.cregs and not scaled_circuit.cregs:
                 scaled_circuit.add_register(*circuit.cregs)
+
+            for q, c in _measurement_order(circuit):
+                scaled_circuit.measure(q, c)
 
         return scaled_circuit
 

--- a/mitiq/mitiq_qiskit/conversions.py
+++ b/mitiq/mitiq_qiskit/conversions.py
@@ -149,8 +149,14 @@ def _measurement_order(circuit: qiskit.QuantumCircuit):
     order = []
     for (gate, qubits, cbits) in circuit.data:
         if isinstance(gate, qiskit.circuit.Measure):
-            # TODO: Is it guaranteed that a measurement gate only has one qubit
-            #  and one cbit in Qiskit?
+            if len(qubits) != 1 or len(cbits) != 1:
+                raise ValueError(
+                    f"Only measurements with one qubit and one bit are "
+                    f"supported, but this measurement has {len(qubits)} "
+                    f"qubit(s) and {len(cbits)} bit(s). If you think this "
+                    f"should be supported and is a bug, please open an issue "
+                    f"at https://github.com/unitaryfund/mitiq."
+                )
             order.append((*qubits, *cbits))
     return order
 

--- a/mitiq/mitiq_qiskit/conversions.py
+++ b/mitiq/mitiq_qiskit/conversions.py
@@ -128,6 +128,33 @@ def _map_bits(
     return [Bit(new_registers[i], j) for i, j in mapped_indices]
 
 
+def _measurement_order(circuit: qiskit.QuantumCircuit):
+    """Returns the left-to-right measurement order in the circuit.
+
+    The "measurement order" is a list of tuples (qubit, bit) involved in
+    measurements ordered as they appear going left-to-right through the circuit
+    (i.e., iterating through circuit.data). The purpose of this is to be able
+    to do
+
+    >>> for (qubit, bit) in _measurement_order(circuit):
+    >>>     other_circuit.measure(qubit, bit)
+
+    which ensures ``other_circuit`` has the same measurement order as
+    ``circuit``, assuming ``other_circuit`` has the same register(s) as
+    ``circuit``.
+
+    Args:
+        circuit: Qiskit circuit to get the measurement order of.
+    """
+    order = []
+    for (gate, qubits, cbits) in circuit.data:
+        if isinstance(gate, qiskit.circuit.Measure):
+            # TODO: Is it guaranteed that a measurement gate only has one qubit
+            #  and one cbit in Qiskit?
+            order.append((*qubits, *cbits))
+    return order
+
+
 def _transform_registers(
     circuit: qiskit.QuantumCircuit,
     new_qregs: Optional[List[qiskit.QuantumRegister]] = None,

--- a/mitiq/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -294,7 +294,7 @@ def test_measurement_order(size):
     q, c = qiskit.QuantumRegister(size), qiskit.ClassicalRegister(size)
     circuit = qiskit.QuantumCircuit(q, c)
 
-    index_order = np.random.RandomState(1).permutation(size)
+    index_order = [int(i) for i in np.random.RandomState(1).permutation(size)]
     for i in index_order:
         circuit.measure(q[i], c[i])
 

--- a/mitiq/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Unit tests for conversions between Mitiq circuits and Qiskit circuits."""
+import numpy as np
 import pytest
 
 import cirq
@@ -27,6 +28,7 @@ from mitiq.mitiq_qiskit.conversions import (
     from_qiskit,
     _map_bit_index,
     _transform_registers,
+    _measurement_order,
 )
 
 
@@ -285,3 +287,16 @@ def test_transform_registers_wrong_bit_number():
 
     with pytest.raises(ValueError):
         _transform_registers(circ, new_qregs, new_cregs)
+
+
+@pytest.mark.parametrize("size", [5])
+def test_measurement_order(size):
+    q, c = qiskit.QuantumRegister(size), qiskit.ClassicalRegister(size)
+    circuit = qiskit.QuantumCircuit(q, c)
+
+    index_order = np.random.RandomState(1).permutation(size)
+    for i in index_order:
+        circuit.measure(q[i], c[i])
+
+    order = _measurement_order(circuit)
+    assert order == [(q[i], c[i]) for i in index_order]

--- a/mitiq/mitiq_qiskit/tests/test_zne_mitiq_qiskit.py
+++ b/mitiq/mitiq_qiskit/tests/test_zne_mitiq_qiskit.py
@@ -60,11 +60,11 @@ def qiskit_executor(qp: QPROGRAM, shots: int = 500) -> float:
 
 
 def get_counts(circuit: QuantumCircuit):
-    return execute(
-        circuit,
-        Aer.get_backend("qasm_simulator"),
-        shots=100
-    ).result().get_counts()
+    return (
+        execute(circuit, Aer.get_backend("qasm_simulator"), shots=100)
+        .result()
+        .get_counts()
+    )
 
 
 @zne.zne_decorator()
@@ -191,7 +191,7 @@ def test_measurement_order_is_preserved_two_registers():
     of counts is the same as the original circuit on a noiseless simulator.
     """
     n = 4
-    qreg= QuantumRegister(n)
+    qreg = QuantumRegister(n)
     creg1, creg2 = ClassicalRegister(n // 2), ClassicalRegister(n // 2)
     circuit = QuantumCircuit(qreg, creg1, creg2)
 

--- a/mitiq/zne/__init__.py
+++ b/mitiq/zne/__init__.py
@@ -14,3 +14,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from mitiq.zne.zne import execute_with_zne, mitigate_executor, zne_decorator
+from mitiq.zne import scaling
+from mitiq.zne.inference import (
+    mitiq_curve_fit,
+    mitiq_polyfit,
+    LinearFactory,
+    PolyFactory,
+    RichardsonFactory,
+    ExpFactory,
+    PolyExpFactory,
+    AdaExpFactory,
+)

--- a/mitiq/zne/scaling/tests/test_folding.py
+++ b/mitiq/zne/scaling/tests/test_folding.py
@@ -1721,3 +1721,13 @@ def test_fold_fidelity_large_scale_factor_only_twoq_gates(fold_method, scale):
     )
     correct = Circuit(ops.H(qreg[0]), [ops.CNOT(*qreg)] * scale)
     assert _equal(folded, correct)
+
+
+def test_folding_keeps_measurement_order_with_qiskit():
+    qreg, creg = QuantumRegister(2), ClassicalRegister(2)
+    circuit = QuantumCircuit(qreg, creg)
+    circuit.h(qreg[0])
+    circuit.measure(qreg, creg)
+
+    folded = fold_gates_at_random(circuit, scale_factor=1.0)
+    assert folded == circuit


### PR DESCRIPTION
Fixes #551.

Results are now as expected for the example in #551:

```python
from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
from mitiq.zne.scaling import fold_gates_at_random

q, c = QuantumRegister(2), ClassicalRegister(2)
circuit = QuantumCircuit(q, c)
circuit.h(q[0])
circuit.measure(q, c)

print(circuit)
```

```
      ┌───┐┌─┐
q0_0: ┤ H ├┤M├
      └┬─┬┘└╥┘
q0_1: ─┤M├──╫─
       └╥┘  ║ 
c0: 2/══╩═══╩═
        1   0 
```

```python
folded = fold_gates_at_random(circuit, scale_factor=1.)

print(folded)
```

```
      ┌───┐┌─┐
q0_0: ┤ H ├┤M├
      └┬─┬┘└╥┘
q0_1: ─┤M├──╫─
       └╥┘  ║ 
c0: 2/══╩═══╩═
        1   0 
```