### PR TITLE
Adds local identity insertion scaling

### DIFF
--- a/docs/source/guide/guide-zne.rst
+++ b/docs/source/guide/guide-zne.rst
@@ -284,10 +284,26 @@ Noise scaling by identity scaling
     This module is currently a WIP. To be added soon are examples for additional
     methods - Scaling gates by fidelity, Global scaling, Custom scaling methods.
 
+Similar to unitary folding, identity insertion scaling is a method applied to
+quantum circuits at the gate level to amplify noise. The depth of the circuit is
+increased by inserting multiple identity gates as described by the scale factor
+
+.. math::
+  G \mapsto G I .
+
 ---------------------
 Local scaling methods
 ---------------------
-Scaling from left, right and at random.
+For local identity insertion scaling, there is a degree of freedom for which gates to fold first.
+The order in which gates are folded can have an important effect on how the noise is scaled.
+As such, Mitiq defines several local folding methods.
+
+    1. :func:`mitiq.zne.scaling.identity_insertion.scale_gates_from_left`
+    2. :func:`mitiq.zne.scaling.identity_insertion.scale_gates_from_right`
+    3. :func:`mitiq.zne.scaling.identity_insertion.scale_gates_at_random`
+
+The function ``fold_gates_from_left`` will fold gates from the left (or start) of the circuit
+until the desired scale factor is reached.
 
 
 

--- a/docs/source/guide/guide-zne.rst
+++ b/docs/source/guide/guide-zne.rst
@@ -344,7 +344,7 @@ In the following code, we use the ``scale_gates_from_right`` function on the sam
 
     # Scale the circuit
     >>> scale = scale_gates_from_right(circ, scale_factor=2.)
-    >>> print("Folded circuit:", scaled, sep="\n")
+    >>> print("Scaled circuit:", scaled, sep="\n")
     Scaled circuit:
     0: ───H───I───I───@───I───I───
                       │   │   │

--- a/docs/source/guide/guide-zne.rst
+++ b/docs/source/guide/guide-zne.rst
@@ -350,7 +350,8 @@ In the following code, we use the ``scale_gates_from_right`` function on the sam
                       │   │   │
     1: ───────────────X───I───I───
 
-We see the original circuit is scaled
+We see the original circuit is scaled by inserting two identity gates after
+each gate in the original circuit. This helps achieve desired scale factor. 
 
 Finally, we mention ``scale_gates_at_random`` which scales gates according to the following rules.
 

--- a/docs/source/guide/guide-zne.rst
+++ b/docs/source/guide/guide-zne.rst
@@ -302,10 +302,63 @@ As such, Mitiq defines several local folding methods.
     2. :func:`mitiq.zne.scaling.identity_insertion.scale_gates_from_right`
     3. :func:`mitiq.zne.scaling.identity_insertion.scale_gates_at_random`
 
+We use the same example circuits as unitary folding.
 The function ``scale_gates_from_left`` will fold gates from the left (or start) of the circuit
 until the desired scale factor is reached.
 
+.. doctest:: python
 
+    >>> import cirq
+    >>> from mitiq.zne.scaling.identity_insertion import scale_gates_from_left
+
+    # Get a circuit to fold
+    >>> qreg = cirq.LineQubit.range(2)
+    >>> circ = cirq.Circuit(cirq.ops.H.on(qreg[0]), cirq.ops.CNOT.on(qreg[0], qreg[1]))
+    >>> print("Original circuit:", circ, sep="\n")
+    Original circuit:
+    0: ───H───@───
+              │
+    1: ───────X───
+
+    # Scale the circuit
+    >>> scaled = scale_gates_from_left(circ, scale_factor=2.)
+    >>> print("Scaled circuit:", scaled, sep="\n")
+    Scaled circuit:
+    0: ───H───I───I───@───I───I───
+                      │   │   │
+    1: ───────────────X───I───I───
+
+In this example, we see that the scaled circuit has 2 identity gates inserted
+after both gates in the circuit to reach the desired scale factor.
+
+
+.. note::
+    Mitiq scaling functions do not modify the input circuit.
+
+Because input circuits are not modified, we can reuse this circuit for the next example.
+In the following code, we use the ``scale_gates_from_right`` function on the same input circuit.
+
+.. doctest:: python
+
+    >>> from mitiq.zne.scaling.identity_insertion import scale_gates_from_right
+
+    # Scale the circuit
+    >>> scale = scale_gates_from_right(circ, scale_factor=2.)
+    >>> print("Folded circuit:", scaled, sep="\n")
+    Scaled circuit:
+    0: ───H───I───I───@───I───I───
+                      │   │   │
+    1: ───────────────X───I───I───
+
+We see the original circuit is scaled
+
+Finally, we mention ``scale_gates_at_random`` which scales gates according to the following rules.
+
+    1. Gates are selected at random and scaled by inserting identity gates until the input scale factor is reached.
+    2. No gate is scaled more than once for any ``scale_factor <= 2``.
+    3. "Virtual gates" (i.e., identity gates appearing from scaling) are never scaled.
+
+All of these local scaling methods can be called with any ``scale_factor >= 1``.
 
 .. _guide_zne_factory:
 

--- a/docs/source/guide/guide-zne.rst
+++ b/docs/source/guide/guide-zne.rst
@@ -302,7 +302,7 @@ As such, Mitiq defines several local folding methods.
     2. :func:`mitiq.zne.scaling.identity_insertion.scale_gates_from_right`
     3. :func:`mitiq.zne.scaling.identity_insertion.scale_gates_at_random`
 
-The function ``fold_gates_from_left`` will fold gates from the left (or start) of the circuit
+The function ``scale_gates_from_left`` will fold gates from the left (or start) of the circuit
 until the desired scale factor is reached.
 
 

--- a/docs/source/guide/guide-zne.rst
+++ b/docs/source/guide/guide-zne.rst
@@ -274,6 +274,33 @@ This function can then be used with ``mitiq.zne.execute_with_zne`` as an option 
     # Variables circ and scale are a circuit to fold and a scale factor, respectively
     zne = mitiq.execute_with_zne(circuit, executor, scale_noise=my_custom_folding_function)
 
+.. _guide_zne_scaling:
+
+=================================
+Noise scaling by identity scaling
+=================================
+
+Note : This module is under construction
+
+---------------------
+Local scaling methods
+---------------------
+Scaling from left, right and at random.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Scaling gates by fidelity
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Note : This module is under construction
+--------------
+Global scaling
+--------------
+Note : This module is under construction
+----------------------
+Custom scaling methods
+----------------------
+Note : This module is under construction
+
 
 .. _guide_zne_factory:
 

--- a/docs/source/guide/guide-zne.rst
+++ b/docs/source/guide/guide-zne.rst
@@ -280,26 +280,15 @@ This function can then be used with ``mitiq.zne.execute_with_zne`` as an option 
 Noise scaling by identity scaling
 =================================
 
-Note : This module is under construction
+.. note::
+    This module is currently a WIP. To be added soon are examples for additional
+    methods - Scaling gates by fidelity, Global scaling, Custom scaling methods.
 
 ---------------------
 Local scaling methods
 ---------------------
 Scaling from left, right and at random.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Scaling gates by fidelity
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Note : This module is under construction
---------------
-Global scaling
---------------
-Note : This module is under construction
-----------------------
-Custom scaling methods
-----------------------
-Note : This module is under construction
 
 
 .. _guide_zne_factory:
@@ -722,7 +711,7 @@ and clips the result if it falls outside its physical domain.
          # Return the clipped zero-noise extrapolation.
          if not full_output:
             return np.clip(result, min_expval, max_expval)
-         
+
          if full_output:
             # In this case "result" is a tuple of extrapolation data
             zne_limit = np.clip(result[0], min_expval, max_expval)

