### PR TITLE
Remove factory equality and fix bug in PolyExpFactory.extrapolate

### DIFF
--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -36,7 +36,6 @@ from scipy.optimize import curve_fit, OptimizeWarning
 
 from mitiq import QPROGRAM
 from mitiq.collector import Collector
-from mitiq.utils import _are_close_dict
 
 
 class ExtrapolationError(Exception):

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -394,18 +394,6 @@ class Factory(ABC):
         self._already_reduced = False
         return self
 
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, Factory):
-            return False
-        if self._already_reduced != other._already_reduced:
-            return False
-        if len(self._instack) != len(other._instack):
-            return False
-        for dict_a, dict_b in zip(self._instack, other._instack):
-            if not _are_close_dict(dict_a, dict_b):
-                return False
-        return np.allclose(self._outstack, other._outstack)
-
 
 class BatchedFactory(Factory, ABC):
     """Abstract class of a non-adaptive Factory initialized with a
@@ -627,11 +615,6 @@ class BatchedFactory(Factory, ABC):
         # Repeat each keyword num_to_average times
         return [k for k in params for _ in range(num_to_average)]
 
-    def __eq__(self, other: Any) -> bool:
-        return Factory.__eq__(self, other) and np.allclose(
-            self._scale_factors, other._scale_factors
-        )
-
 
 class AdaptiveFactory(Factory, ABC):
     """Abstract class designed to adaptively produce a new noise scaling
@@ -844,12 +827,6 @@ class PolyFactory(BatchedFactory):
             return np.polyval(opt_params, scale_factor)
 
         return zne_limit, zne_error, opt_params, params_cov, zne_curve
-
-    def __eq__(self, other: Any) -> bool:
-        return (
-            BatchedFactory.__eq__(self, other)
-            and self._options["order"] == other._options["order"]
-        )
 
 
 class RichardsonFactory(BatchedFactory):
