### PR TITLE
[unitaryHack] Add instructions to solve make docs error for Windows/3.8 users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ development of the library, from your local clone of the fork, run
 #### Special Note for Windows Users Using Python 3.8:
 To prevent errors when running `make docs` and `make doctest`, Windows developers using Pythong 3.8 will also need to edit \_\_init\_\_.py in their environment's asyncio directory.
 This is due to `asyncio` changing their default event loop beginning in Python 3.8, and the default event loop will not support Unix-style APIs used by some dependencies.
-1. Locate your environment directory (likely C:\Users\{username}\anaconda3\envs\{your_env}), and open {env_dir}/Lib/asyncio/\_\_init\_\_.py.
+1. Locate your environment directory (likely C:\Users\{username}\anaconda3\envs\\{your_env}), and open {env_dir}/Lib/asyncio/\_\_init\_\_.py.
 2. Add `import asyncio` to the file's import statements.
 3. Find the block of code below and replace it with the provided replacement.
     * Original Code  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,11 @@ This is due to `asyncio` changing their default event loop beginning in Python 3
     * Original Code  
 
           if sys.platform == 'win32':  # pragma: no cover
-            from .windows_events import *
-            __all__ += windows_events.__all__
+              from .windows_events import *
+              __all__ += windows_events.__all__
+          else:
+              from .unix_events import *  # pragma: no cover
+              __all__ += unix_events.__all__
   
     * Replacement Code  
 
@@ -64,6 +67,9 @@ This is due to `asyncio` changing their default event loop beginning in Python 3
               from .windows_events import *
               asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
               __all__ += windows_events.__all__
+          else:
+              from .unix_events import *  # pragma: no cover
+              __all__ += unix_events.__all__
   
 
 ### Adding tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,9 @@ development of the library, from your local clone of the fork, run
 ```
 
 #### Special Note for Windows Users Using Python 3.8:
-To prevent errors when running `make docs` and `make doctest`, Windows developers using Pythong 3.8 will also need to edit `__init__.py` in their environment's `asyncio` directory.
+To prevent errors when running `make docs` and `make doctest`, Windows developers using Pythong 3.8 will also need to edit __init__.py in their environment's asyncio directory.
 This is due to `asyncio` changing their default event loop beginning in Python 3.8, and the default event loop will not support Unix-style APIs used by some dependencies.
-1. Locate your environment directory (likely `C:\Users\{username}\anaconda3\envs\{your_env}\`), and open `{env_dir}/Lib/asyncio/__init__.py`.
+1. Locate your environment directory (likely C:\Users\{username}\anaconda3\envs\{your_env}), and open {env_dir}/Lib/asyncio/__init__.py.
 2. Add `import asyncio` to the file's import statements.
 3. Find the block of code below and replace it with the provided replacement.
     * Original Code  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,26 @@ development of the library, from your local clone of the fork, run
 (myenv) pip install -r dev_requirements.txt
 ```
 
