### PR TITLE
Fix problem of notebooks without output in Read the Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## Version 0.6.0 (March 1st, 2021)
 
+- [Bug Fix] Examples (notebooks) in the online documentation now have output code cells. (@andreamari, gh-576).
+
 ### Summary
 
 The automated workflows for builds and releases are improved and PyPI releases are now automated.

--- a/docs/source/examples/maxcut-demo.myst
+++ b/docs/source/examples/maxcut-demo.myst
@@ -21,15 +21,6 @@ In particular we are interested in investigating how Mitiq can help reduce error
 
 +++
 
-```{code-cell} ipython3
----
-tags: [hide-cell]
----
-# This cell allows to run the notebook from the mitiq git repository even if mitiq is not installed with pip.
-# If mitiq is installed, this cell can be removed.
-import sys, os
-sys.path.insert(0, os.path.abspath("../../../"))
-```
 
 ## The MaxCut problem
 

--- a/docs/source/examples/maxcut-demo.myst
+++ b/docs/source/examples/maxcut-demo.myst
@@ -21,6 +21,13 @@ In particular we are interested in investigating how Mitiq can help reduce error
 
 +++
 
+```{code-cell} ipython3
+# This cell allows to run the notebook from the mitiq git repository even if mitiq is not installed with pip.
+# If mitiq is installed, this cell can be removed.
+import sys, os
+sys.path.insert(0, os.path.abspath("../../../"))
+```
+
 ## The MaxCut problem
 
 +++
@@ -499,7 +506,6 @@ the accuracy of the results and the execution time.
 [4] [MaxCut tutorial in PyQuil.](https://grove-docs.readthedocs.io/en/latest/qaoa.html)
 
 [5] [MaxCut tuturial in Cirq.](https://quantumai.google/cirq/tutorials/qaoa)
-
 
 ```{code-cell} ipython3
 mitiq.about()

--- a/docs/source/examples/maxcut-demo.myst
+++ b/docs/source/examples/maxcut-demo.myst
@@ -22,6 +22,9 @@ In particular we are interested in investigating how Mitiq can help reduce error
 +++
 
 ```{code-cell} ipython3
+---
+tags: [hide-cell]
+---
 # This cell allows to run the notebook from the mitiq git repository even if mitiq is not installed with pip.
 # If mitiq is installed, this cell can be removed.
 import sys, os

--- a/docs/source/examples/mitiq.py
+++ b/docs/source/examples/mitiq.py
@@ -1,0 +1,23 @@
+# This is a virtual mitiq package.
+# When a notebook is executed in this folder, the line "import mitiq"
+# can be executed without errors even if mitiq is not installed via pip.
+
+# See: https://mg.readthedocs.io/importing-local-python-modules-from-
+# jupyter-notebooks/sys-path-in-helper-module/path-helper.html
+
+import importlib
+import os
+import sys
+
+# Add mitiq folder to sys.path
+sys.path.insert(0, os.path.abspath("../../../"))
+
+# Temporarily hijack __file__ to avoid adding names at module scope;
+# __file__ will be overwritten again during the reload() call.
+__file__ = {'sys': sys, 'importlib': importlib}
+
+del importlib
+del os
+del sys
+
+__file__['importlib'].reload(__file__['sys'].modules[__name__])

--- a/docs/source/examples/simple_landscape.myst
+++ b/docs/source/examples/simple_landscape.myst
@@ -18,20 +18,12 @@ kernelspec:
 This tutorial shows an example in which the energy landscape for a two-qubit variational 
 circuit is explored with and without error mitigation.
 
-```{code-cell} ipython3
----
-tags: [hide-cell]
----
-# This cell allows to run the notebook from the mitiq git repository even if mitiq is not installed with pip.
-# If mitiq is installed, this cell can be removed.
-import sys, os
-sys.path.insert(0, os.path.abspath("../../../"))
-```
 
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
 import numpy as np
 from cirq import Circuit, H, rx, CNOT, DensityMatrixSimulator, LineQubit, depolarize
+import mitiq
 from mitiq.zne import mitigate_executor
 
 SIMULATOR = DensityMatrixSimulator()
@@ -39,7 +31,6 @@ SIMULATOR = DensityMatrixSimulator()
 
 ## Defining the ideal variational circuit
 We define a function which returns a two-qubit circuit at a specified variational angle $\gamma$.
-
 
 ```{code-cell} ipython3
 def variational_circuit(gamma: float) -> Circuit:

--- a/docs/source/examples/simple_landscape.myst
+++ b/docs/source/examples/simple_landscape.myst
@@ -19,6 +19,13 @@ This tutorial shows an example in which the energy landscape for a two-qubit var
 circuit is explored with and without error mitigation.
 
 ```{code-cell} ipython3
+# This cell allows to run the notebook from the mitiq git repository even if mitiq is not installed with pip.
+# If mitiq is installed, this cell can be removed.
+import sys, os
+sys.path.insert(0, os.path.abspath("../../../"))
+```
+
+```{code-cell} ipython3
 import matplotlib.pyplot as plt
 import numpy as np
 from cirq import Circuit, H, rx, CNOT, DensityMatrixSimulator, LineQubit, depolarize

--- a/docs/source/examples/simple_landscape.myst
+++ b/docs/source/examples/simple_landscape.myst
@@ -19,6 +19,9 @@ This tutorial shows an example in which the energy landscape for a two-qubit var
 circuit is explored with and without error mitigation.
 
 ```{code-cell} ipython3
+---
+tags: [hide-cell]
+---
 # This cell allows to run the notebook from the mitiq git repository even if mitiq is not installed with pip.
 # If mitiq is installed, this cell can be removed.
 import sys, os


### PR DESCRIPTION
This is a possible way to fix #573 . 

Description
-----------

The current problem is that when read the docs executes a notebook, mitiq is not installed and the the root folder of the mitiq repo  is not visible from the notebook. 

This PR adds a `mitiq.py ` file in `docs/source/examples` which is fake wrap of the true `mitiq` module. In this way,
the instruction `import mitiq` in each notebook works properly during the building of the docs.

This trick was suggested here: https://mg.readthedocs.io/importing-local-python-modules-from-jupyter-notebooks/sys-path-in-helper-module/path-helper.html

@crazy4pi314, I see only now that you self-assigned #576 .  What do you think?

For a preview of the result: https://mitiq.readthedocs.io/en/try-fixing-notebooks/examples/simple_landscape.html

Checklist
-----------
Please make sure you have finished the following tasks before requesting a review of the pull request (PR). For more information, please refer to the [Contributor's Guide](../blob/master/CONTRIBUTING.md):

- [ ] Contributions to mitiq should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/). You can enforce it easily with [`black`](https://black.readthedocs.io/en/stable/index.html) style and with [`flake8`](http://flake8.pycqa.org) conventions.
- [ ] Please add tests to cover your changes, if applicable, and make sure that all new and existing tests pass locally.
- [ ] If the behavior of the code has changed or new feature has been added, please also [update the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md).
- [ ] Functions and classes have useful [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings and [type hints](https://www.python.org/dev/peps/pep-0484/) in the signature of the objects.
- [x] (Bug fix) The associated issue is referenced above using [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords). If the PR fixes an issue, use the keyword fix/fixes/fixed followed by the issue id. For example, if the PR fixes issue 1184, type "Fixes #1184" (without quotes).
- [x] The [changelog](https://github.com/unitaryfund/mitiq/blob/master/CHANGELOG.md) is updated, including author and PR number (@username, gh-xxx).
