### PR TITLE
[WIP] Add measurement support to executors

### DIFF
--- a/mitiq/executor.py
+++ b/mitiq/executor.py
@@ -1,0 +1,150 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Defines the interface that converts supported quantum circuits to executed
+results which is called in a black-box manner by error mitigation techniques.
+"""
+
+import inspect
+from typing import Any, Callable, Iterable, List, Sequence, Tuple, Union
+
+import numpy as np
+
+from cirq.study import TrialResult
+
+
+MeasurementResult = TrialResult
+
+
+class Executor:
+    def __init__(
+        self,
+        circuit_to_expectation: Callable = None,
+        circuit_to_measurement: Callable = None,
+        measurement_to_expectation: Callable = None,
+    ) -> None:
+        """Constructs an Executor object to run circuits and return expectation
+        values, optionally storing raw measurement results.
+
+        Succinctly, the workflow is
+
+        (a) Circuit(s) -> Expectation value(s) via ``circuit_to_expectation``
+
+        or
+
+        (b) Circuit(s) -> Measurements via ``circuit_to_measurement`` then
+            Measurements -> Expectation value(s) via
+            ``measurement_to_expectation``.
+
+        If a function outputs more than one expectation value (is "batched"),
+        it must be annotated with a return type that is one of the following:
+
+        * Iterable[float]
+        * List[float]
+        * Sequence[float]
+        * Tuple[float]
+        * numpy.ndarray
+
+        Otherwise, by default the function is assumed to output one expectation
+        value (is "serial").
+
+        Args:
+            circuit_to_expectation: A function which inputs one or more
+                circuits and outputs one or more expectation values.
+            circuit_to_measurement: A function which inputs one or more
+                circuits and outputs one or more measurement results.
+            measurement_to_expectation: A function which inputs one or more
+                measurement results and outputs one or more expectation values.
+        """
+        self._measurement_history: List[MeasurementResult] = []
+        self._expectation_history: List[float] = []
+        self._circuit_history: List[Any] = []
+
+        self._supports_measurements = circuit_to_measurement is not None
+        if circuit_to_measurement:
+            self._execute = circuit_to_measurement
+        else:
+            self._execute = circuit_to_expectation
+        self._measurement_to_expectation = measurement_to_expectation
+
+        if not self._execute or (
+            self._supports_measurements
+            and not self._measurement_to_expectation
+        ):
+            raise ValueError(
+                "Unable to compute expectation values with provided arguments."
+                "Provide either `circuit_to_expectation` OR "
+                "`circuit_to_measurement` AND `measurement_to_expectation`."
+            )
+
+        self._is_batched = self._can_batch()
+
+    def _can_batch(self) -> bool:
+        """Returns True if the Executor can batch execute circuits."""
+        if self._supports_measurements:
+            execute = self._measurement_to_expectation
+        else:
+            execute = self._execute
+
+        annotation = inspect.getfullargspec(execute).annotations
+
+        return annotation.get("return") in (
+            List[float],
+            Sequence[float],
+            Tuple[float],
+            Iterable[float],
+            np.ndarray,
+        )
+
+    @property
+    def circuit_history(self) -> List[Any]:
+        return self._circuit_history
+
+    @property
+    def measurement_history(self) -> List[MeasurementResult]:
+        return self._measurement_history
+
+    @property
+    def expectation_history(self) -> List[float]:
+        return self._expectation_history
+
+    @property
+    def last_measurement(self) -> MeasurementResult:
+        return self._measurement_history[-1]
+
+    @property
+    def last_expectation(self) -> Union[float, List[float]]:
+        return self._expectation_history[-1]
+
+    def execute(self, to_run: Any) -> Union[float, List[float]]:
+        """Returns the floating point expectation value(s) obtained by
+        executing the circuit(s) and stores the result in history.
+        Stores measurement results if supported.
+
+        Args:
+            to_run: A single circuit or sequence of circuits to execute.
+        """
+        result = self._execute(to_run)
+
+        if self._supports_measurements:
+            self._measurement_history.append(result)
+            self._expectation_history.append(
+                self._measurement_to_expectation(result)
+            )
+        else:
+            self._expectation_history.append(result)
+
+        self._circuit_history.append(to_run)
+        return self.last_expectation

--- a/mitiq/tests/test_executor.py
+++ b/mitiq/tests/test_executor.py
@@ -1,0 +1,120 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import List
+import pytest
+
+import numpy as np
+
+import cirq
+from mitiq.executor import Executor, MeasurementResult
+
+
+def execute_serial_untyped(x):
+    return x ** 2
+
+
+def executor_serial_typed(x) -> float:
+    return x ** 2
+
+
+def execute_batch(xvals) -> List[float]:
+    return [x ** 2 for x in xvals]
+
+
+@pytest.mark.parametrize(
+    "execute", (execute_serial_untyped, executor_serial_typed)
+)
+def test_executor_with_execute_serial(execute):
+    executor = Executor(circuit_to_expectation=execute)
+    assert not executor._can_batch()
+
+    result = executor.execute(to_run=1)
+    assert result == 1
+    assert executor.expectation_history == [1]
+    assert executor.last_expectation == 1
+
+    next_result = executor.execute(to_run=2)
+    assert next_result == 4
+    assert executor.expectation_history == [1, 4]
+    assert executor.last_expectation == 4
+
+    assert executor.measurement_history == []
+    assert executor.circuit_history == [1, 2]
+
+
+def test_executor_with_execute_batch():
+    executor = Executor(circuit_to_expectation=execute_batch)
+    assert executor._can_batch()
+
+    result = executor.execute(to_run=[1, 2])
+    assert result == [1, 4]
+    assert executor.expectation_history == [[1, 4]]
+    assert executor.last_expectation == [1, 4]
+
+    next_result = executor.execute(to_run=[3, 4])
+    assert next_result == [9, 16]
+    assert executor.expectation_history == [[1, 4], [9, 16]]
+    assert executor.last_expectation == [9, 16]
+
+    assert executor.measurement_history == []
+    assert executor.circuit_history == [[1, 2], [3, 4]]
+
+
+def test_executor_input_combinations():
+    def generic():
+        pass
+
+    with pytest.raises(ValueError):
+        Executor(circuit_to_measurement=generic)
+
+    with pytest.raises(ValueError):
+        Executor(measurement_to_expectation=generic)
+
+    assert Executor(circuit_to_expectation=generic)
+    assert Executor(
+        circuit_to_measurement=generic,
+        measurement_to_expectation=generic,
+    )
+
+
+def test_executor_with_measurement_result():
+    def to_measurement(circuit) -> MeasurementResult:
+        return cirq.Simulator().run(circuit, repetitions=1000)
+
+    def ground_state_prob(measurement: MeasurementResult) -> float:
+        return np.average(np.sum(measurement.measurements["z"], axis=1) == 0)
+
+    executor = Executor(
+        circuit_to_measurement=to_measurement,
+        measurement_to_expectation=ground_state_prob,
+    )
+    assert not executor._can_batch()
+
+    qreg = cirq.LineQubit.range(3)
+    circuit1 = cirq.Circuit(cirq.measure(*qreg, key="z"))
+    circuit2 = cirq.Circuit(cirq.X.on_each(qreg), cirq.measure(*qreg, key="z"))
+    expected_results = [1.0, 0.0]
+
+    for circuit, expected in zip((circuit1, circuit2), expected_results):
+        assert executor.execute(circuit) == expected
+        assert executor.last_expectation == expected
+
+        meas = executor.last_measurement
+        assert ground_state_prob(meas) == executor.last_expectation
+
+    assert executor.expectation_history == expected_results
+    assert executor.circuit_history[0] is circuit1
+    assert executor.circuit_history[1] is circuit2


### PR DESCRIPTION
Opening for comments and discussion.

Initial implementation of the Executor outlined [here](https://docs.google.com/document/d/1Y_CaqfhtMzvfr5X46r3dtrYKZcqH16kRhtecv3wYOJI/edit?usp=sharing). 

As discussed @ Mitiq meeting:

* How to deal with multiple observables? i.e., when you have to use two or more incompatible measurements to compute an expectation? 
  - Option 1: Don't support this. Rely on multiple calls to `mitiq.execute_with_[pec|zne]`. 
      - Note: Multiple calls only required if you want to store measurements. A single call is possible when returning a float by computing the linear combination inside the `circuit_to_expectation` function.
  - Option 2: Add support for observables and store measurements for the product of {circuit} x {observable set}.
  - Option 3: Other suggestions welcome :)
* What's the best interface for accepting `circuit_to_expectation`, `circuit_to_measurement`, and/or `measurement_to_expectation` user-defined functions? As currently is? Abstract base class? Other?


Beyond discussed @ Mitiq meeting:

* I would propose merging the (properly implemented) `Collecter` capabilities into the `Executor` class, assuming the design doesn't significantly change from the current design. Namely, add `Executor.run` method to accept a batch of circuits, detect duplicates, increase shots in duplicates if supported, and handle max batch size & max # shots.

