### PR TITLE
Pins docutils version to avoid issues with newer version

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -10,6 +10,7 @@ black~=19.10b0
 
 # Documentation and examples.
 sphinx~=2.4.4
+docutils==0.16
 sphinxcontrib-bibtex~=1.0.0
 sphinx-copybutton~=0.2.11
 sphinx-autodoc-typehints~=1.10.3


### PR DESCRIPTION
Description
-----------

Check for `docs` fails when newer version of `docutils` is installed. This PR pins older version. See [this comment ](https://github.com/unitaryfund/mitiq/pull/622#issuecomment-813500688)for more information.