### PR TITLE
Density-matrix simulation with depolarizing noise executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@
 
 ### All Changes
 
+- Add qiskit executor example for exact density matrix simulation with depolarizing noise (@aaron-robertson gh-269)
+
 ## Version 0.6.0 (March 1st, 2021)
 
 ### Summary
 
 The automated workflows for builds and releases are improved and PyPI releases are now automated.
 We have more documentation on PEC and have a new tutorial on QAOA with Mitiq, as well as some miscellaneous bug fixes.
+
 ### All Changes
 
 - Improve CI and release/patch workflow and documentation (@crazy4pi314 gh-566).
@@ -30,6 +33,7 @@ We have more documentation on PEC and have a new tutorial on QAOA with Mitiq, as
 - Adding make doc-clean command (@crazy4pi314 gh-549)
 - Fix and refactor RB circuits function (@rmlarose gh-539)
 - Improve GateOperation simplification in exponents (@rmlarose gh-541)
+
 ## Version 0.5.0 (February 8th, 2021)
 
 ### Summary

--- a/docs/source/guide/guide-executors.rst
+++ b/docs/source/guide/guide-executors.rst
@@ -414,8 +414,8 @@ in this example can be found `here <https://quantumcomputing.stackexchange.com/a
 Qiskit: Density-matrix Simulation with Depolarizing Noise
 -----------------------------------------------------------
 
-Analogous to the Cirq implementation, this executor can be used for noisy depolarizing
-simulation.
+This executor can be used to simulate a circuit with depolarizing noise and to return the exact
+expectation value of an observable (without the shot noise typical of a real experiment).
 
 .. testcode::
 
@@ -479,11 +479,6 @@ simulation.
 
     qc = QuantumCircuit(1)
     for _ in range(100):
-        qc.u1(0, 0)
-    assert 0.1 < execute(qc, np.diag([1, 0]), 0.02) < 1.0
-
-    qc = QuantumCircuit(1)
-    for _ in range(100):
         qc.x(0)
 
     assert execute(qc, np.diag([0, 1]), 0.0) == 0.0
@@ -493,7 +488,8 @@ simulation.
 Qiskit: Density-matrix Simulation with Depolarizing Noise and Sampling
 ------------------------------------------------------------------------
 
-You can also include both noise models and finite sampling in your executor.
+This executor can be used to simulate a circuit with depolarizing noise. The expectation value is
+estimated with a finite number of measurements and so it is affected by statistical noise.
 
 .. testcode::
 

--- a/docs/source/guide/guide-executors.rst
+++ b/docs/source/guide/guide-executors.rst
@@ -446,13 +446,7 @@ simulation.
         if len(circ.clbits) > 0:
             raise ValueError("This executor only works on programs with no classical bits.")
 
-        circ = copy.deepcopy(circ)
-        # we need to modify the circuit to measure obs in its eigenbasis
-        # we do this by appending a unitary operation
-        eigvals, U = np.linalg.eigh(obs) # obtains a U s.t. obs = U diag(eigvals) U^dag
-        circ.unitary(np.linalg.inv(U), qubits=range(circ.num_qubits))
         circ.snapshot_density_matrix('final')
-        circ.measure_all()
 
         # initialize a qiskit noise model
         noise_model = NoiseModel()
@@ -494,7 +488,7 @@ simulation.
 
     assert execute(qc, np.diag([0, 1]), 0.0) == 0.0
     assert np.isclose(execute(qc, np.diag([0, 1]), 0.5), 0.5)
-    assert np.isclose(execute(qc, np.diag([0, 1]), 0.001), 0.0480563)
+    assert np.isclose(execute(qc, np.diag([0, 1]), 0.001), 0.0476039)
 
 Qiskit: Density-matrix Simulation with Depolarizing Noise and Sampling
 ------------------------------------------------------------------------

--- a/docs/source/guide/guide-executors.rst
+++ b/docs/source/guide/guide-executors.rst
@@ -413,12 +413,93 @@ in this example can be found `here <https://quantumcomputing.stackexchange.com/a
 
 Qiskit: Density-matrix Simulation with Depolarizing Noise
 -----------------------------------------------------------
