### PR TITLE
Add `PauliString`

### DIFF
--- a/mitiq/observable/__init__.py
+++ b/mitiq/observable/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from mitiq.observable.pauli import PauliString

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -1,0 +1,128 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Optional, Sequence
+
+import numpy as np
+import cirq
+
+from mitiq import QPROGRAM
+from mitiq.conversions import atomic_converter
+
+
+class PauliString:
+    _string_to_gate_map = {"I": cirq.I, "X": cirq.X, "Y": cirq.Y, "Z": cirq.Z}
+
+    def __init__(
+        self,
+        *,
+        spec: str,
+        coeff: complex = 1.0,
+        support: Optional[Sequence[int]] = None,
+    ) -> None:
+        """Initialize a PauliString.
+
+        Args:
+            spec: String specifier of the PauliString. Should only contain
+                characters 'I', 'X', 'Y', and 'Z'.
+            coeff: Coefficient of the PauliString.
+            support: Qubits the ``spec`` acts on, if provided.
+
+        Examples:
+            >>> PauliString(spec="IXY")  # X(1)*Y(2)
+            >>> PauliString(spec="ZZ", coeff=-0.5)  # -0.5*Z(0)*Z(1)
+            >>> PauliString(spec="XZ", support=(10, 17))  # X(10)*Z(17)
+        """
+        if not set(spec).issubset(set(self._string_to_gate_map.keys())):
+            raise ValueError(
+                f"One or more invalid characters in spec {spec}. Valid "
+                f"characters are 'I', 'X', 'Y', and 'Z', and the spec should "
+                f"not contain any spaces."
+            )
+        if support is not None:
+            if len(support) != len(spec):
+                raise ValueError(
+                    f"The spec has {len(spec)} Pauli's but the support has "
+                    f"{len(support)} qubits. These numbers must be equal."
+                )
+        else:
+            support = range(len(spec))
+
+        self._pauli = cirq.PauliString(
+            coeff,
+            (
+                self._string_to_gate_map[s].on(cirq.LineQubit(i))
+                for (i, s) in zip(support, spec)
+            ),
+        )
+
+    def matrix(self) -> np.ndarray:
+        """Returns the (potentially very large) matrix of the PauliString."""
+        return self._pauli.matrix()
+
+    def measure_in(self, circuit: QPROGRAM) -> QPROGRAM:
+        @atomic_converter
+        def _measure_in(circuit: cirq.Circuit, pauli: cirq.PauliString):
+            # Transform circuit to canonical qubit layout.
+            qubit_map = dict(
+                zip(
+                    sorted(circuit.all_qubits()),
+                    cirq.LineQubit.range(len(circuit.all_qubits())),
+                )
+            )
+            circuit = circuit.transform_qubits(lambda q: qubit_map[q])
+
+            # Measure the Paulis.
+            if not set(pauli).issubset(set(circuit.all_qubits())):
+                raise ValueError(
+                    f"Qubit mismatch. The PauliString {self} acts on qubits "
+                    f"{[q.x for q in pauli.qubits]} but the circuit has qubit "
+                    f"indices {sorted([q.x for q in circuit.all_qubits()])}."
+                )
+            measured = (
+                circuit + pauli.to_z_basis_ops() + cirq.measure(*pauli.qubits)
+            )
+
+            # Transform circuit back to original qubits.
+            reverse_qubit_map = dict(zip(qubit_map.values(), qubit_map.keys()))
+            return measured.transform_qubits(lambda q: reverse_qubit_map[q])
+
+        return _measure_in(circuit, self._pauli)
+
+    def can_be_measured_with(self, other: "PauliString") -> bool:
+        """Returns True if the expectation value of the PauliString can be
+        simultaneously estimated with `other` via single-qubit measurements.
+
+        Args:
+            other: The PauliString to check simultaneous measurement with.
+        """
+        overlap = set(self._pauli.qubits).intersection(
+            set(other._pauli.qubits)
+        )
+        for qubit in overlap:
+            if cirq.I in (self._pauli.get(qubit), other._pauli.get(qubit)):
+                continue
+            if self._pauli.get(qubit) != other._pauli.get(qubit):
+                return False
+        return True
+
+    def weight(self) -> int:
+        """Returns the weight of the PauliString, i.e., the number of
+        non-identity terms in the PauliString.
+        """
+        return sum(gate != cirq.I for gate in self._pauli.values())
+
+    def __str__(self) -> str:
+        return str(self._pauli)

