### PR TITLE
Make readthedocs succeed in building the pdf with pdflatex

### DIFF
--- a/docs/source/apidoc.rst
+++ b/docs/source/apidoc.rst
@@ -90,8 +90,11 @@ Probabilistic Error Cancellation (High-Level Tools)
 
 Quasi-Probability Representations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. automodule:: mitiq.pec.representations.optimal
-   :members:
+.. 
+   This has been commented since it may be the cause
+   of readthedocs failure in building the pdf. 
+   .. automodule:: mitiq.pec.representations.optimal
+      :members:
 
 .. automodule:: mitiq.pec.representations.damping
    :members:

--- a/docs/source/apidoc.rst
+++ b/docs/source/apidoc.rst
@@ -91,7 +91,7 @@ Probabilistic Error Cancellation (High-Level Tools)
 Quasi-Probability Representations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: mitiq.pec.representations.optimal
-      :members:
+   :members:
 
 .. automodule:: mitiq.pec.representations.damping
    :members:

--- a/docs/source/apidoc.rst
+++ b/docs/source/apidoc.rst
@@ -90,10 +90,7 @@ Probabilistic Error Cancellation (High-Level Tools)
 
 Quasi-Probability Representations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. 
-   This has been commented since it may be the cause
-   of readthedocs failure in building the pdf. 
-   .. automodule:: mitiq.pec.representations.optimal
+.. automodule:: mitiq.pec.representations.optimal
       :members:
 
 .. automodule:: mitiq.pec.representations.damping

--- a/mitiq/pec/representations/optimal.py
+++ b/mitiq/pec/representations/optimal.py
@@ -40,7 +40,9 @@ def minimize_one_norm(
     the following representation of the input ``ideal_matrix`` holds:
 
     .. math::
-        ideal_matrix = x_0 A_0 + x_1 A_1 + ...,
+        :nowrap:
+
+        \text{ideal_matrix} = x_0 A_0 + x_1 A_1 + ...,
 
     where :math:`\{A_j\}` are the basis matrices, i.e., the elements of
     the input ``basis_matrices``.

--- a/mitiq/pec/representations/optimal.py
+++ b/mitiq/pec/representations/optimal.py
@@ -40,10 +40,12 @@ def minimize_one_norm(
     the following representation of the input ``ideal_matrix`` holds:
 
     .. math::
-        M = x_0 A_0 + x_1 A_1 + ...,
+        :nowrap:
 
-    where :math:`\{A_j\}` are the basis matrices (i.e., the elements of the
-    input ``basis_matrices``), while :math:`M` is the input ``ideal_matrix``.
+        \text{ideal_matrix} = x_0 A_0 + x_1 A_1 + ...,
+
+    where :math:`\{A_j\}` are the basis matrices, i.e., the elements of
+    the input ``basis_matrices``.
 
     This function can be used to compute the optimal representation
     of an ideal superoperator (or Choi state) as a linear

--- a/mitiq/pec/representations/optimal.py
+++ b/mitiq/pec/representations/optimal.py
@@ -40,7 +40,7 @@ def minimize_one_norm(
     the following representation of the input ``ideal_matrix`` holds:
 
     .. math::
-        \text{ideal_matrix} = x_0 A_0 + x_1 A_1 + ...,
+        ideal_matrix = x_0 A_0 + x_1 A_1 + ...,
 
     where :math:`\{A_j\}` are the basis matrices, i.e., the elements of
     the input ``basis_matrices``.

--- a/mitiq/pec/representations/optimal.py
+++ b/mitiq/pec/representations/optimal.py
@@ -40,12 +40,10 @@ def minimize_one_norm(
     the following representation of the input ``ideal_matrix`` holds:
 
     .. math::
-        :nowrap:
+        M = x_0 A_0 + x_1 A_1 + ...,
 
-        \text{ideal_matrix} = x_0 A_0 + x_1 A_1 + ...,
-
-    where :math:`\{A_j\}` are the basis matrices, i.e., the elements of
-    the input ``basis_matrices``.
+    where :math:`\{A_j\}` are the basis matrices (i.e., the elements of the
+    input ``basis_matrices``), while :math:`M` is the input ``ideal_matrix``.
 
     This function can be used to compute the optimal representation
     of an ideal superoperator (or Choi state) as a linear


### PR DESCRIPTION
Description
-----------
This PR will probably fix #542.
At the moment readthedocs fails because of a pdflatex error.
With this change the pdf is created as can be seen in this `test-docs` branch of the guide: https://mitiq.readthedocs.io/en/test-docs/

