### PR TITLE
Clarify and improve PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,11 @@
 Description
 -----------
-Describe your pull request (PR) here. Thank you for contributing to Mitiq! 🙂
 
+Describe your pull request (PR) here. Thank you for contributing to Mitiq! 🙂
 
 Checklist
 -----------
+
 Check off the following once complete (or if not applicable). The PR will be reviewed once this
 checklist is complete and all tests are passing.
 
@@ -12,12 +13,16 @@ checklist is complete and all tests are passing.
 - [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
 - [ ] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
 - [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
+- [ ] I updated the [changelog](https://github.com/unitaryfund/mitiq/blob/master/CHANGELOG.md) including author and PR number (@username, gh-xxx)
 
 If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
 
 Tips
 ----
 
-- If the validation check fails, run `make style` then `make format` 
-  (from the root directory of the repository) to format your code.
+- If the validation check fails:
+  1. Run `make check-style` (from the root directory
+  of the repository) and fix any [flake8](http://flake8.pycqa.org) errors.
+  2. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html)
+  autoformatter.
 - Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,23 @@
 Description
 -----------
-Describe here the proposed change. Thank you for contributing to mitiq! 🙂
+Describe your pull request (PR) here. Thank you for contributing to Mitiq! 🙂
 
-
-If you have not finished all tasks in the checklist, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work and keep this checklist in the PR description.
 
 Checklist
 -----------
-Please make sure you have finished the following tasks before requesting a review of the pull request (PR). For more information, please refer to the [Contributor's Guide](../blob/master/CONTRIBUTING.md):
+Check off the following once complete (or if not applicable). The PR will be reviewed once this
+checklist is complete and all tests are passing.
 
-- [ ] Contributions to mitiq should follow the [pep8 style](https://www.python.org/dev/peps/pep-0008/). You can enforce it easily with [`black`](https://black.readthedocs.io/en/stable/index.html) style and with [`flake8`](http://flake8.pycqa.org) conventions.
-- [ ] Please add tests to cover your changes, if applicable, and make sure that all new and existing tests pass locally.
-- [ ] If the behavior of the code has changed or new feature has been added, please also [update the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md).
-- [ ] Functions and classes have useful [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings and [type hints](https://www.python.org/dev/peps/pep-0484/) in the signature of the objects.
-- [ ] (Bug fix) The associated issue is referenced above using [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords). If the PR fixes an issue, use the keyword fix/fixes/fixed followed by the issue id. For example, if the PR fixes issue 1184, type "Fixes #1184" (without quotes).
-- [ ] The [changelog](https://github.com/unitaryfund/mitiq/blob/master/CHANGELOG.md) is updated, including author and PR number (@username, gh-xxx).
+- [ ] I added unit tests for new code.
+- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
+- [ ] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
+- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
+
+If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
+
+Tips
+----
+
+- If the validation check fails, run `make style` then `make format` 
+  (from the root directory of the repository) to format your code.
+- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.


### PR DESCRIPTION
Biggest motivation: It wasn't clear to a contributor how to fix style issues

> The style changes I can fix, sorry i didnt realise they were so simple

This should be clear from the PR template.

Secondary motivation: The current template has a lot of text and is cumbersome. Some points were really tips or FYI's but they were in the checklist, others were essentially extraneous information.

Tertiary motivation: I want to try and get rid of the changelog and see if no one notices. 