### PR TITLE
Specify qiskit elements in output of about.py

### DIFF
--- a/mitiq/_about.py
+++ b/mitiq/_about.py
@@ -44,6 +44,9 @@ def about() -> None:
         from qiskit import __qiskit_version__  # pragma: no cover
 
         qiskit_version = __qiskit_version__["qiskit"]  # pragma: no cover
+        terra_version = __qiskit_version__['qiskit-terra']
+        aer_version = __qiskit_version__["qiskit-aer"]
+        ibmq_provider_version=__qiskit_version__["qiskit-ibmq-provider"]
     except ImportError:
         qiskit_version = "Not installed"
 
@@ -63,7 +66,10 @@ SciPy Version:\t{scipy_version}
 Optional Dependencies
 ---------------------
 PyQuil Version:\t{pyquil_version}
-Qiskit Version:\t{qiskit_version}
+Qiskit Elements:
+    Terra : {terra_version}
+    Aer : {aer_version}
+    IBMQ-Provider : {ibmq_provider_version}
 
 Python Version:\t{PYTHON_VERSION[0]}.{PYTHON_VERSION[1]}.{PYTHON_VERSION[2]}
 Platform Info:\t{platform.system()} ({platform.machine()})"""

--- a/mitiq/_about.py
+++ b/mitiq/_about.py
@@ -44,9 +44,11 @@ def about() -> None:
         from qiskit import __qiskit_version__  # pragma: no cover
 
         qiskit_version = __qiskit_version__["qiskit"]  # pragma: no cover
-        terra_version = __qiskit_version__["qiskit-terra"]
-        aer_version = __qiskit_version__["qiskit-aer"]
-        ibmq_provider_version = __qiskit_version__["qiskit-ibmq-provider"]
+        terra_version = __qiskit_version__["qiskit-terra"]  # pragma: no cover
+        aer_version = __qiskit_version__["qiskit-aer"]  # pragma: no cover
+        ibmq_provider_version = __qiskit_version__[
+            "qiskit-ibmq-provider"
+        ]  # pragma: no cover
     except ImportError:
         qiskit_version = "Not installed"
 
@@ -66,10 +68,11 @@ SciPy Version:\t{scipy_version}
 Optional Dependencies
 ---------------------
 PyQuil Version:\t{pyquil_version}
-Qiskit Elements:
-    Terra : {terra_version}
-    Aer : {aer_version}
-    IBMQ-Provider : {ibmq_provider_version}
+Qiskit Version: {qiskit_version}
+    Qiskit Elements:
+        Terra : {terra_version}
+        Aer : {aer_version}
+        IBMQ-Provider : {ibmq_provider_version}
 
 Python Version:\t{PYTHON_VERSION[0]}.{PYTHON_VERSION[1]}.{PYTHON_VERSION[2]}
 Platform Info:\t{platform.system()} ({platform.machine()})"""

--- a/mitiq/_about.py
+++ b/mitiq/_about.py
@@ -44,9 +44,9 @@ def about() -> None:
         from qiskit import __qiskit_version__  # pragma: no cover
 
         qiskit_version = __qiskit_version__["qiskit"]  # pragma: no cover
-        terra_version = __qiskit_version__['qiskit-terra']
+        terra_version = __qiskit_version__["qiskit-terra"]
         aer_version = __qiskit_version__["qiskit-aer"]
-        ibmq_provider_version=__qiskit_version__["qiskit-ibmq-provider"]
+        ibmq_provider_version = __qiskit_version__["qiskit-ibmq-provider"]
     except ImportError:
         qiskit_version = "Not installed"
 


### PR DESCRIPTION
Description
-----------
Instead of full `qiskit` version in `Optional Dependencies`, versions of terra, aer and ibmq-provider are output for `mitiq.about()`. 

Not sure if the version of full `qiskit` package should be still included or not.

```
Mitiq: A Python toolkit for implementing error mitigation on quantum computers
==============================================================================
Authored by: Mitiq team, 2020 & later (https://github.com/unitaryfund/mitiq)

Mitiq Version:  0.9.0dev

Core Dependencies

-----------------
Cirq Version:   0.10.0
NumPy Version:  1.20.2
SciPy Version:  1.4.1

Optional Dependencies
---------------------
PyQuil Version: 2.28.0
Qiskit Version: 0.24.1
    Qiskit Elements:
        Terra : 0.16.4
        Aer : 0.7.6
        IBMQ-Provider : 0.12.2

Python Version: 3.8.5
Platform Info:  Linux (x86_64)
```