### PR TITLE
Fixed error in random_circuits benchmark

### DIFF
--- a/mitiq/benchmarks/random_circuits.py
+++ b/mitiq/benchmarks/random_circuits.py
@@ -20,7 +20,7 @@ import numpy as np
 from cirq.testing import random_circuit
 from cirq import NamedQubit, Circuit
 
-from mitiq import execute_with_zne
+from mitiq.zne import execute_with_zne
 from mitiq._typing import QPROGRAM
 from mitiq.zne.inference import Factory
 from mitiq.zne.scaling import fold_gates_at_random


### PR DESCRIPTION
Fixed import statement to fix error in testing

Description
-----------
While writing tests for issue 638, I realized I kept getting 1 error unrelated to what I was doing when I ran "make test". I corrected an import statement and that resolved the test error.

I didn't run any of the checklist items, because the edit was so minor, nor did I open an issue because the fix was so simple.


Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [ N/A ] I added unit tests for new code.
- [ N/A ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ N/A ] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [ N/A ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-style` (from the root directory
  of the repository) and fix any [flake8](http://flake8.pycqa.org) errors.

    2. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html)
  autoformatter.

  For more information, check the [style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines) for Mitiq.
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