--- a/mitiq/zne/scaling/identity_insertion.py
+++ b/mitiq/zne/scaling/identity_insertion.py
@@ -101,14 +101,14 @@ def _create_scale_mask(
         [2, 2, 1, 0]
     """
 
-    if not 0.0 <= scale_factor:
+    if not 1.0 <= scale_factor:
         raise ValueError(
-            f"Requires scale_factor >= 0.0 but scale_factor = {scale_factor}."
+            f"Requires scale_factor >= 1.0 but scale_factor = {scale_factor}."
         )
 
     # Find the maximum odd integer smaller or equal to scale_factor
     num_uniform_folds = int(scale_factor - 1.0)
-    odd_integer_scale_factor = num_uniform_folds - 1.0
+    odd_integer_scale_factor = np.abs(num_uniform_folds - 1)
 
     # Uniformly scaling all gates to reach odd_integer_scale_factor
     num_inserts_mask = []
@@ -119,7 +119,7 @@ def _create_scale_mask(
             num_inserts_mask.append(num_uniform_folds)
 
     # If the scale_factor is an odd integer, we are done.
-    if np.isclose(odd_integer_scale_factor, scale_factor):
+    if np.isclose(odd_integer_scale_factor, scale_factor, atol=0.01):
         return num_inserts_mask
 
     # Express scaling order through a list of indices

--- a/mitiq/zne/scaling/identity_insertion.py
+++ b/mitiq/zne/scaling/identity_insertion.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Functions for identity scaling on supported circuits."""

--- a/mitiq/zne/scaling/identity_insertion.py
+++ b/mitiq/zne/scaling/identity_insertion.py
@@ -106,20 +106,20 @@ def _create_scale_mask(
             f"Requires scale_factor >= 1.0 but scale_factor = {scale_factor}."
         )
 
-    # Find the maximum odd integer smaller or equal to scale_factor
-    num_uniform_folds = int(scale_factor - 1.0)
-    odd_integer_scale_factor = np.abs(num_uniform_folds - 1)
+    # Find the maximum integer smaller or equal to scale_factor
+    num_uniform_inserts = int(scale_factor - 1.0)
+    integer_scale_factor = num_uniform_inserts + 1
 
-    # Uniformly scaling all gates to reach odd_integer_scale_factor
+    # Uniformly scaling all gates to reach integer_scale_factor
     num_inserts_mask = []
     for w in weight_mask:
         if np.isclose(w, 0.0):
             num_inserts_mask.append(0)
         else:
-            num_inserts_mask.append(num_uniform_folds)
+            num_inserts_mask.append(num_uniform_inserts)
 
-    # If the scale_factor is an odd integer, we are done.
-    if np.isclose(odd_integer_scale_factor, scale_factor, atol=0.01):
+    # If the scale_factor is an integer, we are done.
+    if np.isclose(integer_scale_factor, scale_factor, atol=0.01):
         return num_inserts_mask
 
     # Express scaling order through a list of indices

--- a/mitiq/zne/scaling/identity_insertion.py
+++ b/mitiq/zne/scaling/identity_insertion.py
@@ -139,7 +139,7 @@ def _create_scale_mask(
 
     # Fold gates until the input scale_factor is better approximated
     input_circuit_weight = sum(weight_mask)
-    output_circuit_weight = odd_integer_scale_factor * input_circuit_weight
+    output_circuit_weight = integer_scale_factor * input_circuit_weight
     approx_error = np.abs(
         output_circuit_weight - scale_factor * input_circuit_weight
     )

--- a/mitiq/zne/scaling/identity_insertion.py
+++ b/mitiq/zne/scaling/identity_insertion.py
@@ -15,32 +15,30 @@
 
 """Functions for identity scaling on supported circuits."""
 from copy import deepcopy
-from typing import (
-    Any,
-    Dict,
-    FrozenSet,
-    List,
-    Optional,
-    Tuple,
-)
+from typing import Any, List, Optional
 
 import numpy as np
-from cirq import Circuit, InsertStrategy, inverse, ops, has_unitary
+from cirq import GateOperation, Circuit, has_unitary
+from cirq.ops import IdentityGate
 
 from mitiq._typing import QPROGRAM
 from mitiq.conversions import noise_scaling_converter
+from mitiq.zne.scaling.folding import (
+    _pop_measurements,
+    _append_measurements,
+    _create_weight_mask,
+)
 
-from mitiq.zne.scaling.folding import ( _string_keys_to_cirq_gates,
-_cirq_gates_to_string_keys, _is_measurement, _pop_measurements, _append_measurements,
-_squash_moments)
 
 class UnscalableCircuitError(Exception):
     pass
 
+
 def _check_scalable(circuit: Circuit) -> None:
-    """Raises an error if the input circuit cannot be scaled.
+    """Raises an error if the input circuit cannot be scaled by inserting
+       identities.
     Args:
-        circuit: Checks whether this circuit is able to be scaled.
+        circuit: Checks whether this circuit is able to be identity scaled.
     Raises:
         UnfoldableCircuitError:
             * If the circuit has intermediate measurements.
@@ -49,11 +47,379 @@ def _check_scalable(circuit: Circuit) -> None:
     """
     if not circuit.are_all_measurements_terminal():
         raise UnscalableCircuitError(
-            "Circuit contains intermediate measurements and cannot be scaled."
+            "Circuit contains intermediate measurements and cannot be scaled"
+            " by inserting identities."
         )
 
     if not has_unitary(circuit):
         raise UnscalableCircuitError(
             "Circuit contains non-unitary channels which are not terminal "
-            "measurements and cannot be scaled."
+            "measurements and cannot be scaled by inserting identities."
         )
+
+
+def _create_scale_mask(
+    weight_mask: List[float],
+    scale_factor: float,
+    scaling_method: str,
+    seed: Optional[int] = None,
+) -> List[float]:
+    r"""Returns a list of integers determining how many times an identity gate
+    must be inserted to realize the desired input scale_factor.
+    More precicely, the j_th element of the returned list is associated
+    to the j_th gate G_j of a circuit that we want to scale and determines
+    how many times I should be applied after G_j.
+    The gate ordering is equal to the one used in the `all_operations()`
+    method of the :class:`cirq.Circuit` class: gates from earlier moments
+    come first and gates within the same moment follow the order in which
+    they were given to the moment's constructor.
+    The returned list is built such that the total weight of the
+    folded circuit is approximately equal to scale_factor times the
+    total weight of the input circuit.
+    For equal weights, this function reproduces identity scaled version of
+    the local unitary folding method defined in equation (5) of
+    :cite:`Giurgica_Tiron_2020_arXiv`.
+    Args:
+        weight_mask: The weights of all the gates of the circuit to fold.
+            Highly noisy gates should have a corresponding high weight.
+            Gates with zero weight are assumed to be ideal and are not folded.
+        scale_factor: The effective noise scale factor.
+        scaling_method: A string equal to "at_random", or "from_left", or
+            "from_right". Determines the partial folding method described in
+            :cite:`Giurgica_Tiron_2020_arXiv`. If scale_factor is an odd
+            integer, all methods are equivalent and this option is irrelevant.
+        seed: A seed for the random number generator. This is used only when
+            scaling_method is "at_random".
+    Returns: The list of integers determining to how many times one should
+            insert I in the circuit to be scaled.
+    Example:
+        >>>_create_scale_mask(
+            weight_mask=[1.0, 0.5, 2.0, 0.0],
+            scale_factor=4,
+            scaling_method="from_left",
+        )
+        [2, 2, 1, 0]
+    """
+
+    if not 0.0 <= scale_factor:
+        raise ValueError(
+            f"Requires scale_factor >= 0.0 but scale_factor = {scale_factor}."
+        )
+
+    # Find the maximum odd integer smaller or equal to scale_factor
+    num_uniform_folds = int(scale_factor - 1.0)
+    odd_integer_scale_factor = num_uniform_folds - 1.0
+
+    # Uniformly scaling all gates to reach odd_integer_scale_factor
+    num_inserts_mask = []
+    for w in weight_mask:
+        if np.isclose(w, 0.0):
+            num_inserts_mask.append(0)
+        else:
+            num_inserts_mask.append(num_uniform_folds)
+
+    # If the scale_factor is an odd integer, we are done.
+    if np.isclose(odd_integer_scale_factor, scale_factor):
+        return num_inserts_mask
+
+    # Express scaling order through a list of indices
+    scaling_order = list(range(len(weight_mask)))
+    if scaling_method == "from_left":
+        pass
+    elif scaling_method == "from_right":
+        scaling_order.reverse()
+    elif scaling_method == "at_random":
+        rnd_state = np.random.RandomState(seed)
+        rnd_state.shuffle(scaling_order)
+    else:
+        raise ValueError(
+            "The option 'scaling_method' is not valid."
+            "It must be 'at_random', or 'from_left', or 'from_right'."
+        )
+
+    # Fold gates until the input scale_factor is better approximated
+    input_circuit_weight = sum(weight_mask)
+    output_circuit_weight = odd_integer_scale_factor * input_circuit_weight
+    approx_error = np.abs(
+        output_circuit_weight - scale_factor * input_circuit_weight
+    )
+    for j in scaling_order:
+        # Skip gates with 0 weight
+        if np.isclose(weight_mask[j], 0.0):
+            continue
+        # Compute the approx error if a new fold would be applied
+        new_output_circuit_weight = output_circuit_weight + weight_mask[j]
+        new_approx_error = np.abs(
+            new_output_circuit_weight - scale_factor * input_circuit_weight
+        )
+        # Fold the candidate gate only if it helps improving the approximation
+        if new_approx_error >= approx_error:
+            break
+        approx_error = new_approx_error
+        output_circuit_weight = new_output_circuit_weight
+        num_inserts_mask[j] += 1
+
+    return num_inserts_mask
+
+
+def _apply_scale_mask(
+    circuit: Circuit,
+    num_inserts_mask: List[int],
+    squash_moments: Optional[bool] = True,
+) -> Circuit:
+    r"""Applies local identity scaling to the gates of the input circuit
+    according to the input num_folds_mask.
+    More precicely, I is applied after the j_th gate G_j of
+    the input circuit an integer number of times given by num_folds_mask[j].
+    The gate ordering is equal to the one used in the `all_operations()`
+    method of the :class:`cirq.Circuit` class: gates from earlier moments
+    come first and gates within the same moment follow the order in which
+    they were given to the moment's constructor.
+    Args:
+        circuit: The quantum circuit to scale.
+        num_inserts_mask: The list of integers indicating how many times
+            the corresponding gates of 'circuit' should be folded.
+        squash_moments: If True or None, all gates (including inserted gates)
+            are placed as early as possible in the circuit. If False, new
+            moments are created for inserted gates. This option only applies to
+            QPROGRAM types which have a "moment" or "time" structure. Default
+            is True.
+    Returns: The scaled quantum circuit.
+    """
+    _check_scalable(circuit)
+    circ_copy = deepcopy(circuit)
+    measurements = _pop_measurements(circ_copy)
+
+    num_gates = len(list(circ_copy.all_operations()))
+    if num_gates != len(num_inserts_mask):
+        raise ValueError(
+            "The circuit and the scaling mask have incompatible sizes."
+            f" The number of gates is {num_gates}"
+            f" but len(num_folds_mask) is {len(num_inserts_mask)}."
+        )
+
+    scaled_circuit = circ_copy[:0]
+    if squash_moments:
+        for op, num_inserts in zip(
+            circ_copy.all_operations(), num_inserts_mask
+        ):
+            scaled_circuit.append(
+                [op]
+                + num_inserts
+                * [GateOperation(IdentityGate(len(op.qubits)), op.qubits)]
+            )
+    else:
+        mask_index = 0
+        for moment in circ_copy:
+            scaled_moment = Circuit(moment)
+            for op in moment:
+                num_inserts = num_inserts_mask[mask_index]
+                scaled_moment.append(
+                    num_inserts
+                    * [GateOperation(IdentityGate(len(op.qubits)), op.qubits)]
+                )
+                mask_index += 1
+            # New scaled gates are only squashed with respect to scaled_moment
+            # while scaled_circuit is not squashed.
+            scaled_circuit.append(scaled_moment)
+
+    _append_measurements(scaled_circuit, measurements)
+    return scaled_circuit
+
+
+@noise_scaling_converter
+def scale_gates_from_left(
+    circuit: QPROGRAM, scale_factor: float, **kwargs: Any
+) -> QPROGRAM:
+    """Returns a new scaled circuit by applying the map G -> G I to a
+    subset of gates of the input circuit, starting with gates at the
+    left (beginning) of the circuit.
+    The scaled circuit has a number of gates approximately equal to
+    scale_factor * n where n is the number of gates in the input circuit.
+    For equal gate fidelities, this function reproduces the identoty scaled
+    version of local unitary folding method defined in equation (5) of
+    :cite:`Giurgica_Tiron_2020_arXiv`.
+    Args:
+        circuit: Circuit to scale.
+        scale_factor: Factor to scale the circuit by. Any real number >= 1.
+    Keyword Args:
+        fidelities (Dict[str, float]): Dictionary of gate fidelities. Each key
+            is a string which specifies the gate and each value is the
+            fidelity of that gate. When this argument is provided, scaled
+            gates contribute an amount proportional to their infidelity
+            (1 - fidelity) to the total noise scaling. Fidelity values must be
+            in the interval (0, 1]. Gates not specified have a default
+            fidelity of 0.99**n where n is the number of qubits the gates act
+            on.
+            Supported gate keys are listed in the following table.::
+                Gate key    | Gate
+                -------------------------
+                "H"         | Hadamard
+                "X"         | Pauli X
+                "Y"         | Pauli Y
+                "Z"         | Pauli Z
+                "I"         | Identity
+                "CNOT"      | CNOT
+                "CZ"        | CZ gate
+                "TOFFOLI"   | Toffoli gate
+                "single"    | All single qubit gates
+                "double"    | All two-qubit gates
+                "triple"    | All three-qubit gates
+            Keys for specific gates override values set by "single", "double",
+            and "triple".
+            For example, `fidelities = {"single": 1.0, "H", 0.99}` sets all
+            single-qubit gates except Hadamard to have fidelity one.
+        squash_moments (bool): If True, all gates (including scaled gates) are
+            placed as early as possible in the circuit. If False, new moments
+            are created for scaled gates. This option only applies to QPROGRAM
+            types which have a "moment" or "time" structure. Default is True.
+        return_mitiq (bool): If True, returns a Mitiq circuit instead of
+            the input circuit type (if different). Default is False.
+    Returns:
+        scaled: The scaled quantum circuit as a QPROGRAM.
+    """
+
+    weight_mask = _create_weight_mask(circuit, kwargs.get("fidelities"))
+
+    num_inserts_mask = _create_scale_mask(
+        weight_mask, scale_factor, scaling_method="from_left"
+    )
+
+    return _apply_scale_mask(
+        circuit,
+        num_inserts_mask,
+        squash_moments=kwargs.get("squash_moments", True),
+    )
+
+
+@noise_scaling_converter
+def scale_gates_from_right(
+    circuit: QPROGRAM, scale_factor: float, **kwargs: Any
+) -> QPROGRAM:
+    r"""Returns a new scaled circuit by applying the map G -> G I to a
+    subset of gates of the input circuit, starting with gates at the
+    right (end) of the circuit.
+    The scaled circuit has a number of gates approximately equal to
+    scale_factor * n where n is the number of gates in the input circuit.
+    For equal gate fidelities, this function reproduces the identity scaled
+    version of local unitary folding method defined in equation (5) of
+    :cite:`Giurgica_Tiron_2020_arXiv`.
+    Args:
+        circuit: Circuit to scale.
+        scale_factor: Factor to scale the circuit by. Any real number >= 1.
+    Keyword Args:
+        fidelities (Dict[str, float]): Dictionary of gate fidelities. Each key
+            is a string which specifies the gate and each value is the
+            fidelity of that gate. When this argument is provided, scaled
+            gates contribute an amount proportional to their infidelity
+            (1 - fidelity) to the total noise scaling. Fidelity values must be
+            in the interval (0, 1]. Gates not specified have a default
+            fidelity of 0.99**n where n is the number of qubits the gates act
+            on.
+            Supported gate keys are listed in the following table.::
+                Gate key    | Gate
+                -------------------------
+                "H"         | Hadamard
+                "X"         | Pauli X
+                "Y"         | Pauli Y
+                "Z"         | Pauli Z
+                "I"         | Identity
+                "CNOT"      | CNOT
+                "CZ"        | CZ gate
+                "TOFFOLI"   | Toffoli gate
+                "single"    | All single qubit gates
+                "double"    | All two-qubit gates
+                "triple"    | All three-qubit gates
+            Keys for specific gates override values set by "single", "double",
+            and "triple".
+            For example, `fidelities = {"single": 1.0, "H", 0.99}` sets all
+            single-qubit gates except Hadamard to have fidelity one.
+        squash_moments (bool): If True, all gates (including scaled gates) are
+            placed as early as possible in the circuit. If False, new moments
+            are created for scaled gates. This option only applies to QPROGRAM
+            types which have a "moment" or "time" structure. Default is True.
+        return_mitiq (bool): If True, returns a Mitiq circuit instead of
+            the input circuit type (if different). Default is False.
+    Returns:
+        scaled: The scaled quantum circuit as a QPROGRAM.
+    """
+
+    weight_mask = _create_weight_mask(circuit, kwargs.get("fidelities"))
+
+    num_inserts_mask = _create_scale_mask(
+        weight_mask, scale_factor, scaling_method="from_right"
+    )
+
+    return _apply_scale_mask(
+        circuit,
+        num_inserts_mask,
+        squash_moments=kwargs.get("squash_moments", True),
+    )
+
+
+@noise_scaling_converter
+def scale_gates_at_random(
+    circuit: QPROGRAM,
+    scale_factor: float,
+    seed: Optional[int] = None,
+    **kwargs: Any,
+) -> QPROGRAM:
+    r"""Returns a new scaled circuit by applying the map G -> G I to a
+    subset of gates of the input circuit, starting with gates at the
+    right (end) of the circuit.
+    The scaled circuit has a number of gates approximately equal to
+    scale_factor * n where n is the number of gates in the input circuit.
+    For equal gate fidelities, this function reproduces the identity scaled
+    version of local unitary folding method defined in equation (5) of
+    :cite:`Giurgica_Tiron_2020_arXiv`.
+    Args:
+        circuit: Circuit to scale.
+        scale_factor: Factor to scale the circuit by. Any real number >= 1.
+    Keyword Args:
+        fidelities (Dict[str, float]): Dictionary of gate fidelities. Each key
+            is a string which specifies the gate and each value is the
+            fidelity of that gate. When this argument is provided, scaled
+            gates contribute an amount proportional to their infidelity
+            (1 - fidelity) to the total noise scaling. Fidelity values must be
+            in the interval (0, 1]. Gates not specified have a default
+            fidelity of 0.99**n where n is the number of qubits the gates act
+            on.
+            Supported gate keys are listed in the following table.::
+                Gate key    | Gate
+                -------------------------
+                "H"         | Hadamard
+                "X"         | Pauli X
+                "Y"         | Pauli Y
+                "Z"         | Pauli Z
+                "I"         | Identity
+                "CNOT"      | CNOT
+                "CZ"        | CZ gate
+                "TOFFOLI"   | Toffoli gate
+                "single"    | All single qubit gates
+                "double"    | All two-qubit gates
+                "triple"    | All three-qubit gates
+            Keys for specific gates override values set by "single", "double",
+            and "triple".
+            For example, `fidelities = {"single": 1.0, "H", 0.99}` sets all
+            single-qubit gates except Hadamard to have fidelity one.
+        squash_moments (bool): If True, all gates (including scaled gates) are
+            placed as early as possible in the circuit. If False, new moments
+            are created for scaled gates. This option only applies to QPROGRAM
+            types which have a "moment" or "time" structure. Default is True.
+        return_mitiq (bool): If True, returns a Mitiq circuit instead of
+            the input circuit type (if different). Default is False.
+    Returns:
+        scaled: The scaled quantum circuit as a QPROGRAM.
+    """
+
+    weight_mask = _create_weight_mask(circuit, kwargs.get("fidelities"))
+
+    num_inserts_mask = _create_scale_mask(
+        weight_mask, scale_factor, scaling_method="at_random", seed=seed,
+    )
+
+    return _apply_scale_mask(
+        circuit,
+        num_inserts_mask,
+        squash_moments=kwargs.get("squash_moments", True),
+    )

--- a/mitiq/zne/scaling/tests/test_identity_insertion.py
+++ b/mitiq/zne/scaling/tests/test_identity_insertion.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Unit tests for scaling noise by identity insertion."""

--- a/mitiq/zne/scaling/tests/test_identity_insertion.py
+++ b/mitiq/zne/scaling/tests/test_identity_insertion.py
@@ -22,13 +22,26 @@ from cirq import (
     LineQubit,
     ops,
     testing,
+    equal_up_to_global_phase,
     GateOperation,
+    InsertStrategy,
 )
-
+from cirq.google import Sycamore
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit.quantum_info.operators import Operator
+from pyquil import Program
+from pyquil.quilbase import Pragma
+from mitiq.conversions import (
+    CircuitConversionError,
+    convert_to_mitiq,
+    convert_from_mitiq,
+)
 from cirq.ops import IdentityGate
 from mitiq.utils import _equal
+from mitiq.zne.scaling.folding import _create_weight_mask
 from mitiq.zne.scaling.identity_insertion import (
     UnscalableCircuitError,
+    _apply_scale_mask,
     _create_scale_mask,
     scale_gates_from_left,
     scale_gates_from_right,
@@ -43,7 +56,7 @@ from mitiq.zne.scaling.identity_insertion import (
 def test_scaling_with_bad_scale_factor(scale_method):
     """Checks the test fails when scale factor is negative and input method is
      called directly."""
-    with pytest.raises(ValueError, match="Requires scale_factor >= 0.0"):
+    with pytest.raises(ValueError, match="Requires scale_factor >= 1.0"):
         scale_method(Circuit(), scale_factor=-1.0)
 
 
@@ -51,7 +64,7 @@ def test_scaling_with_bad_scale_factor(scale_method):
 def test_create_mask_with_bad_scale_factor(method):
     """Checks the test fails when scale factor is negative and input method is
     a string."""
-    with pytest.raises(ValueError, match="Requires scale_factor >= 0.0"):
+    with pytest.raises(ValueError, match="Requires scale_factor >= 1.0"):
         _create_scale_mask([1], scale_factor=-1.0, scaling_method=method)
 
 
@@ -60,27 +73,63 @@ def test_create_mask_with_bad_scaling_method():
     with pytest.raises(ValueError, match="'scaling_method' is not valid."):
         _create_scale_mask([1], scale_factor=1.5, scaling_method=None)
 
+@pytest.mark.parametrize("method", ("at_random", "from_left", "from_right"))
+def test_create_scale_mask_approximates_well(method):
+    """Check _create_scale_mask well approximates the scale factor."""
+    rnd_state = np.random.RandomState(seed=0)
+    for scale_factor in [1.1, 1.4, 1.8, 2.8, 6.8, 18.8, 19.0, 31]:
+        weight_mask = [rnd_state.rand() for _ in range(100)]
+        seed = rnd_state.randint(100)
+        fold_mask = _create_scale_mask(
+            weight_mask, scale_factor, scaling_method=method, seed=seed,
+        )
+        out_weights = [w + n * w for w, n in zip(weight_mask, fold_mask)]
+        actual_scale = sum(out_weights) / sum(weight_mask)
+        # Less than 10% error
+        assert np.isclose(scale_factor/actual_scale, 1.0, atol=0.1)
+
+
+def test_create_scale_mask_with_fidelities():
+    qreg = LineQubit.range(3)
+    circ = Circuit(
+        ops.H.on_each(*qreg),
+        ops.CNOT.on(qreg[0], qreg[1]),
+        ops.T.on(qreg[2]),
+        ops.TOFFOLI.on(*qreg),
+        ops.measure_each(*qreg),
+    )
+    # Measurement gates should be ignored
+    fidelities = {"H": 0.9, "CNOT": 0.8, "T": 0.7, "TOFFOLI": 0.6}
+    weight_mask = _create_weight_mask(circ, kwargs.get("fidelities"))
+    scale_mask = _create_scale_mask(circ, weight_mask)
+    assert np.allclose(scale_mask, [0.1, 0.1, 0.1, 0.2, 0.3, 0.4])
+
+    fidelities = {"single": 1.0, "double": 0.5, "triple": 0.1}
+    weight_mask = _create_weight_mask(circ, kwargs.get("fidelities"))
+    scale_mask = _create_scale_mask(circ, weight_mask)
+    assert np.allclose(scale_mask, [0.0, 0.0, 0.0, 0.5, 0.0, 0.9])
+
+    fidelities = {"single": 1.0, "H": 0.1, "CNOT": 0.2, "TOFFOLI": 0.3}
+    weight_mask = _create_weight_mask(circ, kwargs.get("fidelities"))
+    scale_mask = _create_scale_mask(circ, weight_mask)
+    assert np.allclose(scale_mask, [0.9, 0.9, 0.9, 0.8, 0.0, 0.7])
 
 @pytest.mark.parametrize(
     "scale_method",
     [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
 )
-def test_scale_from_left_no_stretch(scale_method):
+def test_scale_no_stretch(scale_method):
     """Unit test for scaling gates from left for a scale factor of 0 i.e
     no identity gates are inserted."""
     circuit = testing.random_circuit(qubits=2, n_moments=10, op_density=0.99)
-    scaled = scale_method(circuit, scale_factor=0, seed=None)
+    scaled = scale_method(circuit, scale_factor=1.0, seed=None)
     assert _equal(scaled, circuit)
     assert not (scaled is circuit)
 
 
-@pytest.mark.parametrize(
-    "scale_method",
-    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
-)
-def test_scale_from_left_and_right_small_factor(scale_method):
-    """Basic test for scaling from left and right with small
-    scale factor.
+
+def test_scale_from_left_very_small_factor():
+    """Basic test for scaling from left with very small scale factor.
     """
     # Test Circuit
     # 0: ───H───@───────
@@ -95,27 +144,20 @@ def test_scale_from_left_and_right_small_factor(scale_method):
         ]
     )
 
-    scaled = scale_method(circ, scale_factor=0.7, seed=3)
+    scaled = scale_gates_from_left(circ, scale_factor=1.1, seed=3)
     correct = Circuit(
         [
             ops.H.on_each(*qreg),
-            ops.I.on_each(*qreg),
             ops.CNOT.on(qreg[0], qreg[1]),
-            GateOperation(IdentityGate(2), qreg),
             ops.T.on(qreg[1]),
-            ops.I.on(qreg[1]),
         ]
     )
     assert _equal(scaled, correct)
 
 
-@pytest.mark.parametrize(
-    "scale_method",
-    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
-)
-def test_scale_from_left_and_right_intermediate_factor(scale_method):
-    """Basic test for scaling from left and right with intermediate
-    scale factor.
+
+def test_scale_from_left_small_factor():
+    """Basic test for scaling from left with small scale factor.
     """
     # Test Circuit
     # 0: ───H───@───────
@@ -130,15 +172,204 @@ def test_scale_from_left_and_right_intermediate_factor(scale_method):
         ]
     )
 
-    scaled = scale_method(circ, scale_factor=1.5, seed=3)
+    scaled = scale_gates_from_left(circ, scale_factor=1.5, seed=3)
     correct = Circuit(
         [
             ops.H.on_each(*qreg),
             ops.I.on_each(*qreg),
             ops.CNOT.on(qreg[0], qreg[1]),
-            GateOperation(IdentityGate(2), qreg),
             ops.T.on(qreg[1]),
-            ops.I.on(qreg[1]),
+        ]
+    )
+    assert _equal(scaled, correct)
+
+def test_scale_from_left_intermediate_factor():
+    """Basic test for scaling from left with intermediate scale factor.
+    """
+    # Test Circuit
+    # 0: ───H───@───────
+    #           |
+    # 1: ───H───X───T───
+    qreg = LineQubit.range(2)
+    circ = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+
+    scaled = scale_gates_from_left(circ, scale_factor=1.7, seed=3)
+    correct = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.I.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+    assert _equal(scaled, correct)
+
+def test_scale_from_right_very_small_factor():
+    """Basic test for scaling from right with very small scale factor.
+    """
+    # Test Circuit
+    # 0: ───H───@───────
+    #           |
+    # 1: ───H───X───T───
+    qreg = LineQubit.range(2)
+    circ = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+
+    scaled = scale_gates_from_right(circ, scale_factor=1.1, seed=3)
+    correct = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+    assert _equal(scaled, correct)
+
+
+
+def test_scale_from_right_small_factor():
+    """Basic test for scaling from right with small scale factor.
+    """
+    # Test Circuit
+    # 0: ───H───@───────
+    #           |
+    # 1: ───H───X───T───
+    qreg = LineQubit.range(2)
+    circ = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+
+    scaled = scale_gates_from_right(circ, scale_factor=1.5, seed=3)
+    correct = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.I.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+    assert _equal(scaled, correct)
+
+def test_scale_from_right_intermediate_factor():
+    """Basic test for scaling from right with intermediate scale factor.
+    """
+    # Test Circuit
+    # 0: ───H───@───────
+    #           |
+    # 1: ───H───X───T───
+    qreg = LineQubit.range(2)
+    circ = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+
+    scaled = scale_gates_from_right(circ, scale_factor=1.7, seed=3)
+    correct = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.I.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+    assert _equal(scaled, correct)
+
+def test_scale_at_random_with_very_small_factor():
+    """Basic test for scaling at random with very small scale factor.
+    """
+    # Test Circuit
+    # 0: ───H───@───────
+    #           |
+    # 1: ───H───X───T───
+    qreg = LineQubit.range(2)
+    circ = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+
+    scaled = scale_gates_at_random(circ, scale_factor=1.1, seed=3)
+    correct = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+    assert _equal(scaled, correct)
+
+
+
+def test_scale_scale_gates_at_random_with_small_factor():
+    """Basic test for scaling at random with small scale factor.
+    """
+    # Test Circuit
+    # 0: ───H───@───────
+    #           |
+    # 1: ───H───X───T───
+    qreg = LineQubit.range(2)
+    circ = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+
+    scaled = scale_gates_at_random(circ, scale_factor=1.5, seed=3)
+    correct = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.I.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+    assert _equal(scaled, correct)
+
+def test_scale_scale_gates_at_random_with_intermediate_factor():
+    """Basic test for scaling at random with intermediate scale factor.
+    """
+    # Test Circuit
+    # 0: ───H───@───────
+    #           |
+    # 1: ───H───X───T───
+    qreg = LineQubit.range(2)
+    circ = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+
+    scaled = scale_gates_at_random(circ, scale_factor=1.7, seed=3)
+    correct = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.I.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
         ]
     )
     assert _equal(scaled, correct)
@@ -148,7 +379,7 @@ def test_scale_from_left_and_right_intermediate_factor(scale_method):
     "scale_method",
     [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
 )
-def test_scale_from_left_and_right_full_factor(scale_method):
+def test_scale_with_full_factor(scale_method):
     """Basic test for scaling from left and right with full
     scale factor.
     """
@@ -242,7 +473,7 @@ def test_scale_from_left_and_right_scale_factor_more_than_full_factor(
     "scale_method",
     [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
 )
-def test_scale_from_left_and_right_with_terminal_measurements_min_stretch(
+def test_scale_from_left_and_right_with_terminal_measurements_no_stretch(
     scale_method,
 ):
     """Tests scaling from left with terminal measurements."""
@@ -254,7 +485,7 @@ def test_scale_from_left_and_right_with_terminal_measurements_min_stretch(
         [ops.TOFFOLI.on(*qreg)],
         [ops.measure_each(*qreg)],
     )
-    scaled = scale_method(circ, scale_factor=0.0)
+    scaled = scale_method(circ, scale_factor=1.0)
     correct = Circuit(
         [ops.H.on_each(*qreg)],
         [ops.CNOT.on(qreg[0], qreg[1])],
@@ -372,7 +603,7 @@ def test_scale_right_retains_terminal_measurements_in_input_circuit():
     """
     qbit = LineQubit(1)
     circ = Circuit(ops.H.on(qbit), ops.measure(qbit))
-    scaled = scale_gates_from_right(circ, scale_factor=0.0)
+    scaled = scale_gates_from_right(circ, scale_factor=1.0)
     assert _equal(circ, scaled)
 
 
@@ -395,3 +626,418 @@ def test_local_scaling_methods_match_on_even_scale_factors():
             require_qubit_equality=True,
             require_measurement_equality=True,
         )
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+def test_local_no_scale_with_qiskit_circuits(scale_method):
+    """Tests folding from left with Qiskit circuits."""
+    # Test Qiskit circuit:
+    #          ┌───┐
+    # q0_0: |0>┤ H ├──■────■──
+    #          ├───┤┌─┴─┐  │
+    # q0_1: |0>┤ H ├┤ X ├──■──
+    #          ├───┤├───┤┌─┴─┐
+    # q0_2: |0>┤ H ├┤ T ├┤ X ├
+    #          └───┘└───┘└───┘
+    qiskit_qreg = QuantumRegister(3)
+    qiskit_creg = ClassicalRegister(3)
+    qiskit_circuit = QuantumCircuit(qiskit_qreg, qiskit_creg)
+    qiskit_circuit.h(qiskit_qreg)
+    qiskit_circuit.cnot(qiskit_qreg[0], qiskit_qreg[1])
+    qiskit_circuit.t(qiskit_qreg[2])
+    qiskit_circuit.ccx(*qiskit_qreg)
+    qiskit_circuit.measure(qiskit_qreg, qiskit_creg)
+
+    folded_circuit = scale_method(
+        qiskit_circuit, scale_factor=1.0, return_mitiq=True
+    )
+
+    qreg = LineQubit.range(3)
+    correct_folded_circuit = Circuit(
+        [ops.H.on_each(*qreg)],
+        [ops.CNOT.on(qreg[0], qreg[1])],
+        [ops.T.on(qreg[2])],
+        [ops.TOFFOLI.on(*qreg)],
+        [ops.measure_each(*qreg)],
+    )
+
+    assert isinstance(folded_circuit, Circuit)
+    assert _equal(folded_circuit, correct_folded_circuit)
+
+    # Keep the input type
+    qiskit_folded_circuit = scale_method(
+        qiskit_circuit, scale_factor=1.0, return_mitiq=False
+    )
+    assert isinstance(qiskit_folded_circuit, QuantumCircuit)
+    assert qiskit_folded_circuit.qregs == qiskit_circuit.qregs
+    assert qiskit_folded_circuit.cregs == qiskit_circuit.cregs
+
+@pytest.mark.parametrize(
+    "scale_method",
+    (
+        scale_gates_from_left,
+        scale_gates_from_right,
+        scale_gates_at_random,
+    ),
+)
+def test_folding_circuit_conversion_error_qiskit(scale_method):
+    # Custom gates are not supported in conversions
+    gate = Operator([[0.0, 1.0], [-1.0, 0.0]])
+    qreg = QuantumRegister(1)
+    circ = QuantumCircuit(qreg)
+    circ.unitary(gate, [0])
+
+    with pytest.raises(
+        CircuitConversionError, match="Circuit could not be converted to"
+    ):
+        scale_method(circ, scale_factor=2.0)
+
+@pytest.mark.parametrize(
+    "scale_method",
+    (
+        scale_gates_from_left,
+        scale_gates_from_right,
+        scale_gates_at_random,
+    ),
+)
+def test_folding_circuit_conversion_error_pyquil(scale_method):
+    # Pragmas are not supported in conversions
+    prog = Program(Pragma("INITIAL_REWIRING", ['"Partial"']))
+
+    with pytest.raises(
+        CircuitConversionError, match="Circuit could not be converted to"
+    ):
+        scale_method(prog, scale_factor=2.0)
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    (
+        scale_gates_from_left,
+        scale_gates_from_right,
+        scale_gates_at_random,
+    ),
+)
+def test_scale_local_squash_moments(scale_method):
+    """Tests folding from left with kwarg squash_moments."""
+    # Test circuit
+    # 0: ───H───@───@───M───
+    #           │   │
+    # 1: ───H───X───@───M───
+    #               │
+    # 2: ───H───T───X───M───
+    qreg = LineQubit.range(3)
+    circ = Circuit(
+        [ops.H.on_each(*qreg)],
+        [ops.CNOT.on(qreg[0], qreg[1])],
+        [ops.T.on(qreg[2])],
+        [ops.TOFFOLI.on(*qreg)],
+        [ops.measure_each(*qreg)],
+    )
+    folded_not_squashed = scale_method(
+        circ, scale_factor=3, squash_moments=False
+    )
+    folded_and_squashed = scale_method(
+        circ, scale_factor=3, squash_moments=True
+    )
+    correct = Circuit(
+        [ops.H.on_each(*qreg)],
+        [ops.I.on_each(*qreg)] * 3,
+        [ops.CNOT.on(qreg[0], qreg[1])],
+        [GateOperation(IdentityGate(2), (qreg[0], qreg[1]))] * 3,
+        [ops.T.on(qreg[2])],
+        [ops.I.on(qreg[2])] * 3,
+        [ops.TOFFOLI.on(*qreg)],
+        [GateOperation(IdentityGate(3), qreg)] * 3,
+        [ops.measure_each(*qreg)],
+    )
+    assert _equal(folded_and_squashed, folded_not_squashed)
+    assert _equal(folded_and_squashed, correct)
+    assert len(folded_and_squashed) == 13
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [
+        scale_gates_from_left,
+        scale_gates_from_right,
+        scale_gates_at_random,
+    ],
+)
+def test_fold_and_squash_max_stretch(scale_method):
+    """Tests folding and squashing a two-qubit circuit."""
+    # Test circuit:
+    # 0: ───────H───────H───────H───────H───────H───
+    #
+    # 1: ───H───────H───────H───────H───────H───────
+
+    # Get the test circuit
+    d = 10
+    qreg = LineQubit.range(2)
+    circuit = Circuit()
+    for i in range(d):
+        circuit.insert(0, ops.H.on(qreg[i % 2]), strategy=InsertStrategy.NEW)
+
+    folded_not_squashed = scale_method(
+        circuit, scale_factor=2.0, squash_moments=False
+    )
+    folded_and_squashed = scale_method(
+        circuit, scale_factor=2.0, squash_moments=True
+    )
+    folded_with_squash_moments_not_specified = scale_method(
+        circuit, scale_factor=2.0
+    )  # Checks that the default is to squash moments
+
+    assert len(folded_not_squashed) == 30
+    assert len(folded_and_squashed) == 15
+    assert len(folded_with_squash_moments_not_specified) == 15
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [
+        scale_gates_from_left,
+        scale_gates_from_right,
+        scale_gates_at_random,
+    ],
+)
+def test_scale_and_squash_random_circuits_random_stretches(scale_method):
+    """Tests folding and squashing random circuits and ensures the number of
+    moments in the squashed circuits is never greater than the number of
+    moments in the un-squashed circuit.
+    """
+    rng = np.random.RandomState(seed=1)
+    for trial in range(5):
+        circuit = testing.random_circuit(
+            qubits=8, n_moments=8, op_density=0.75
+        )
+        scale = 2 * rng.random() + 1
+        folded_not_squashed = scale_method(
+            circuit, scale_factor=scale, squash_moments=False, seed=trial,
+        )
+        folded_and_squashed = scale_method(
+            circuit, scale_factor=scale, squash_moments=True, seed=trial,
+        )
+        assert len(folded_and_squashed) <= len(folded_not_squashed)
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+@pytest.mark.parametrize("qiskit", [True, False])
+def test_scale_local_with_fidelities(scale_method, qiskit):
+    qreg = LineQubit.range(3)
+    circ = Circuit(
+        ops.H.on_each(*qreg),
+        ops.CNOT.on(qreg[0], qreg[1]),
+        ops.T.on(qreg[2]),
+        ops.TOFFOLI.on(*qreg),
+    )
+    if qiskit:
+        circ = convert_from_mitiq(circ, "qiskit")
+    # Only fold the Toffoli gate
+    fidelities = {"H": 1.0, "T": 1.0, "CNOT": 1.0, "TOFFOLI": 0.95}
+    folded = scale_method(circ, scale_factor=3.0, fidelities=fidelities)
+    correct = Circuit(
+        [ops.H.on_each(*qreg)],
+        [ops.CNOT.on(qreg[0], qreg[1])],
+        [ops.T.on(qreg[2])],
+        [ops.TOFFOLI.on(*qreg)],
+        [GateOperation(IdentityGate(3), qreg)] * 3,
+    )
+    if qiskit:
+        folded, _ = convert_to_mitiq(folded)
+        assert equal_up_to_global_phase(folded.unitary(), correct.unitary())
+    else:
+        assert _equal(folded, correct)
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+@pytest.mark.parametrize("qiskit", [True, False])
+def test_scale_local_with_single_qubit_gates_fidelity_one(scale_method, qiskit):
+    """Tests folding only two-qubit gates by using fidelities = {"single": 1.}.
+    """
+    qreg = LineQubit.range(3)
+    circ = Circuit(
+        ops.H.on_each(*qreg),
+        ops.CNOT.on(qreg[0], qreg[1]),
+        ops.T.on(qreg[2]),
+        ops.TOFFOLI.on(*qreg),
+    )
+    if qiskit:
+        circ = convert_from_mitiq(circ, "qiskit")
+    folded = scale_method(
+        circ,
+        scale_factor=3.0,
+        fidelities={"single": 1.0, "CNOT": 0.99, "TOFFOLI": 0.95},
+    )
+    correct = Circuit(
+        [ops.H.on_each(*qreg)],
+        [ops.CNOT.on(qreg[0], qreg[1])],
+        [GateOperation(IdentityGate(2), (qreg[0], qreg[1]))] * 3,
+        [ops.T.on(qreg[2])],
+        [ops.TOFFOLI.on(*qreg)],
+        [GateOperation(IdentityGate(3), qreg)] * 3,
+    )
+    if qiskit:
+        assert folded.qregs == circ.qregs
+        assert folded.cregs == circ.cregs
+        folded, _ = convert_to_mitiq(folded)
+        assert equal_up_to_global_phase(folded.unitary(), correct.unitary())
+    else:
+        assert _equal(folded, correct)
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+@pytest.mark.parametrize("qiskit", [True, False])
+def test_all_gates_folded_at_max_scale_with_fidelities(scale_method, qiskit):
+    """Tests that all gates are folded regardless of the input fidelities when
+    the scale factor is three.
+    """
+    rng = np.random.RandomState(1)
+
+    qreg = LineQubit.range(3)
+    circ = Circuit(
+        ops.H.on_each(*qreg),
+        ops.CNOT.on(qreg[0], qreg[1]),
+        ops.T.on(qreg[2]),
+        ops.TOFFOLI.on(*qreg),
+    )
+    ngates = len(list(circ.all_operations()))
+
+    if qiskit:
+        circ = convert_from_mitiq(circ, "qiskit")
+
+    folded = scale_method(
+        circ,
+        scale_factor=2.0,
+        fidelities={
+            "H": rng.rand(),
+            "T": rng.rand(),
+            "CNOT": rng.rand(),
+            "TOFFOLI": rng.rand(),
+        },
+    )
+    correct = Circuit(
+        [ops.H.on_each(*qreg)],
+        [ops.I.on_each(*qreg)] * 2,
+        [ops.CNOT.on(qreg[0], qreg[1])],
+        [GateOperation(IdentityGate(2), (qreg[0], qreg[1]))] * 2,
+        [ops.T.on(qreg[2])],
+        [ops.I.on(qreg[2])] * 2,
+        [ops.TOFFOLI.on(*qreg)],
+        [GateOperation(IdentityGate(3), qreg)] * 2,
+    )
+    if qiskit:
+        assert folded.qregs == circ.qregs
+        assert folded.cregs == circ.cregs
+        folded, _ = convert_to_mitiq(folded)
+        assert equal_up_to_global_phase(folded.unitary(), correct.unitary())
+    else:
+        assert _equal(folded, correct)
+        assert len(list(folded.all_operations())) == 3 * ngates
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+def test_scale_local_raises_error_with_bad_fidelities(scale_method):
+    with pytest.raises(ValueError, match="Fidelities should be"):
+        scale_method(Circuit(), scale_factor=1.21, fidelities={"H": -1.0})
+
+    with pytest.raises(ValueError, match="Fidelities should be"):
+        scale_method(Circuit(), scale_factor=1.21, fidelities={"CNOT": 0.0})
+
+    with pytest.raises(ValueError, match="Fidelities should be"):
+        scale_method(Circuit(), scale_factor=1.21, fidelities={"triple": 1.2})
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+@pytest.mark.parametrize("scale", [1, 3, 5, 9])
+def test_scale_fidelity_large_scale_factor_only_twoq_gates(scale_method, scale):
+    qreg = LineQubit.range(2)
+    circuit = Circuit(ops.H(qreg[0]), ops.CNOT(*qreg))
+    folded = scale_method(
+        circuit, scale_factor=scale, fidelities={"single": 1.0}
+    )
+    correct = Circuit(ops.H(qreg[0]), [ops.CNOT(*qreg)], [GateOperation(IdentityGate(2), qreg)] * scale)
+    assert _equal(folded, correct)
+
+
+def test_scaling_keeps_measurement_order_with_qiskit():
+    qreg, creg = QuantumRegister(2), ClassicalRegister(2)
+    circuit = QuantumCircuit(qreg, creg)
+    circuit.h(qreg[0])
+    circuit.measure(qreg, creg)
+
+    folded = scale_gates_at_random(circuit, scale_factor=1.0)
+    assert folded == circuit
+
+@pytest.mark.parametrize(
+    "weight_mask",
+    ([0.1, 0.2, 0.3, 0.0], [0.3, 0.5, 0.7, 0.0], [1.0, 1.0, 1.0, 0.0]),
+)
+@pytest.mark.parametrize("scale_factor", (1, 3, 5, 7, 9, 11))
+@pytest.mark.parametrize("method", ("at_random", "from_left", "from_right"))
+def test_create_fold_mask_with_odd_scale_factors(
+    weight_mask, scale_factor, method,
+):
+    fold_mask = _create_scale_mask(weight_mask, scale_factor, method)
+    num_folds = int((scale_factor))
+    assert fold_mask == [num_folds, num_folds, num_folds, 0]
+
+@pytest.mark.parametrize(
+    "weight_mask",
+    ([0.1, 0.2, 0.3, 0.0], [0.3, 0.5, 0.7, 0.0], [1.0, 1.0, 1.0, 0.0]),
+)
+@pytest.mark.parametrize("scale_factor", (2, 4, 6, 8, 10, 12))
+@pytest.mark.parametrize("method", ("at_random", "from_left", "from_right"))
+def test_create_fold_mask_with_even_scale_factors(
+    weight_mask, scale_factor, method,
+):
+    fold_mask = _create_scale_mask(weight_mask, scale_factor, method)
+    num_folds = int((scale_factor))
+    assert fold_mask == [num_folds, num_folds, num_folds, 0]
+
+@pytest.mark.parametrize("method", ("at_random", "from_left", "from_right"))
+def test_create_scale_mask_with_real_scale_factors(method):
+    fold_mask = _create_scale_mask(
+        weight_mask=[0.1, 0.2, 0.3, 0.0],
+        scale_factor=1.0,
+        scaling_method=method,
+    )
+    assert fold_mask == [0, 0, 0, 0]
+
+    fold_mask = _create_scale_mask(
+        weight_mask=[0.1, 0.1, 0.1, 0.1],
+        scale_factor=1.5,
+        scaling_method=method,
+    )
+    assert fold_mask == [1, 1, 1, 1]
+
+    fold_mask = _create_scale_mask(
+        weight_mask=[1.0, 1.0, 1.0, 1.0],
+        scale_factor=2,
+        scaling_method=method,
+    )
+    assert fold_mask == [2, 2, 2, 2]
+
+    fold_mask = _create_scale_mask(
+        weight_mask=[1.0, 1.0, 1.0, 1.0],
+        scale_factor=3.9,
+        scaling_method=method,
+    )
+    assert fold_mask == [3, 3, 3, 3]
+
+def test_apply_scale_mask_wrong_size():
+    qreg = LineQubit(0)
+    circ = Circuit(ops.H(qreg))
+    with pytest.raises(ValueError, match="have incompatible sizes"):
+        _ = _apply_scale_mask(circ, [1, 1])

--- a/mitiq/zne/scaling/tests/test_identity_insertion.py
+++ b/mitiq/zne/scaling/tests/test_identity_insertion.py
@@ -14,3 +14,384 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Unit tests for scaling noise by identity insertion."""
+
+import numpy as np
+import pytest
+from cirq import (
+    Circuit,
+    LineQubit,
+    ops,
+    testing,
+    GateOperation,
+)
+
+from cirq.ops import IdentityGate
+from mitiq.utils import _equal
+from mitiq.zne.scaling.identity_insertion import (
+    UnscalableCircuitError,
+    _create_scale_mask,
+    scale_gates_from_left,
+    scale_gates_from_right,
+    scale_gates_at_random,
+)
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_at_random, scale_gates_from_left, scale_gates_from_right,],
+)
+def test_scaling_with_bad_scale_factor(scale_method):
+    """Checks the test fails when scale factor is negative and input method is
+     called directly."""
+    with pytest.raises(ValueError, match="Requires scale_factor >= 0.0"):
+        scale_method(Circuit(), scale_factor=-1.0)
+
+
+@pytest.mark.parametrize("method", ["at_random", "from_right", "from_left"])
+def test_create_mask_with_bad_scale_factor(method):
+    """Checks the test fails when scale factor is negative and input method is
+    a string."""
+    with pytest.raises(ValueError, match="Requires scale_factor >= 0.0"):
+        _create_scale_mask([1], scale_factor=-1.0, scaling_method=method)
+
+
+def test_create_mask_with_bad_scaling_method():
+    "Checks test fails when no scaling method is given."
+    with pytest.raises(ValueError, match="'scaling_method' is not valid."):
+        _create_scale_mask([1], scale_factor=1.5, scaling_method=None)
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+def test_scale_from_left_no_stretch(scale_method):
+    """Unit test for scaling gates from left for a scale factor of 0 i.e
+    no identity gates are inserted."""
+    circuit = testing.random_circuit(qubits=2, n_moments=10, op_density=0.99)
+    scaled = scale_method(circuit, scale_factor=0,seed=None)
+    assert _equal(scaled, circuit)
+    assert not (scaled is circuit)
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+def test_scale_from_left_and_right_small_factor(scale_method):
+    """Basic test for scaling from left and right with small
+    scale factor.
+    """
+    # Test Circuit
+    # 0: ───H───@───────
+    #           |
+    # 1: ───H───X───T───
+    qreg = LineQubit.range(2)
+    circ = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+
+    scaled = scale_method(circ, scale_factor=0.7, seed=3)
+    correct = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.I.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            GateOperation(IdentityGate(2), qreg),
+            ops.T.on(qreg[1]),
+            ops.I.on(qreg[1]),
+        ]
+    )
+    assert _equal(scaled, correct)
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+def test_scale_from_left_and_right_intermediate_factor(scale_method):
+    """Basic test for scaling from left and right with intermediate
+    scale factor.
+    """
+    # Test Circuit
+    # 0: ───H───@───────
+    #           |
+    # 1: ───H───X───T───
+    qreg = LineQubit.range(2)
+    circ = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+
+    scaled = scale_method(circ, scale_factor=1.5, seed=3)
+    correct = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.I.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            GateOperation(IdentityGate(2), qreg),
+            ops.T.on(qreg[1]),
+            ops.I.on(qreg[1]),
+        ]
+    )
+    assert _equal(scaled, correct)
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+def test_scale_from_left_and_right_full_factor(scale_method):
+    """Basic test for scaling from left and right with full
+    scale factor.
+    """
+    # Test Circuit
+    # 0: ───H───@───────
+    #           |
+    # 1: ───H───X───T───
+    qreg = LineQubit.range(2)
+    circ = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[1]),
+        ]
+    )
+
+    scaled = scale_method(circ, scale_factor=2.0, seed=3)
+    correct = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            [ops.I.on_each(*qreg)] * 2,
+            ops.CNOT.on(qreg[0], qreg[1]),
+            [GateOperation(IdentityGate(2), qreg)] * 2,
+            ops.T.on(qreg[1]),
+            [ops.I.on(qreg[1])] * 2,
+        ]
+    )
+    assert _equal(scaled, correct)
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+def test_scale_from_left_and_right_three_qubits(scale_method):
+    """Unit test for scaling gates from left to for a 3 qubit circuit."""
+    # Test Circuit
+    # 0: ───H───@───@───
+    #           │   │
+    # 1: ───H───X───@───
+    #               │
+    # 2: ───H───T───X───
+
+    qreg = LineQubit.range(3)
+    circ = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            ops.CNOT.on(qreg[0], qreg[1]),
+            ops.T.on(qreg[2]),
+            ops.TOFFOLI.on(*qreg),
+        ]
+    )
+
+    scaled = scale_method(circ, scale_factor=2,seed=3 )
+    correct = Circuit(
+        [
+            ops.H.on_each(*qreg),
+            [ops.I.on_each(*qreg)] * 2,
+            ops.CNOT.on(qreg[0], qreg[1]),
+            [GateOperation(IdentityGate(2), (qreg[0], qreg[1]))] * 2,
+            ops.T.on(qreg[2]),
+            [ops.I.on(qreg[2])] * 2,
+            ops.TOFFOLI.on(*qreg),
+            [GateOperation(IdentityGate(3), qreg)] * 2,
+        ]
+    )
+    assert _equal(scaled, correct)
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+def test_scale_from_left_and_right_scale_factor_more_than_full_factor(
+    scale_method,
+):
+    """Tests scaling from left with a scale_factor larger than two."""
+    qreg = LineQubit.range(2)
+    circuit = Circuit([ops.SWAP.on(*qreg)], [ops.CNOT.on(*qreg)])
+    scaled = scale_method(circuit, scale_factor=5.0)
+    correct = Circuit(
+        [ops.SWAP.on(*qreg)],
+        [GateOperation(IdentityGate(2), qreg)] * 5,
+        [ops.CNOT.on(*qreg)],
+        [GateOperation(IdentityGate(2), qreg)] * 5,
+    )
+    assert _equal(scaled, correct)
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+def test_scale_from_left_and_right_with_terminal_measurements_min_stretch(
+    scale_method,
+):
+    """Tests scaling from left with terminal measurements."""
+    qreg = LineQubit.range(3)
+    circ = Circuit(
+        [ops.H.on_each(*qreg)],
+        [ops.CNOT.on(qreg[0], qreg[1])],
+        [ops.T.on(qreg[2])],
+        [ops.TOFFOLI.on(*qreg)],
+        [ops.measure_each(*qreg)],
+    )
+    scaled = scale_method(circ, scale_factor=0.0)
+    correct = Circuit(
+        [ops.H.on_each(*qreg)],
+        [ops.CNOT.on(qreg[0], qreg[1])],
+        [ops.T.on(qreg[2])],
+        [ops.TOFFOLI.on(*qreg)],
+        [ops.measure_each(*qreg)],
+    )
+    assert _equal(scaled, correct)
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+def test_fold_from_left_and_right_with_terminal_measurements_max_stretch(
+    scale_method,
+):
+    """Tests scaling from left with terminal measurements."""
+    qreg = LineQubit.range(3)
+    circ = Circuit(
+        [ops.H.on_each(*qreg)],
+        [ops.CNOT.on(qreg[0], qreg[1])],
+        [ops.T.on(qreg[2])],
+        [ops.TOFFOLI.on(*qreg)],
+        [ops.measure_each(*qreg)],
+    )
+    scaled = scale_method(circ, scale_factor=2.0)
+    correct = Circuit(
+        [ops.H.on_each(*qreg)],
+        [ops.I.on_each(*qreg)] * 2,
+        [ops.CNOT.on(qreg[0], qreg[1])],
+        [GateOperation(IdentityGate(2), (qreg[0], qreg[1]))] * 2,
+        [ops.T.on(qreg[2])],
+        [ops.I.on(qreg[2])] * 2,
+        [ops.TOFFOLI.on(*qreg)],
+        [GateOperation(IdentityGate(3), (qreg))] * 2,
+        [ops.measure_each(*qreg)],
+    )
+    assert _equal(scaled, correct)
+
+    # Make sure original circuit is not modified
+    original = Circuit(
+        [ops.H.on_each(*qreg)],
+        [ops.CNOT.on(qreg[0], qreg[1])],
+        [ops.T.on(qreg[2])],
+        [ops.TOFFOLI.on(*qreg)],
+        [ops.measure_each(*qreg)],
+    )
+    assert _equal(circ, original)
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random,],
+)
+def test_scale_with_intermediate_measurements_raises_error(scale_method):
+    """Tests local scaling functions raise an error on circuits with
+    intermediate measurements.
+    """
+    qbit = LineQubit(0)
+    circ = Circuit([ops.H.on(qbit)], [ops.measure(qbit)], [ops.T.on(qbit)])
+    with pytest.raises(
+        UnscalableCircuitError,
+        match="Circuit contains intermediate measurements",
+    ):
+        scale_method(circ, scale_factor=3.0)
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
+)
+def test_scale_with_channels_raises_error(scale_method):
+    """Tests local scaling functions raise an error on circuits with
+    non-unitary channels (which are not measurements).
+    """
+    qbit = LineQubit(0)
+    circ = Circuit(
+        ops.H.on(qbit), ops.depolarize(p=0.1).on(qbit), ops.measure(qbit)
+    )
+    with pytest.raises(
+        UnscalableCircuitError, match="Circuit contains non-unitary channels"
+    ):
+        scale_method(circ, scale_factor=3.0)
+
+
+@pytest.mark.parametrize(
+    "scale_method",
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random]
+)
+def test_scale_no_repeats(scale_method):
+    """Tests scaling at random to ensure that no gates are folded twice and
+    scaled gates are not scaled again.
+    """
+    qreg = LineQubit.range(2)
+    circ = Circuit(
+        [ops.H.on_each(qreg[0])],
+        [ops.CNOT.on(*qreg)],
+        [ops.X.on(qreg[1])],
+        [ops.Y.on(qreg[0])],
+        [ops.CZ.on(*qreg)],
+    )
+    circuit_ops = set(circ.all_operations())
+
+    for scale in np.linspace(1.0, 3.0, 5):
+        scaled = scale_method(circ, scale_factor=scale, seed=1)
+        gates = list(scaled.all_operations())
+        counts = {gate: gates.count(gate) for gate in circuit_ops}
+        assert all(count <= 3 for count in counts.values())
+
+
+def test_scale_right_retains_terminal_measurements_in_input_circuit():
+    """Tests that scaling from the right doesn't modify the terminal
+    measurements in the input circuit.
+    """
+    qbit = LineQubit(1)
+    circ = Circuit(ops.H.on(qbit), ops.measure(qbit))
+    scaled = scale_gates_from_right(circ, scale_factor=0.0)
+    assert _equal(circ, scaled)
+
+
+def test_local_scaling_methods_match_on_even_scale_factors():
+    circuit = testing.random_circuit(
+        qubits=3, n_moments=5, op_density=1.0, random_state=11
+    )
+    for s in (2, 6, 14):
+        assert _equal(
+            scale_gates_from_left(circuit, s),
+            scale_gates_from_right(circuit, s),
+            require_qubit_equality=True,
+            require_measurement_equality=True,
+        )
+
+    for s in (2, 6, 14):
+        assert _equal(
+            scale_gates_from_left(circuit, s),
+            scale_gates_at_random(circuit, s),
+            require_qubit_equality=True,
+            require_measurement_equality=True,
+        )

