### PR TITLE
Improve conversion from braket to cirq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,18 @@ test:
 test-pyquil:
 	pytest -v --cov=mitiq --cov-report=term --cov-report=xml mitiq/mitiq_pyquil
 
+.PHONY: test-qiskit
+test-qiskit:
+	pytest -v --cov=mitiq --cov-report=term --cov-report=xml mitiq/mitiq_qiskit
+
+.PHONY: test-cirq
+test-cirq:
+	pytest -v --cov=mitiq --cov-report=term --cov-report=xml mitiq/mitiq_cirq
+
+.PHONY: test-braket
+test-braket:
+	pytest -v --cov=mitiq --cov-report=term --cov-report=xml mitiq/mitiq_braket
+
 .PHONY: test-all
 test-all:
 	pytest -n auto -v --cov=mitiq --cov-report=term --cov-report=xml

--- a/mitiq/mitiq_braket/conversions.py
+++ b/mitiq/mitiq_braket/conversions.py
@@ -88,14 +88,12 @@ def _translate_braket_instruction_to_cirq_operation(
             return [cirq_ops.TOFFOLI.on(*qubits)]
         elif isinstance(instr.operator, braket_gates.CSwap):
             return [cirq_ops.FREDKIN.on(*qubits)]
+        else:
+            _raise_braket_to_cirq_error(instr)
 
     # Unknown instructions.
     else:
-        raise ValueError(
-            f"Unable to convert the instruction {instr} to Cirq. If you think "
-            "this is a bug, you can open an issue on the Mitiq GitHub at "
-            "https://github.com/unitaryfund/mitiq."
-        )
+        _raise_braket_to_cirq_error(instr)
 
 
 def _translate_cirq_operation_to_braket_instruction(
@@ -125,14 +123,11 @@ def _translate_cirq_operation_to_braket_instruction(
             return [Instruction(braket_gates.CCNot(), qubits)]
         elif isinstance(op.gate, cirq_ops.FREDKIN):
             return [Instruction(braket_gates.CSwap(), qubits)]
-
+        else:
+            _raise_cirq_to_braket_error(op)
     # Unsupported gates.
     else:
-        raise ValueError(
-            f"Unable to convert {op} to Braket. If you think this is a bug, "
-            "you can open an issue on the Mitiq GitHub at"
-            " https://github.com/unitaryfund/mitiq."
-        )
+        _raise_cirq_to_braket_error(op)
 
 
 def _translate_one_qubit_braket_instruction_to_cirq_operation(
@@ -184,11 +179,7 @@ def _translate_one_qubit_braket_instruction_to_cirq_operation(
         return [cirq_ops.Z.on(*qubits) ** (gate.angle / np.pi)]
 
     else:
-        raise ValueError(
-            f"Unable to convert the instruction {instr} to Cirq. If you think "
-            "this is a bug, you can open an issue on the Mitiq GitHub at "
-            "https://github.com/unitaryfund/mitiq."
-        )
+        _raise_braket_to_cirq_error(instr)
 
 
 def _translate_two_qubit_braket_instruction_to_cirq_operation(
@@ -269,11 +260,7 @@ def _translate_two_qubit_braket_instruction_to_cirq_operation(
         return [cirq_ops.ISwapPowGate(exponent=gate.angle / np.pi).on(*qubits)]
 
     else:
-        raise ValueError(
-            f"Unable to convert the instruction {instr} to Cirq. If you think "
-            "this is a bug, you can open an issue on the Mitiq GitHub at "
-            "https://github.com/unitaryfund/mitiq."
-        )
+        _raise_braket_to_cirq_error(instr)
 
 
 def _translate_one_qubit_cirq_operation_to_braket_instruction(
@@ -438,3 +425,18 @@ def _translate_two_qubit_cirq_operation_to_braket_instruction(
         *_translate_one_qubit_cirq_operation_to_braket_instruction(B1, q1),
         *_translate_one_qubit_cirq_operation_to_braket_instruction(B2, q2),
     ]
+
+def _raise_braket_to_cirq_error(instr):
+    raise ValueError(
+        f"Unable to convert the instruction {instr} to Cirq. If you think "
+        "this is a bug, you can open an issue on the Mitiq GitHub at "
+        "https://github.com/unitaryfund/mitiq."
+    )
+
+def _raise_cirq_to_braket_error(op):
+    raise ValueError(
+        f"Unable to convert {op} to Braket. If you think this is a bug, "
+        "you can open an issue on the Mitiq GitHub at"
+        " https://github.com/unitaryfund/mitiq."
+    )
+

--- a/mitiq/mitiq_braket/conversions.py
+++ b/mitiq/mitiq_braket/conversions.py
@@ -218,24 +218,27 @@ def _translate_two_qubit_braket_instruction_to_cirq_operation(
         return [cirq_ops.CZ.on(*qubits) ** (gate.angle / np.pi)]
     elif isinstance(gate, braket_gates.CPhaseShift00):
         return [
+            cirq_ops.XX(*qubits),
             cirq_ops.CZ.on(*qubits) ** (gate.angle / np.pi),
-            cirq_ops.XX.on(*qubits),
+            cirq_ops.XX(*qubits),
         ]
     elif isinstance(gate, braket_gates.CPhaseShift01):
         return [
+            cirq_ops.X(qubits[0]),
             cirq_ops.CZ.on(*qubits) ** (gate.angle / np.pi),
-            cirq_ops.X.on(qubits[0]),
+            cirq_ops.X(qubits[0]),
         ]
     elif isinstance(gate, braket_gates.CPhaseShift10):
         return [
+            cirq_ops.X(qubits[1]),
             cirq_ops.CZ.on(*qubits) ** (gate.angle / np.pi),
-            cirq_ops.X.on(qubits[1]),
+            cirq_ops.X(qubits[1]),
         ]
     elif isinstance(gate, braket_gates.PSwap):
         return [
             cirq_ops.SWAP.on(*qubits),
             cirq_ops.CNOT.on(*qubits),
-            cirq_ops.Z.on(*qubits) ** (gate.angle / np.pi),
+            cirq_ops.Z.on(qubits[1]) ** (gate.angle / np.pi),
             cirq_ops.CNOT.on(*qubits),
         ]
     elif isinstance(gate, braket_gates.XX):

--- a/mitiq/mitiq_braket/conversions.py
+++ b/mitiq/mitiq_braket/conversions.py
@@ -223,16 +223,30 @@ def _translate_two_qubit_braket_instruction_to_cirq_operation(
         ]
 
     # Two-qubit parameterized gates.
-    elif isinstance(gate, braket_gates.PSwap):
-        raise ValueError  # TODO.
     elif isinstance(gate, braket_gates.CPhaseShift):
         return [cirq_ops.CZ.on(*qubits) ** (gate.angle / np.pi)]
     elif isinstance(gate, braket_gates.CPhaseShift00):
-        raise ValueError  # TODO.
+        return [
+            cirq_ops.CZ.on(*qubits) ** (gate.angle / np.pi),
+            cirq_ops.XX.on(*qubits),
+        ]
     elif isinstance(gate, braket_gates.CPhaseShift01):
-        raise ValueError  # TODO.
+        return [
+            cirq_ops.CZ.on(*qubits) ** (gate.angle / np.pi),
+            cirq_ops.X.on(qubits[0]),
+        ]
     elif isinstance(gate, braket_gates.CPhaseShift10):
-        raise ValueError  # TODO.
+        return [
+            cirq_ops.CZ.on(*qubits) ** (gate.angle / np.pi),
+            cirq_ops.X.on(qubits[1]),
+        ]
+    elif isinstance(gate, braket_gates.PSwap):
+        return [
+            cirq_ops.SWAP.on(*qubits),
+            cirq_ops.CNOT.on(*qubits),
+            cirq_ops.Z.on(*qubits) ** (gate.angle / np.pi),
+            cirq_ops.CNOT.on(*qubits),
+        ]
     elif isinstance(gate, braket_gates.XX):
         return [
             cirq_ops.XXPowGate(
@@ -263,7 +277,8 @@ def _translate_two_qubit_braket_instruction_to_cirq_operation(
 
 
 def _translate_one_qubit_cirq_operation_to_braket_instruction(
-    op: Union[np.ndarray, "cirq.Operation"], target: Optional[int] = None,
+    op: Union[np.ndarray, "cirq.Operation"],
+    target: Optional[int] = None,
 ) -> List[Instruction]:
     """Translates a one-qubit Cirq operation to a (sequence of) Braket
     instruction(s) according to the following rules:

--- a/mitiq/mitiq_braket/tests/test_conversions_braket.py
+++ b/mitiq/mitiq_braket/tests/test_conversions_braket.py
@@ -140,10 +140,12 @@ def test_from_braket_non_parameterized_two_qubit_gates():
 
 
 def test_from_braket_parameterized_two_qubit_gates():
-    braket_circuit = BKCircuit()
-    # TODO: Add all two-qubit parameterized gates once translated.
     pgates = [
         braket_gates.CPhaseShift,
+        braket_gates.CPhaseShift00,
+        braket_gates.CPhaseShift01,
+        braket_gates.CPhaseShift10,
+        braket_gates.PSwap,
         braket_gates.XX,
         braket_gates.YY,
         braket_gates.ZZ,
@@ -153,15 +155,18 @@ def test_from_braket_parameterized_two_qubit_gates():
     instructions = [
         Instruction(rot(a), target=[0, 1]) for rot, a in zip(pgates, angles)
     ]
+
+    cirq_circuits = list()
     for instr in instructions:
+        braket_circuit = BKCircuit()
         braket_circuit.add_instruction(instr)
-    cirq_circuit = from_braket(braket_circuit)
+        cirq_circuits.append(from_braket(braket_circuit))
 
-    for i, op in enumerate(cirq_circuit.all_operations()):
+    for instr, cirq_circuit in zip(instructions, cirq_circuits):
+        print(cirq_circuit.unitary())
         assert np.allclose(
-            instructions[i].operator.to_matrix(), protocols.unitary(op)
+            instr.operator.to_matrix(), cirq_circuit.unitary()
         )
-
 
 def test_from_braket_three_qubit_gates():
     braket_circuit = BKCircuit()


### PR DESCRIPTION
This add conversions for some parametric 2-qubit gates related to #679.

- I added an item to the MakeFile (test-braket)
- I updated the conversion tests to take into account the decomposition into multiple gates.
- I implemented the missing conversions.
- I fixed a bug where the main functions where not raising any error in the case of a non-supported 3-qubit instruction.
