### PR TITLE
CDR Clifford gate fix

### DIFF
--- a/mitiq/cdr/clifford_training_data.py
+++ b/mitiq/cdr/clifford_training_data.py
@@ -76,7 +76,11 @@ def generate_training_circuits(
     # Find the non-Clifford operations in the circuit.
     operations = np.array(list(circuit.all_operations()))
     non_clifford_indices_and_ops = np.array(
-        [[i, op] for i, op in enumerate(operations) if not _is_clifford(op)]
+        [
+            [i, op]
+            for i, op in enumerate(operations)
+            if not cirq.protocols.has_stabilizer_effect(op)
+        ]
     )
     if len(non_clifford_indices_and_ops) == 0:
         raise ValueError("Circuit is already Clifford.")
@@ -113,7 +117,10 @@ def is_clifford(op_like: cirq.ops.OP_TREE) -> bool:
     except TypeError:
         raise ValueError("Could not convert `op_like` to a circuit.")
 
-    return all(_is_clifford(op) for op in circuit.all_operations())
+    return all(
+        cirq.protocols.has_stabilizer_effect(op)
+        for op in circuit.all_operations()
+    )
 
 
 # TODO: Accept any QPROGRAM.
@@ -124,7 +131,10 @@ def count_non_cliffords(circuit: Circuit) -> int:
     Args:
         circuit: Circuit to count the number of non-Clifford operations in.
     """
-    return sum(not _is_clifford(op) for op in circuit.all_operations())
+    return sum(
+        not cirq.protocols.has_stabilizer_effect(op)
+        for op in circuit.all_operations()
+    )
 
 
 def _map_to_near_clifford(
@@ -407,21 +417,3 @@ def _probabilistic_angle_to_clifford(
         _CLIFFORD_ANGLES, 1, replace=False, p=np.array(dists) / np.sum(dists)
     )
     return cliff_ang
-
-
-def _is_clifford(op: cirq.ops.Operation) -> bool:
-    if isinstance(op.gate, cirq.ops.XPowGate):
-        return True
-    if isinstance(op.gate, cirq.ops.CNotPowGate) and op.gate.exponent == 1.0:
-        return True
-    if (
-        isinstance(op.gate, cirq.ops.ZPowGate)
-        and op.gate.exponent % 2 in _CLIFFORD_EXPONENTS
-    ):
-        return True
-
-    # Ignore measurements.
-    if isinstance(op.gate, cirq.ops.MeasurementGate):
-        return True
-    # TODO: Could add additional logic here.
-    return False

--- a/mitiq/cdr/test_clifford_training_data.py
+++ b/mitiq/cdr/test_clifford_training_data.py
@@ -208,7 +208,6 @@ def test_count_non_cliffords():
         cirq.ops.rz(0.4 * np.pi).on(b),  # Non-Clifford.
         cirq.ops.rz(0.5 * np.pi).on(b),  # Clifford.
         cirq.ops.CNOT.on(a, b),  # Clifford.
-        cirq.ops.rx(0.5 * np.pi).on(b),  # Clifford.
     )
 
     assert count_non_cliffords(circuit) == 2

--- a/mitiq/cdr/test_clifford_training_data.py
+++ b/mitiq/cdr/test_clifford_training_data.py
@@ -22,6 +22,7 @@ from cirq.circuits import Circuit
 
 from mitiq.cdr.clifford_training_data import (
     _is_clifford_angle,
+    _is_clifford,
     is_clifford,
     _map_to_near_clifford,
     _select,
@@ -102,7 +103,7 @@ def test_replace(method):
     )
 
     assert len(new_ops) == len(ops)
-    assert all(cirq.protocols.has_stabilizer_effect(op) for op in new_ops)
+    assert all(_is_clifford(op) for op in new_ops)
 
 
 def test_map_to_near_clifford():
@@ -202,9 +203,12 @@ def test_count_non_cliffords():
     a, b = cirq.LineQubit.range(2)
     circuit = Circuit(
         cirq.ops.rz(0.0).on(a),  # Clifford.
-        cirq.ops.rx(0.1).on(b),  # Non-Clifford.
-        cirq.ops.rz(0.4).on(b),  # Non-Clifford.
+        cirq.ops.rx(0.1 * np.pi).on(b),  # Non-Clifford.
+        cirq.ops.rx(0.5 * np.pi).on(b),  # Clifford
+        cirq.ops.rz(0.4 * np.pi).on(b),  # Non-Clifford.
+        cirq.ops.rz(0.5 * np.pi).on(b),  # Clifford.
         cirq.ops.CNOT.on(a, b),  # Clifford.
+        cirq.ops.rx(0.5 * np.pi).on(b),  # Clifford.
     )
 
     assert count_non_cliffords(circuit) == 2

--- a/mitiq/cdr/test_clifford_training_data.py
+++ b/mitiq/cdr/test_clifford_training_data.py
@@ -22,7 +22,6 @@ from cirq.circuits import Circuit
 
 from mitiq.cdr.clifford_training_data import (
     _is_clifford_angle,
-    _is_clifford,
     is_clifford,
     _map_to_near_clifford,
     _select,
@@ -103,7 +102,7 @@ def test_replace(method):
     )
 
     assert len(new_ops) == len(ops)
-    assert all(_is_clifford(op) for op in new_ops)
+    assert all(cirq.protocols.has_stabilizer_effect(op) for op in new_ops)
 
 
 def test_map_to_near_clifford():
@@ -203,12 +202,12 @@ def test_count_non_cliffords():
     a, b = cirq.LineQubit.range(2)
     circuit = Circuit(
         cirq.ops.rz(0.0).on(a),  # Clifford.
-        cirq.ops.rx(0.1).on(b),  # Clifford.
+        cirq.ops.rx(0.1).on(b),  # Non-Clifford.
         cirq.ops.rz(0.4).on(b),  # Non-Clifford.
         cirq.ops.CNOT.on(a, b),  # Clifford.
     )
 
-    assert count_non_cliffords(circuit) == 1
+    assert count_non_cliffords(circuit) == 2
 
 
 def test_count_non_cliffords_empty_circuit():


### PR DESCRIPTION
Description
-----------
Made a simple change to the `_is_clifford` function so that Rx(m*pi/2) are identified as Clifford gates, where m is some integer. 



Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-style` (from the root directory
  of the repository) and fix any [flake8](http://flake8.pycqa.org) errors.

    2. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html)
  autoformatter.

  For more information, check the [style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines) for Mitiq.
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