-    TODO
+
+Analogous to the Cirq implementation, this executor can be used for noisy depolarizing
+simulation.
+
+.. testcode::
+
+    import qiskit
+    from qiskit import QuantumCircuit
+    import numpy as np
+    import copy
+
+    # Noise simulation packages
+    from qiskit.providers.aer.noise import NoiseModel
+    from qiskit.providers.aer.noise.errors.standard_errors import depolarizing_error
+    from qiskit.providers.aer.extensions import snapshot_density_matrix
+
+    QISKIT_SIMULATOR = qiskit.Aer.get_backend("qasm_simulator")
+
+    def execute(circ: QuantumCircuit, obs: np.ndarray, noise: float) -> float:
+        """Simulates the evolution of the noisy circuit and returns
+        the expectation value of the observable.
+
+        Args:
+            circ: The input Cirq circuit.
+            obs: The observable to measure as a NumPy array.
+            noise: The depolarizing noise strength as a float, i.e. 0.001 is 0.1%.
+
+        Returns:
+            The expectation value of obs as a float.
+        """
+        if len(circ.clbits) > 0:
+            raise ValueError("This executor only works on programs with no classical bits.")
+
+        circ = copy.deepcopy(circ)
+        # we need to modify the circuit to measure obs in its eigenbasis
+        # we do this by appending a unitary operation
+        eigvals, U = np.linalg.eigh(obs) # obtains a U s.t. obs = U diag(eigvals) U^dag
+        circ.unitary(np.linalg.inv(U), qubits=range(circ.num_qubits))
+        circ.snapshot_density_matrix('final')
+        circ.measure_all()
+
+        # initialize a qiskit noise model
+        noise_model = NoiseModel()
+
+        # we assume the same depolarizing error for each
+        # gate of the standard IBM basis
+        noise_model.add_all_qubit_quantum_error(depolarizing_error(noise, 1), ["u1", "u2", "u3"])
+        noise_model.add_all_qubit_quantum_error(depolarizing_error(noise, 2), ["cx"])
+
+        # execution of the experiment
+        job = qiskit.execute(
+            circ,
+            backend=QISKIT_SIMULATOR,
+            backend_options={'method':'density_matrix'},
+            noise_model=noise_model,
+            # we want all gates to be actually applied,
+            # so we skip any circuit optimization
+            basis_gates=noise_model.basis_gates,
+            optimization_level=0,
+            shots=1,
+        )
+        result = job.result()
+        rho = result.data()['snapshots']['density_matrix']['final'][0]['value']
+
+        expectation = np.real(np.trace(rho @ obs))
+        return expectation
+
+.. testcode::
+    :hide:
+
+    qc = QuantumCircuit(1)
+    for _ in range(100):
+        qc.u1(0, 0)
+    assert 0.1 < execute(qc, np.diag([1, 0]), 0.02) < 1.0
+
+    qc = QuantumCircuit(1)
+    for _ in range(100):
+        qc.x(0)
+
+    assert execute(qc, np.diag([0, 1]), 0.0) == 0.0
+    assert np.isclose(execute(qc, np.diag([0, 1]), 0.5), 0.5)
+    assert np.isclose(execute(qc, np.diag([0, 1]), 0.001), 0.0480563)
 
 Qiskit: Density-matrix Simulation with Depolarizing Noise and Sampling
 ------------------------------------------------------------------------
 
-This executor can be used for noisy depolarizing simulation.
+You can also include both noise models and finite sampling in your executor.
 
 .. testcode::
 


### PR DESCRIPTION
Description
-----------
Resolves #269: add a qiskit executor example for exact density matrix simulation 

Checklist
-----------
Please make sure you have finished the following tasks before requesting a review of the pull request (PR). For more information, please refer to the [Contributor's Guide](../blob/master/CONTRIBUTING.md):

- [x] Contributions to mitiq should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/). You can enforce it easily with [`black`](https://black.readthedocs.io/en/stable/index.html) style and with [`flake8`](http://flake8.pycqa.org) conventions.
- [x] Please add tests to cover your changes, if applicable, and make sure that all new and existing tests pass locally.
- [x] If the behavior of the code has changed or new feature has been added, please also [update the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md).
- [x] Functions and classes have useful [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings and [type hints](https://www.python.org/dev/peps/pep-0484/) in the signature of the objects.
- [x] (Bug fix) The associated issue is referenced above using [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords). If the PR fixes an issue, use the keyword fix/fixes/fixed followed by the issue id. For example, if the PR fixes issue 1184, type "Fixes #1184" (without quotes).
- [x] The [changelog](https://github.com/unitaryfund/mitiq/blob/master/CHANGELOG.md) is updated, including author and PR number (@username, gh-xxx).