+#### Special Note for Windows Users Using Python 3.8:
+To prevent errors when running `make docs` and `make doctest`, Windows developers using Pythong 3.8 will also need to edit `__init__.py` in their environment's `asyncio` directory.
+This is due to `asyncio` changing their default event loop beginning in Python 3.8, and the default event loop will not support Unix-style APIs used by some dependencies.
+1. Locate your environment directory (likely `C:\Users\{username}\anaconda3\envs\{your_env}\`), and open `{env_dir}/Lib/asyncio/__init__.py`.
+2. Add `import asyncio` to the file's import statements.
+3. Find the block of code below and replace it with the provided replacement.
+    * Original Code  
+
+          if sys.platform == 'win32':  # pragma: no cover
+            from .windows_events import *
+            __all__ += windows_events.__all__
+  
+    * Replacement Code  
+
+          if sys.platform == 'win32':  # pragma: no cover
+              from .windows_events import *
+              asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+              __all__ += windows_events.__all__
+  
+
 ### Adding tests
 If you add new features to a function or class, it is required to add tests for such object. Mitiq uses a nested structure for packaging tests in directories named `tests` at the same level of each module.
 The only except to this is that any tests requiring a QVM should be placed in the mitiq_pyquil/tests folder.
@@ -91,7 +111,7 @@ docstrings with
 ```bash
 (myenv) make doctest
 ```
-
+You may need to run `make docs` before you are able to run `make doctest`. 
 
 ### Style Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ development of the library, from your local clone of the fork, run
 
 #### Special Note for Windows Users Using Python 3.8:
 To prevent errors when running `make docs` and `make doctest`, Windows developers using Pythong 3.8 will also need to edit \_\_init\_\_.py in their environment's asyncio directory.
-This is due to `asyncio` changing their default event loop beginning in Python 3.8, and the default event loop will not support Unix-style APIs used by some dependencies.
+This is due to asyncio changing their default event loop beginning in Python 3.8, and the default event loop will not support Unix-style APIs used by some dependencies.
 1. Locate your environment directory (likely C:\Users\{username}\anaconda3\envs\\{your_env}), and open {env_dir}/Lib/asyncio/\_\_init\_\_.py.
 2. Add `import asyncio` to the file's import statements.
 3. Find the block of code below and replace it with the provided replacement.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,10 @@ development of the library, from your local clone of the fork, run
 ```
 
 #### Special Note for Windows Users Using Python 3.8:
-To prevent errors when running `make docs` and `make doctest`, Windows developers using Pythong 3.8 will also need to edit \_\_init\_\_.py in their environment's asyncio directory.
-This is due to asyncio changing their default event loop beginning in Python 3.8, and the default event loop will not support Unix-style APIs used by some dependencies.
-1. Locate your environment directory (likely C:\Users\{username}\anaconda3\envs\\{your_env}), and open {env_dir}/Lib/asyncio/\_\_init\_\_.py.
+To prevent errors when running `make docs` and `make doctest`, Windows developers using Python 3.8 will also need to edit `__init__.py` in their environment's asyncio directory.
+This is due to Python changing `asyncio`'s [default event loop in Windows beginning in Python 3.8](https://docs.python.org/3/library/asyncio-policy.html#asyncio.DefaultEventLoopPolicy).
+The new default event loop will not support Unix-style APIs used by some dependencies.
+1. Locate your environment directory (likely `C:\Users\{username}\anaconda3\envs\{your_env}`), and open `{env_dir}/Lib/asyncio/__init__.py`.
 2. Add `import asyncio` to the file's import statements.
 3. Find the block of code below and replace it with the provided replacement.
     * Original Code  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,9 @@ development of the library, from your local clone of the fork, run
 ```
 
 #### Special Note for Windows Users Using Python 3.8:
-To prevent errors when running `make docs` and `make doctest`, Windows developers using Pythong 3.8 will also need to edit __init__.py in their environment's asyncio directory.
+To prevent errors when running `make docs` and `make doctest`, Windows developers using Pythong 3.8 will also need to edit \_\_init\_\_.py in their environment's asyncio directory.
 This is due to `asyncio` changing their default event loop beginning in Python 3.8, and the default event loop will not support Unix-style APIs used by some dependencies.
-1. Locate your environment directory (likely C:\Users\{username}\anaconda3\envs\{your_env}), and open {env_dir}/Lib/asyncio/__init__.py.
+1. Locate your environment directory (likely C:\Users\{username}\anaconda3\envs\{your_env}), and open {env_dir}/Lib/asyncio/\_\_init\_\_.py.
 2. Add `import asyncio` to the file's import statements.
 3. Find the block of code below and replace it with the provided replacement.
     * Original Code  


### PR DESCRIPTION
Description
-----------
Closes #689 

As described in the issue, Windows users need to edit a file in their asyncio environment which affects non-Unix-like systems running Python 3.8 or higher.

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [N/A] I added unit tests for new code.
- [N/A] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [N/A] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [X] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-style` (from the root directory of the repository) and fix any [flake8](http://flake8.pycqa.org) errors.

    2. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