--- a/mitiq/observable/tests/test_pauli.py
+++ b/mitiq/observable/tests/test_pauli.py
@@ -1,0 +1,137 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import pytest
+
+import numpy as np
+import cirq
+
+from mitiq.observable import PauliString
+from mitiq import mitiq_qiskit, mitiq_pyquil
+from mitiq.utils import _equal
+
+
+def test_pauli_init():
+    pauli = PauliString(spec="IZXYI", coeff=1.0)
+    a, b, c = cirq.LineQubit.range(1, 4)
+    assert pauli._pauli == cirq.PauliString(
+        1.0, cirq.Z(a), cirq.X(b), cirq.Y(c)
+    )
+    assert str(pauli) == "Z(1)*X(2)*Y(3)"
+
+
+def test_pauli_init_with_support():
+    support = (2, 37)
+    pauli = PauliString(spec="XZ", support=support)
+
+    assert pauli._pauli == cirq.PauliString(
+        cirq.X(cirq.LineQubit(support[0])), cirq.Z(cirq.LineQubit(support[1]))
+    )
+    assert str(pauli) == f"X({support[0]})*Z({support[1]})"
+
+
+def test_matrix():
+    xmat = cirq.unitary(cirq.X)
+    zmat = cirq.unitary(cirq.Z)
+
+    assert np.allclose(PauliString(spec="X").matrix(), xmat)
+    assert np.allclose(PauliString(spec="Z", coeff=-0.5).matrix(), -0.5 * zmat)
+    assert np.allclose(PauliString(spec="ZZ").matrix(), np.kron(zmat, zmat))
+    assert np.allclose(PauliString(spec="XZ").matrix(), np.kron(xmat, zmat))
+
+
+@pytest.mark.parametrize("support", [range(3), range(1, 4)])
+@pytest.mark.parametrize("circuit_type", ("cirq", "qiskit", "pyquil"))
+def test_pauli_measure_in_circuit(support, circuit_type):
+    pauli = PauliString(spec="XYZ", support=support, coeff=-0.5)
+
+    names = ("0th", "1st", "2nd", "3rd", "4th", "5th")
+    qreg = [cirq.NamedQubit(name) for name in names]
+    base_circuit = cirq.Circuit(cirq.H.on_each(qreg))
+
+    if circuit_type == "cirq":
+        convert = lambda circ: circ
+    elif circuit_type == "qiskit":
+        convert = mitiq_qiskit.to_qiskit
+    elif circuit_type == "pyquil":
+        convert = mitiq_pyquil.to_pyquil
+
+    circuit = convert(base_circuit)
+    measured = pauli.measure_in(circuit)
+
+    qreg = [cirq.NamedQubit(name) for name in names]
+    expected = cirq.Circuit(
+        # Original circuit.
+        base_circuit.all_operations(),
+        # Basis rotations.
+        cirq.SingleQubitCliffordGate.Y_nsqrt.on(qreg[support[0]]),
+        cirq.SingleQubitCliffordGate.X_sqrt.on(qreg[support[1]]),
+        cirq.SingleQubitCliffordGate.I.on(qreg[support[2]]),
+        # Measurements.
+        cirq.measure(*[qreg[s] for s in support]),
+    )
+    if circuit_type == "cirq":
+        assert _equal(measured, expected, require_qubit_equality=True)
+    else:
+        assert measured == convert(expected)
+
+
+def test_pauli_measure_in_bad_qubits_error():
+    n = 5
+    pauli = PauliString(spec="X" * n)
+    circuit = cirq.Circuit(cirq.H.on_each(cirq.LineQubit.range(n - 1)))
+
+    with pytest.raises(ValueError, match="Qubit mismatch."):
+        pauli.measure_in(circuit)
+
+
+def test_can_be_measured_with_single_qubit():
+    pauli = PauliString(spec="Z")
+
+    assert pauli.can_be_measured_with(PauliString(spec="I"))
+    assert not pauli.can_be_measured_with(PauliString(spec="X"))
+    assert not pauli.can_be_measured_with(PauliString(spec="Y"))
+    assert pauli.can_be_measured_with(PauliString(spec="Z", coeff=-0.5))
+    assert pauli.can_be_measured_with(pauli)
+
+
+def test_can_be_measured_with_two_qubits():
+    pauli = PauliString(spec="ZX")
+
+    assert pauli.can_be_measured_with(PauliString(spec="Z"))
+    assert pauli.can_be_measured_with(PauliString(spec="X", support=(1,)))
+    assert not pauli.can_be_measured_with(PauliString(spec="X"))
+    assert not pauli.can_be_measured_with(PauliString(spec="Y", coeff=-1.0))
+
+    assert pauli.can_be_measured_with(PauliString(spec="ZX", coeff=0.5))
+    assert not pauli.can_be_measured_with(PauliString(spec="ZZ"))
+
+
+def test_can_be_measured_with_non_overlapping_paulis():
+    pauli = PauliString(spec="ZX")
+
+    assert pauli.can_be_measured_with(PauliString(spec="IIZI"))
+    assert pauli.can_be_measured_with(PauliString(spec="IIIX"))
+    assert pauli.can_be_measured_with(PauliString(spec="IIYZ"))
+
+
+def test_weight():
+    assert PauliString(spec="I").weight() == 0
+    assert PauliString(spec="Z").weight() == 1
+
+    n = 4
+    assert PauliString(spec="X" * n).weight() == n
+    assert PauliString(spec="IX" * n).weight() == n
+    assert PauliString(spec="ZX" * n).weight() == 2 * n

