### PR TITLE
Clearer return type for extrapolate and remove deprecated method

### DIFF
--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -38,6 +38,18 @@ from mitiq import QPROGRAM
 from mitiq.collector import Collector
 
 
+ExtrapolationResult = Union[
+    float,  # The zero-noise value.
+    Tuple[
+        float,  # The zero-noise value.
+        Optional[float],  # The (estimated) error on the zero-noise value.
+        List[float],  # Optimal parameters found during fitting.
+        Optional[np.ndarray],  # Covariance of fitting parameters.
+        Callable[[float], float],  # Function that was fit.
+    ],
+]
+
+
 class ExtrapolationError(Exception):
     """Error raised by :class:`.Factory` objects when
     the extrapolation fit fails.
@@ -302,16 +314,6 @@ class Factory(ABC):
         """
         raise NotImplementedError
 
-    def iterate(
-        self, noise_to_expval: Callable[..., float], max_iterations: int = 100
-    ) -> "Factory":
-        warnings.warn(
-            "The `iterate` method is deprecated in v0.3.0 and will be removed "
-            "in v0.4.0. Use `run_classical` instead.",
-            DeprecationWarning,
-        )
-        return self.run_classical(noise_to_expval)
-
     def push(
         self, instack_val: Dict[str, float], outstack_val: float
     ) -> "Factory":
@@ -448,7 +450,7 @@ class BatchedFactory(Factory, ABC):
 
     @staticmethod
     @abstractmethod
-    def extrapolate(*args, **kwargs) -> float:
+    def extrapolate(*args, **kwargs) -> ExtrapolationResult:
         """Returns the extrapolation to the zero-noise limit."""
         raise NotImplementedError
 
@@ -781,16 +783,7 @@ class PolyFactory(BatchedFactory):
         exp_values: Sequence[float],
         order: int,
         full_output: bool = False,
-    ) -> Union[
-        float,
-        Tuple[
-            float,
-            Optional[float],
-            List[float],
-            Optional[np.ndarray],
-            Callable[[float], float],
-        ],
-    ]:
+    ) -> ExtrapolationResult:
         """Static method which evaluates a polynomial extrapolation to the
         zero-noise limit.
 
@@ -862,16 +855,7 @@ class RichardsonFactory(BatchedFactory):
         scale_factors: Sequence[float],
         exp_values: Sequence[float],
         full_output: bool = False,
-    ) -> Union[
-        float,
-        Tuple[
-            float,
-            Optional[float],
-            List[float],
-            Optional[np.ndarray],
-            Callable[[float], float],
-        ],
-    ]:
+    ) -> ExtrapolationResult:
         """Static method which evaluates the Richardson extrapolation to the
          zero-noise limit.
 
@@ -939,16 +923,7 @@ class FakeNodesFactory(BatchedFactory):
         scale_factors: Sequence[float],
         exp_values: Sequence[float],
         full_output: bool = False,
-    ) -> Union[
-        float,
-        Tuple[
-            float,
-            Optional[float],
-            List[float],
-            Optional[np.ndarray],
-            Callable[[float], float],
-        ],
-    ]:
+    ) -> ExtrapolationResult:
 
         if not FakeNodesFactory._is_equally_spaced(scale_factors):
             raise ValueError("The scale factors must be equally spaced.")
@@ -1055,16 +1030,7 @@ class LinearFactory(BatchedFactory):
         scale_factors: Sequence[float],
         exp_values: Sequence[float],
         full_output: bool = False,
-    ) -> Union[
-        float,
-        Tuple[
-            float,
-            Optional[float],
-            List[float],
-            Optional[np.ndarray],
-            Callable[[float], float],
-        ],
-    ]:
+    ) -> ExtrapolationResult:
         """Static method which evaluates the linear extrapolation to the
         zero-noise limit.
 
@@ -1152,16 +1118,7 @@ class ExpFactory(BatchedFactory):
         avoid_log: bool = False,
         eps: float = 1.0e-6,
         full_output: bool = False,
-    ) -> Union[
-        float,
-        Tuple[
-            float,
-            Optional[float],
-            List[float],
-            Optional[np.ndarray],
-            Callable[[float], float],
-        ],
-    ]:
+    ) -> ExtrapolationResult:
         """Static method which evaluates the extrapolation to the zero-noise
         limit assuming an exponential ansatz y(x) = a + b * exp(-c * x),
         with c > 0.
@@ -1283,16 +1240,7 @@ class PolyExpFactory(BatchedFactory):
         avoid_log: bool = False,
         eps: float = 1.0e-6,
         full_output: bool = False,
-    ) -> Union[
-        float,
-        Tuple[
-            float,
-            Optional[float],
-            List[float],
-            Optional[np.ndarray],
-            Callable[[float], float],
-        ],
-    ]:
+    ) -> ExtrapolationResult:
         """Static method which evaluates the extrapolation to the
         zero-noise limit with an exponential ansatz (whose exponent
         is a polynomial of degree "order").
@@ -1613,16 +1561,7 @@ class AdaExpFactory(AdaptiveFactory):
         avoid_log: bool = False,
         eps: float = 1.0e-6,
         full_output: bool = False,
-    ) -> Union[
-        float,
-        Tuple[
-            float,
-            Optional[float],
-            List[float],
-            Optional[np.ndarray],
-            Callable[[float], float],
-        ],
-    ]:
+    ) -> ExtrapolationResult:
         """Static method which evaluates the extrapolation to the zero-noise
         limit assuming an exponential ansatz y(x) = a + b * exp(-c * x),
         with c > 0.


### PR DESCRIPTION
Description
-----------

Closes #651. In that issue we decided to change the type, but really the issue wasn't about the return type itself, but rather how it was documented/written. As such, I made this clearer.

Also removes a deprecated method which I found in doing the above.


Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-style` (from the root directory of the repository) and fix any [flake8](http://flake8.pycqa.org) errors.

    2. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
