### PR TITLE
Fixed typo in Getting Started Guide

### DIFF
--- a/docs/source/guide/guide-getting-started.rst
+++ b/docs/source/guide/guide-getting-started.rst
@@ -141,7 +141,7 @@ It is easy to try different ones.
 
     Mitigated error with linear ZNE: 0.00769
 
-You can use bult-in methods from factories like :meth:`~mitiq.zne.inference.Factory.plot_data`
+You can use built-in methods from factories like :meth:`~mitiq.zne.inference.Factory.plot_data`
 and :meth:`~mitiq.zne.inference.Factory.plot_fit` to plot the noise scale factors v. the expectation
 value returned by the executor.
 


### PR DESCRIPTION
Fixed simple typo.

Description
-----------
I just fixed a typo in the Getting Started docs. "bult in" -> "built-in"


Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [N/A] I added unit tests for new code.
- [N/A] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [N/A] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [N/A] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:
  1. Run `make check-style` (from the root directory of the repository) and fix any [flake8](http://flake8.pycqa.org) errors.
  2. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
