### PR TITLE
Supresses Test PyPI nightly upload on forks

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -10,6 +10,7 @@ jobs:
   #generate_artifacts:
   # TODO: make docs pdf and tarball
   create_release:
+    if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
     if: github.repository_owner == 'unitaryfund'
     steps:

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -12,7 +12,6 @@ jobs:
   create_release:
     if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'unitaryfund'
     steps:
       - name: Check out Mitiq
         uses: actions/checkout@v2

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches: # specify branch to Mitiq master not forks
-      - master
+      - release
     # Sequence of patterns matched against refs/tags
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches: # specify branch to Mitiq master not forks
+      - master
     # Sequence of patterns matched against refs/tags
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: # specify branch to Mitiq master not forks
+    branches: # specify branch to Mitiq release, not running from forks
       - release
     # Sequence of patterns matched against refs/tags
     tags:

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -11,6 +11,7 @@ jobs:
   # TODO: make docs pdf and tarball
   create_release:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'unitaryfund'
     steps:
       - name: Check out Mitiq
         uses: actions/checkout@v2

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-if: github.repository_owner == 'unitaryfund'
+    if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
     steps:
     - name: Check out mitiq

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
     - name: Check out mitiq
       uses: actions/checkout@v2
-      with:
-        ref: 'release'
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,7 +1,7 @@
 # This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
-name: Upload Python Package to Test PyPI
+name: Upload Release Package to PyPI
 
 on:
   release:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,7 +11,8 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'unitaryfund'
+    # if: github.repository_owner == 'unitaryfund'
+    # above condition is made a comment until needed to specify main repo even when master has been specified for release branch. 
     steps:
     - name: Check out mitiq
       uses: actions/checkout@v2

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - name: Check out mitiq
       uses: actions/checkout@v2
+      with:
+        ref: 'release'
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-
+if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
     steps:
     - name: Check out mitiq

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-
+    if: github.repository_owner == 'unitaryfund'
     steps:
     - name: Check out mitiq
       uses: actions/checkout@v2

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,8 +11,6 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-    # if: github.repository_owner == 'unitaryfund'
-    # above condition is made a comment until needed to specify main repo even when master has been specified for release branch. 
     steps:
     - name: Check out mitiq
       uses: actions/checkout@v2

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-    # if: github.repository_owner == 'unitaryfund'
+    if: github.repository_owner == 'unitaryfund'
     steps:
     - name: Check out mitiq
       uses: actions/checkout@v2

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -12,13 +12,10 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-    # if: github.repository_owner == 'unitaryfund'
-    # above condition is made a comment until needed to specify main repo even when master has been specified for release branch. 
+    if: github.repository_owner == 'unitaryfund'
     steps:
     - name: Check out mitiq
       uses: actions/checkout@v2
-      with:
-        ref: 'release'
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -12,12 +12,13 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'unitaryfund'
+    # if: github.repository_owner == 'unitaryfund'
+    # above condition is made a comment until needed to specify main repo even when master has been specified for release branch. 
     steps:
     - name: Check out mitiq
       uses: actions/checkout@v2
-      # with:
-           # repository: unitaryfund/mitiq
+      with:
+        ref: 'release'
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -12,7 +12,6 @@ jobs:
   deploy:
 if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'unitaryfund'
     steps:
     - name: Check out mitiq
       uses: actions/checkout@v2

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-  if: github.repository_owner == 'unitaryfund'
+    if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
     steps:
     - name: Check out mitiq

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-if: github.repository_owner == 'unitaryfund'
+  if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
     steps:
     - name: Check out mitiq

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -6,12 +6,13 @@ name: Nightly Upload to Test PyPI
 on:
   schedule:
     - cron: '0 0 * * *'
+    
 
 jobs:
   deploy:
 
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'unitaryfund'
+    # if: github.repository_owner == 'unitaryfund'
     steps:
     - name: Check out mitiq
       uses: actions/checkout@v2

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-
+    if: github.repository_owner == 'unitaryfund'
     steps:
     - name: Check out mitiq
       uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         twine upload --repository testpypi dist/*
-  
+
   # TODO: Need a way to get the version number from previous step
   # download-test:
     # runs-on: ubuntu-latest

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-
+if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
     if: github.repository_owner == 'unitaryfund'
     steps:

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -6,7 +6,6 @@ name: Nightly Upload to Test PyPI
 on:
   schedule:
     - cron: '0 0 * * *'
-    
 
 jobs:
   deploy:

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Check out mitiq
       uses: actions/checkout@v2
+      # with:
+           # repository: unitaryfund/mitiq
     - name: Set up Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
Description
-----------
Fixes #581

When actions are enabled on a fork, Test PyPI tries to deploy from this fork instead of just the master. I have added a conditional statement for `deploy` to run in `publish-pypi.yml` and `publish-testpypi.yml` only when current branch is `master`. This is based on discussion at [this link](https://docs.github.com/en/actions/reference/environment-variables#determining-when-to-use-default-environment-variables-or-contexts). 

I am unsure if this worked or not because running the `deploy` workflow in a fork with the added condition still leads to same errors as before. This seems to be a WIP for the main repo [here](https://github.com/unitaryfund/mitiq/pull/579). So far, disabling the workflow in a fork seems to have solved issue #581. 

Feel free to close this PR if this ought to be worked on after the new PyPI workflow is released.  