--- a/mitiq/observable/tests/test_pauli.py
+++ b/mitiq/observable/tests/test_pauli.py
@@ -62,8 +62,10 @@ def test_pauli_measure_in_circuit(support, circuit_type):
     base_circuit = cirq.Circuit(cirq.H.on_each(qreg))
 
     if circuit_type == "cirq":
+
         def convert(circ):
             return circ
+
     elif circuit_type == "qiskit":
         convert = mitiq_qiskit.to_qiskit
     elif circuit_type == "pyquil":

--- a/mitiq/observable/tests/test_pauli.py
+++ b/mitiq/observable/tests/test_pauli.py
@@ -62,7 +62,8 @@ def test_pauli_measure_in_circuit(support, circuit_type):
     base_circuit = cirq.Circuit(cirq.H.on_each(qreg))
 
     if circuit_type == "cirq":
-        convert = lambda circ: circ
+        def convert(circ):
+            return circ
     elif circuit_type == "qiskit":
         convert = mitiq_qiskit.to_qiskit
     elif circuit_type == "pyquil":

--- a/mitiq/tests/test_conversions.py
+++ b/mitiq/tests/test_conversions.py
@@ -23,7 +23,7 @@ import qiskit
 from mitiq.conversions import (
     convert_to_mitiq,
     convert_from_mitiq,
-    converter,
+    noise_scaling_converter,
     UnsupportedCircuitError,
 )
 from mitiq.utils import _equal
@@ -46,7 +46,7 @@ pyquil_circuit = Program(gates.H(0), gates.CNOT(0, 1))
 circuit_types = {"qiskit": qiskit.QuantumCircuit, "pyquil": Program}
 
 
-@converter
+@noise_scaling_converter
 def scaling_function(circ: cirq.Circuit, *args, **kwargs) -> cirq.Circuit:
     return circ
 

--- a/mitiq/zne/scaling/folding.py
+++ b/mitiq/zne/scaling/folding.py
@@ -31,7 +31,7 @@ import numpy as np
 from cirq import Circuit, InsertStrategy, inverse, ops, has_unitary
 
 from mitiq._typing import QPROGRAM
-from mitiq.conversions import converter
+from mitiq.conversions import noise_scaling_converter
 
 
 class UnfoldableGateError(Exception):
@@ -289,7 +289,7 @@ def _get_num_to_fold(scale_factor: float, ngates: int) -> int:
 
 
 # Local folding functions
-@converter
+@noise_scaling_converter
 def fold_gates_from_left(
     circuit: QPROGRAM, scale_factor: float, **kwargs: Any
 ) -> QPROGRAM:
@@ -412,7 +412,7 @@ def fold_gates_from_left(
     return folded
 
 
-@converter
+@noise_scaling_converter
 def fold_gates_from_right(
     circuit: QPROGRAM, scale_factor: float, **kwargs: Any
 ) -> Circuit:
@@ -529,7 +529,7 @@ def _update_moment_indices(
     return moment_indices
 
 
-@converter
+@noise_scaling_converter
 def fold_gates_at_random(
     circuit: QPROGRAM,
     scale_factor: float,
@@ -763,7 +763,7 @@ def _fold_local(
 
 
 # Global folding function
-@converter
+@noise_scaling_converter
 def fold_global(
     circuit: QPROGRAM, scale_factor: float, **kwargs: Any
 ) -> QPROGRAM:

--- a/mitiq/zne/scaling/parameter.py
+++ b/mitiq/zne/scaling/parameter.py
@@ -30,7 +30,7 @@ from cirq import (
     Gate,
     Qid,
 )
-from mitiq.conversions import converter
+from mitiq.conversions import noise_scaling_converter
 
 
 class GateTypeException(Exception):
@@ -113,7 +113,7 @@ def _parameter_calibration(
     return sigma
 
 
-@converter
+@noise_scaling_converter
 def scale_parameters(
     circ: Circuit,
     scale_factor: float,


### PR DESCRIPTION
Description
-----------

Part of #623. This is a thin wrapper for `cirq.PauliString` with appropriate I/O for us.

Checklist
-----------

Check off the following once complete (or if not applicable). The PR will be reviewed once this
checklist is complete and all tests are passing.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] I updated the [changelog](https://github.com/unitaryfund/mitiq/blob/master/CHANGELOG.md) including author and PR number (@username, gh-xxx)

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:
  1. Run `make check-style` (from the root directory
  of the repository) and fix any [flake8](http://flake8.pycqa.org) errors.
  2. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html)
  autoformatter.
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.