--- a/mitiq/zne/scaling/tests/test_identity_insertion.py
+++ b/mitiq/zne/scaling/tests/test_identity_insertion.py
@@ -69,7 +69,7 @@ def test_scale_from_left_no_stretch(scale_method):
     """Unit test for scaling gates from left for a scale factor of 0 i.e
     no identity gates are inserted."""
     circuit = testing.random_circuit(qubits=2, n_moments=10, op_density=0.99)
-    scaled = scale_method(circuit, scale_factor=0,seed=None)
+    scaled = scale_method(circuit, scale_factor=0, seed=None)
     assert _equal(scaled, circuit)
     assert not (scaled is circuit)
 
@@ -202,7 +202,7 @@ def test_scale_from_left_and_right_three_qubits(scale_method):
         ]
     )
 
-    scaled = scale_method(circ, scale_factor=2,seed=3 )
+    scaled = scale_method(circ, scale_factor=2, seed=3)
     correct = Circuit(
         [
             ops.H.on_each(*qreg),
@@ -343,7 +343,7 @@ def test_scale_with_channels_raises_error(scale_method):
 
 @pytest.mark.parametrize(
     "scale_method",
-    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random]
+    [scale_gates_from_left, scale_gates_from_right, scale_gates_at_random],
 )
 def test_scale_no_repeats(scale_method):
     """Tests scaling at random to ensure that no gates are folded twice and


### PR DESCRIPTION
Description
-----------
Fixes #335 partially - Adds local identity scaled functions. Documentation is also updated with new examples.

The test/code for these functions is similar to code found in `ZNE/folding.py`.  All the changes are made to account for only 1 gate being inserted in the circuit instead of 2 gates. The main difference between the methods can be seen when the scaling factor is not a whole number (say scale_factor=2.5) otherwise they all produce equivalent circuits (scale_factor=3). 

Other functions (global folding etc.) will be added after this PR is accepted. 
 