### PR TITLE
Update links to Cirq documentation

### DIFF
--- a/docs/source/guide/guide-error-mitigation.rst
+++ b/docs/source/guide/guide-error-mitigation.rst
@@ -278,7 +278,7 @@ quantum computing, noisy quantum dynamics and error mitigation:
 
 - **IBM Q**'s `Qiskit`_ provides a stack for quantum computing simulation and execution on real devices from the cloud. In particular, ``qiskit.Aer`` contains the :class:`~qiskit.providers.aer.noise.NoiseModel` object, integrated with Mitiq tools. Qiskit's OpenPulse provides pulse-level control of qubit operations in some of the superconducting circuit devices. Mitiq is integrated with ``qiskit``, in the :mod:`~mitiq.mitiq_qiskit.qiskit_utils` and :mod:`~mitiq.mitiq_qiskit.conversions` modules.
 
-- **Goole AI Quantum**'s `Cirq`_ offers quantum simulation of quantum circuits. The :class:`cirq.Circuit` object is integrated in Mitiq algorithms as the default circuit.
+- **Google AI Quantum**'s `Cirq`_ offers quantum simulation of quantum circuits. The :class:`cirq.Circuit` object is integrated in Mitiq algorithms as the default circuit.
 
 - **Rigetti Computing**'s `PyQuil`_ is a library for quantum programming. Rigetti's stack offers the execution of quantum circuits on superconducting circuits devices from the cloud, as well as their simulation on a quantum virtual machine (QVM), integrated with Mitiq tools in the :mod:`~mitiq.mitiq_pyquil.pyquil_utils` module.
 
@@ -296,7 +296,7 @@ can be found `here`_ and on `Unitary Fund`_'s list of supported projects.
 
 .. _Qiskit: https://qiskit.org
 
-.. _Cirq: http://cirq.readthedocs.io/
+.. _Cirq: https://quantumai.google/cirq/
 
 .. _PyQuiL: https://github.com/rigetti/pyquil
 

--- a/docs/source/guide/guide-overview.rst
+++ b/docs/source/guide/guide-overview.rst
@@ -12,6 +12,6 @@ quantum programs. For an introduction to the error mitigation techniques impleme
 
 Developed by `Unitary Fund <https://unitary.fund/>`_, Mitiq is a framework agnostic
 library with a long-term vision to be useful for quantum programmers using any quantum programming
-framework and any quantum backend. Today we support `Cirq <https://cirq.readthedocs.io/en/stable/>`_,
+framework and any quantum backend. Today we support `Cirq <https://quantumai.google/cirq/>`_,
 `Qiskit <https://qiskit.org/>`_, and `PyQuil <https://pyquil-docs.rigetti.com/en/stable/>`_
 frontends and backends.


### PR DESCRIPTION
`Google` is mistyped as `Goole`.

Documentation for `Cirq` has moved from https://cirq.readthedocs.io/ to https://quantumai.google/cirq/.