@@ -1226,32 +1203,6 @@ class ExpFactory(BatchedFactory):
             full_output=full_output,
         )
 
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, ExpFactory):
-            return False
-        if (
-            self._options["asymptote"]
-            and other._options["asymptote"] is None
-            or self._options["asymptote"] is None
-            and other._options["asymptote"]
-        ):
-            return False
-        if (
-            self._options["asymptote"] is None
-            and other._options["asymptote"] is None
-        ):
-            return (
-                BatchedFactory.__eq__(self, other)
-                and self._options["avoid_log"] == other._options["avoid_log"]
-            )
-        return (
-            BatchedFactory.__eq__(self, other)
-            and np.isclose(
-                self._options["asymptote"], other._options["asymptote"],
-            )
-            and self._options["avoid_log"] == other._options["avoid_log"]
-        )
-
 
 class PolyExpFactory(BatchedFactory):
     """
@@ -1522,17 +1473,6 @@ class PolyExpFactory(BatchedFactory):
             return zero_limit, zne_error, opt_params, params_cov, _zne_curve
         return zne_limit
 
-    def __eq__(self, other: Any) -> bool:
-        return (
-            BatchedFactory.__eq__(self, other)
-            and isinstance(other, PolyExpFactory)
-            and np.isclose(
-                self._options["asymptote"], other._options["asymptote"],
-            )
-            and self._options["avoid_log"] == other._options["avoid_log"]
-            and self._options["order"] == other._options["order"]
-        )
-
 
 # Keep a log of the optimization process storing:
 # noise value(s), expectation value(s), parameters, and zero limit
@@ -1749,14 +1689,3 @@ class AdaExpFactory(AdaptiveFactory):
         )
         self._already_reduced = True
         return self._zne_limit
-
-    def __eq__(self, other: Any) -> bool:
-        return (
-            Factory.__eq__(self, other)
-            and isinstance(other, AdaExpFactory)
-            and self._steps == other._steps
-            and self._scale_factor == other._scale_factor
-            and np.isclose(self.asymptote, other.asymptote)
-            and self.avoid_log == other.avoid_log
-            and np.allclose(self.history, other.history)
-        )

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -1452,7 +1452,7 @@ class PolyExpFactory(BatchedFactory):
             weights=np.sqrt(np.abs(shifted_y)),
         )
         # The zero noise limit is ansatz(0)
-        zero_limit = asymptote + sign * np.exp(z_coefficients[-1])
+        zne_limit = asymptote + sign * np.exp(z_coefficients[-1])
 
         def _zne_curve(scale_factor: float) -> float:
             return asymptote + sign * np.exp(
@@ -1470,7 +1470,7 @@ class PolyExpFactory(BatchedFactory):
         opt_params = [asymptote] + list(z_coefficients[::-1])
 
         if full_output:
-            return zero_limit, zne_error, opt_params, params_cov, _zne_curve
+            return zne_limit, zne_error, opt_params, params_cov, _zne_curve
         return zne_limit
 
 

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -16,7 +16,6 @@
 """Tests for zero-noise inference and extrapolation methods (factories) with
 classically generated data.
 """
-from copy import copy, deepcopy
 from typing import Callable, List
 from pytest import mark, raises, warns
 

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -478,10 +478,19 @@ def test_poly_exp_factory_with_asympt(
     fac = PolyExpFactory(X_VALS, order=2, asymptote=A, avoid_log=avoid_log)
     fac.run_classical(seeded_f)
     assert not fac._opt_params
-    assert np.isclose(fac.reduce(), seeded_f(0, err=0), atol=POLYEXP_TOL)
+
+    zne_value = fac.reduce()
+    assert np.isclose(zne_value, seeded_f(0, err=0), atol=POLYEXP_TOL)
 
     # There are four parameters to fit for the PolyExpFactory of order 1
     assert len(fac._opt_params) == 4
+
+    exp_values = [test_f(x) for x in X_VALS]
+    assert np.isclose(
+        PolyExpFactory.extrapolate(
+            X_VALS, exp_values, order=2, asymptote=A, avoid_log=avoid_log
+        ), zne_value, atol=POLYEXP_TOL
+    )
 
 
 @mark.parametrize("test_f", [f_poly_exp_down, f_poly_exp_up])

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -660,52 +660,6 @@ def test_adaptive_factory_max_iteration_warnings():
         fac.run_classical(lambda scale_factor: 1.0, max_iterations=3)
 
 
-@mark.parametrize("factory", [LinearFactory, ExpFactory])
-def test_equal_simple(factory):
-    fac = factory(scale_factors=[1, 2, 3])
-    assert fac != 1
-
-    copied_fac = copy(fac)
-    assert copied_fac == fac
-    copied_fac._already_reduced = True
-    assert copied_fac != fac
-
-    fac._instack = [{"scale_factor": 1, "shots": 100}]
-    copied_fac = deepcopy(fac)
-    assert copied_fac == fac
-    copied_fac._instack[0].update({"shots": 101})
-    assert copied_fac != fac
-
-
-@mark.parametrize(
-    "factory",
-    (LinearFactory, RichardsonFactory, FakeNodesFactory, PolyFactory),
-)
-def test_equal(factory):
-    for run_classical in (True, False):
-        if factory is PolyFactory:
-            fac = factory(
-                scale_factors=[1, 2, 3], order=2, shot_list=[1, 2, 3]
-            )
-        else:
-            fac = factory(scale_factors=[1, 2, 3], shot_list=[1, 2, 3])
-        if run_classical:
-            fac.run_classical(
-                scale_factor_to_expectation_value=lambda x, shots: np.exp(x)
-                + 0.5
-            )
-
-        copied_factory = copy(fac)
-        assert copied_factory == fac
-        assert copied_factory is not fac
-
-        if run_classical:
-            fac.reduce()
-            copied_factory = copy(fac)
-            assert copied_factory == fac
-            assert copied_factory is not fac
-
-
 @mark.parametrize("fac_class", [LinearFactory, RichardsonFactory])
 def test_iterate_with_shot_list(fac_class):
     """Tests factories with (and without) the "shot_list" argument."""


### PR DESCRIPTION
Closes #490. 

PolyExpFactory.extrapolate returned an undefined variable with some combination of input args. Fixed this and added a check. Do we not test extrapolate methods anywhere? I don't know how this wasn't caught.