### PR TITLE
Fix typo in ZNE documentation. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add qiskit executor example for exact density matrix simulation with depolarizing noise (@aaron-robertson gh-269)
 - Add qiskit and cirq executor examples gifs to readme (@nathanshammah, gh-587)
 - Fix mitiq.about() qiskit version (@aaron-robertson, gh-595)
+- Fix typo in ZNE documentation (@purva-thakre, gh-602)
 
 ## Version 0.6.0 (March 1st, 2021)
 

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -1206,7 +1206,8 @@ class ExpFactory(BatchedFactory):
 class PolyExpFactory(BatchedFactory):
     """
     Factory object implementing a zero-noise extrapolation algorithm assuming
-    an (almost) exponential ansatz with a non linear exponent, i.e. y(x) = a + sign * exp(z(x)), where z(x) is a polynomial of a given order.
+    an (almost) exponential ansatz with a non linear exponent
+    y(x) = a + sign * exp(z(x)), where z(x) is a polynomial of a given order.
 
     The parameter "sign" is a sign variable which can be either 1 or -1,
     corresponding to decreasing and increasing exponentials, respectively.

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -1206,9 +1206,7 @@ class ExpFactory(BatchedFactory):
 class PolyExpFactory(BatchedFactory):
     """
     Factory object implementing a zero-noise extrapolation algorithm assuming
-    an (almost) exponential ansatz with a non linear exponent, i.e.:
-
-    y(x) = a + sign * exp(z(x)), where z(x) is a polynomial of a given order.
+    an (almost) exponential ansatz with a non linear exponent, i.e. y(x) = a + sign * exp(z(x)), where z(x) is a polynomial of a given order.
 
     The parameter "sign" is a sign variable which can be either 1 or -1,
     corresponding to decreasing and increasing exponentials, respectively.


### PR DESCRIPTION
Description
-----------
In the table of [Factory Objects](https://mitiq.readthedocs.io/en/stable/guide/guide-zne.html#classical-fitting-and-extrapolation-factory-objects), a typo of `:` leads to no equation for `mitiq.zne.inference.PolyExpFactory`. This fixes the typo by removing both `i.e.` and `:` because I think `autosummary` thinks the period in `i.e.` ends the sentence. 