### PR TITLE
Fix docs build

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,12 +20,10 @@ Tips
 
 - If the validation check fails:
 
-    1. Run `make check-style` (from the root directory
-  of the repository) and fix any [flake8](http://flake8.pycqa.org) errors.
+    1. Run `make check-style` (from the root directory of the repository) and fix any [flake8](http://flake8.pycqa.org) errors.
 
-    2. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html)
-  autoformatter.
+    2. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.
 
-  For more information, check the [style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines) for Mitiq.
+  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
   
 - Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -11,8 +11,8 @@ flake8~=3.7.9
 black~=19.10b0
 
 # Documentation and examples.
-sphinxcontrib-bibtex
-sphinx-copybutton
-sphinx-autodoc-typehints
-myst-nb
-pydata-sphinx-theme
+sphinxcontrib-bibtex~=2.2.0
+sphinx-copybutton~=0.3.0
+sphinx-autodoc-typehints~=1.12.0
+myst-nb~=0.12.3
+pydata-sphinx-theme~=0.6.3

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -11,13 +11,8 @@ flake8~=3.7.9
 black~=19.10b0
 
 # Documentation and examples.
-sphinx~=3.5.3
-docutils==0.16
-sphinxcontrib-bibtex~=1.0.0
-sphinx-copybutton~=0.2.11
-sphinx-autodoc-typehints~=1.10.3
-myst-nb~=0.11.1
-myst-parser~=0.13.3
-pybtex~=0.22.2
-pydata-sphinx-theme~=0.3.1
-notebook~=6.1.5
+sphinxcontrib-bibtex
+sphinx-copybutton
+sphinx-autodoc-typehints
+myst-nb
+pydata-sphinx-theme

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,4 +17,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -W
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -W --keep-going

--- a/mitiq/zne/scaling/folding.py
+++ b/mitiq/zne/scaling/folding.py
@@ -401,7 +401,7 @@ def _create_fold_mask(
     total weight of the input circuit.
 
     For equal weights, this function reproduces the local unitary folding
-    method defined in equation (5) of [Giurgica_Tiron_2020_arXiv]_.
+    method defined in equation (5) of :cite:`Giurgica_Tiron_2020_arXiv`.
 
     Args:
         weight_mask: The weights of all the gates of the circuit to fold.
@@ -410,8 +410,8 @@ def _create_fold_mask(
         scale_factor: The effective noise scale factor.
         folding_method: A string equal to "at_random", or "from_left", or
             "from_right". Determines the partial folding method described in
-            [Giurgica_Tiron_2020_arXiv]_. If scale_factor is an odd integer,
-            all methods are equivalent and this option is irrelevant.
+            :cite:`Giurgica_Tiron_2020_arXiv`. If scale_factor is an odd
+            integer, all methods are equivalent and this option is irrelevant.
         seed: A seed for the random number generator. This is used only when
             folding_method is "at_random".
 
@@ -559,7 +559,8 @@ def fold_gates_from_left(
     scale_factor * n where n is the number of gates in the input circuit.
 
     For equal gate fidelities, this function reproduces the local unitary
-    folding method defined in equation (5) of [Giurgica_Tiron_2020_arXiv]_.
+    folding method defined in equation (5) of
+    :cite:`Giurgica_Tiron_2020_arXiv`.
 
     Args:
         circuit: Circuit to fold.
@@ -635,7 +636,8 @@ def fold_gates_from_right(
     scale_factor * n where n is the number of gates in the input circuit.
 
     For equal gate fidelities, this function reproduces the local unitary
-    folding method defined in equation (5) of [Giurgica_Tiron_2020_arXiv]_.
+    folding method defined in equation (5) of
+    :cite:`Giurgica_Tiron_2020_arXiv`.
 
     Args:
         circuit: Circuit to fold.
@@ -714,7 +716,8 @@ def fold_gates_at_random(
     scale_factor * n where n is the number of gates in the input circuit.
 
     For equal gate fidelities, this function reproduces the local unitary
-    folding method defined in equation (5) of [Giurgica_Tiron_2020_arXiv]_.
+    folding method defined in equation (5) of
+    :cite:`Giurgica_Tiron_2020_arXiv`.
 
     Args:
         circuit: Circuit to fold.


### PR DESCRIPTION
Description
-----------

There's some deprecation warnings from Sphinx causing the docs build to fail. See [this action](https://github.com/unitaryfund/mitiq/pull/671/checks?check_run_id=2563234172), excerpt below.

```python
/opt/hostedtoolcache/Python/3.8.10/x64/lib/python3.8/site-packages/sphinx_autodoc_typehints.py:161: RemovedInSphinx40Warning: sphinx.util.inspect.Signature() is deprecated
```

Also formats the PR template.

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-style` (from the root directory
  of the repository) and fix any [flake8](http://flake8.pycqa.org) errors.

    2. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html)
  autoformatter.

  For more information, check the [style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines) for Mitiq.
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
