### PR TITLE
Add CDR example to docs + small change to `cdr.calculate_observable`

### DIFF
--- a/docs/source/examples/cdr_api.md
+++ b/docs/source/examples/cdr_api.md
@@ -6,9 +6,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.11.3
 kernelspec:
-  display_name: envwhyisthisneeded
+  display_name: Python 3
   language: python
-  name: envwhyisthisneeded
+  name: python3
 ---
 
 # Clifford data regression API

--- a/docs/source/examples/cdr_api.md
+++ b/docs/source/examples/cdr_api.md
@@ -5,6 +5,10 @@ jupytext:
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.11.3
+kernelspec:
+  display_name: envwhyisthisneeded
+  language: python
+  name: envwhyisthisneeded
 ---
 
 # Clifford data regression API

--- a/docs/source/examples/cdr_api.md
+++ b/docs/source/examples/cdr_api.md
@@ -1,0 +1,206 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.11.3
+---
+
+# Clifford data regression API
+
++++
+
+This example shows how to use Clifford data regression (CDR) by means of a simple example.
+
+```{code-cell} ipython3
+import warnings
+warnings.filterwarnings("ignore")
+
+import numpy as np
+
+import cirq
+from mitiq import cdr
+```
+
+## Setup
+
++++
+
+To use CDR, we call `cdr.execute_with_cdr` with four necessary "ingredients":
+
+1. A quantum circuit to prepare a state $\rho$.
+1. A quantum computer or noisy simulator to sample bitstrings from $\rho$.
+1. One or more observables $O$ which specify what we wish to compute: $\text{Tr} [ \rho O ]$.
+1. A near-Clifford (classical) circuit simulator.
+
++++
+
+### (1) Circuit
+
++++
+
+The circuit can be specified as any quantum circuit supported by Mitiq but **must be compiled into the gateset $\{ \sqrt{X}, Z, \text{CNOT}\}$.**
+
+```{code-cell} ipython3
+a, b = cirq.LineQubit.range(2)
+circuit = cirq.Circuit(
+    cirq.rx(0.1).on(a),
+    cirq.rx(-0.72).on(b),
+    cirq.rz(0.4).on(a),
+    cirq.rz(0.2).on(b),
+    cirq.CNOT.on(a, b),
+    cirq.rx(-0.1).on(b),
+    cirq.rz(-0.23).on(a),
+    cirq.CNOT.on(b, a),
+    cirq.rx(-0.112).on(a),
+    cirq.measure(a, b, key="z"),
+)
+circuit
+```
+
+### (2) Executor
+
++++
+
+The executor inputs a circuit and returns a dictionary or counter of computational basis measurements. **The return type must be `Dict[int, int]` or `Counter[int]`.** 
+
+Typically this function will send the circuit to a quantum computer and wait for the results. Here for sake of example we use a noisy simulator.
+
+```{code-cell} ipython3
+from typing import Counter
+
+
+def sample_bitstrings(circ: cirq.Circuit, shots: int = 1000, noise: float = 0.01) -> Counter[int]:
+    # Add depolarizing noise to emulate a noisy quantum processor!
+    circuit = circ.with_noise(cirq.depolarize(noise))
+    
+    return cirq.DensityMatrixSimulator().run(circuit, repetitions=shots).histogram(key="z")
+```
+
+An example of calling this function is shown below.
+
+```{code-cell} ipython3
+sample_bitstrings(circuit)
+```
+
+### (3) Observable(s)
+
++++
+
+The observables $O$ indicate what we wish to compute via $\text{Tr} [ \rho O ]$ and **must be specified as "diagonal" (one-dimensional) NumPy arrays.**
+
+```{code-cell} ipython3
+# Observable(s) to measure.
+z = np.diag([1, -1])
+obs = np.diag(np.kron(z, z))
+```
+
+### (4) (Near-clifford) Simulator
+
++++
+
+The CDR method creates a set of "training circuits" which are related to the input circuit and are efficiently simulable. These circuits are simulated on a classical (noiseless) simulator to collect data for regression. **The simulator return type must be the same as the executor return type.**
+
+To use CDR at scale, an efficient near-Clifford circuit simulator must be specified. In this example, the circuit is small enough to use any classical simulator.
+
+```{code-cell} ipython3
+def sample_bitstrings_simulator(circuit, shots: int = 1000) -> Counter:
+    return sample_bitstrings(circuit, shots=shots, noise=0.0)
+```
+
+## Results
+
++++
+
+Now we can run CDR. We first compute the noiseless result then the noisy result to compare to the mitigated result from CDR.
+
++++
+
+### The noiseless result
+
+```{code-cell} ipython3
+cdr.execute.calculate_observable(
+    state_or_measurements=sample_bitstrings_simulator(circuit),
+    observable=obs,
+)
+```
+
+### The noisy result
+
+```{code-cell} ipython3
+cdr.execute.calculate_observable(
+    state_or_measurements=sample_bitstrings(circuit),
+    observable=obs,
+)
+```
+
+### The mitigated result
+
+```{code-cell} ipython3
+cdr.execute_with_cdr(
+    circuit=circuit,
+    executor=sample_bitstrings,
+    observables=[obs],
+    simulator=sample_bitstrings_simulator,
+)
+```
+
+## Additional options
+
++++
+
+In addition to the four necessary arguments shown above, there are additional parameters in CDR.
+
++++
+
+### Training circuits
+
++++
+
+One option is how many circuits are in the training set (default is 10). This can be changed as follows.
+
+```{code-cell} ipython3
+cdr.execute_with_cdr(
+    circuit=circuit,
+    executor=sample_bitstrings,
+    observables=[obs],
+    simulator=sample_bitstrings_simulator,
+    num_training_circuits=5,
+)
+```
+
+Another option is which fit function to use for regresstion (default is `cdr.linear_fit_function`).
+
++++
+
+### Fit function
+
+```{code-cell} ipython3
+cdr.execute_with_cdr(
+    circuit=circuit,
+    executor=sample_bitstrings,
+    observables=[obs],
+    simulator=sample_bitstrings_simulator,
+    fit_function=cdr.linear_fit_function_no_intercept,
+)
+```
+
+### Variable noise CDR
+
++++
+
+The circuit + training circuits can also be run at different noise scale factors to implement [Variable noise Clifford data regression](https://arxiv.org/abs/2011.01157).
+
+```{code-cell} ipython3
+from mitiq.zne import scaling
+
+cdr.execute_with_cdr(
+    circuit=circuit,
+    executor=sample_bitstrings,
+    observables=[obs],
+    simulator=sample_bitstrings_simulator,
+    scale_factors=(1, 3),
+    scale_noise=scaling.fold_gates_at_random,
+)
+```

--- a/docs/source/examples/examples.myst
+++ b/docs/source/examples/examples.myst
@@ -8,5 +8,6 @@ ibmq-backends.rst
 hamiltonians.rst
 simple_landscape.rst
 maxcut-demo.myst
+cdr-api.md
 test.myst
 ```

--- a/docs/source/examples/examples.myst
+++ b/docs/source/examples/examples.myst
@@ -8,6 +8,6 @@ ibmq-backends.rst
 hamiltonians.rst
 simple_landscape.rst
 maxcut-demo.myst
-cdr-api.md
+cdr_api.md
 test.myst
 ```

--- a/mitiq/cdr/_testing.py
+++ b/mitiq/cdr/_testing.py
@@ -72,7 +72,7 @@ def executor(
     circuit.append(cirq.measure(*circuit.all_qubits(), key="z"))
 
     result = cirq.DensityMatrixSimulator().run(circuit, repetitions=shots)
-    return {bin(k): v for k, v in result.histogram(key="z").items()}
+    return result.histogram(key="z")
 
 
 def simulator(circuit: QPROGRAM, shots: int = 8192) -> MeasurementResult:

--- a/mitiq/cdr/execute.py
+++ b/mitiq/cdr/execute.py
@@ -18,7 +18,7 @@ from typing import Counter as CounterType, Dict, Union
 
 import numpy as np
 
-MeasurementResult = Union[Dict[bin, int], CounterType[bin]]
+MeasurementResult = Union[Dict[int, int], CounterType[int]]
 
 
 def calculate_observable(
@@ -50,7 +50,7 @@ def calculate_observable(
     elif isinstance(state_or_measurements, (dict, Counter)):
         probs = normalize_measurements(state_or_measurements)
         observable_values = [
-            observable[i] * probs.get(bin(i), 0.0) for i in range(2 ** nqubits)
+            observable[i] * probs.get(i, 0.0) for i in range(2 ** nqubits)
         ]
     else:
         raise ValueError(
@@ -61,7 +61,7 @@ def calculate_observable(
     return sum(np.real(observable_values))
 
 
-def normalize_measurements(counts: MeasurementResult) -> Dict[bin, float]:
+def normalize_measurements(counts: MeasurementResult) -> Dict[int, float]:
     """Normalizes the values of the MeasurementResult to get probabilities.
 
     Args:

--- a/mitiq/cdr/tests/test_execute.py
+++ b/mitiq/cdr/tests/test_execute.py
@@ -24,7 +24,7 @@ from mitiq.cdr.execute import calculate_observable, normalize_measurements
 from mitiq.cdr._testing import simulator_statevector, simulator
 
 # Observables.
-sigma_z = np.diag(np.diag([1, -1]))
+sigma_z = np.array([1, -1])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Description
-----------

Closes #693 with an example showing how to use the CDR API.

I also changed the dictionary/counter key type of measurements to be integers, since this is what Cirq returns by default and I think it's more natural.

Additional docs/examples could be added on generating training circuits and doing the regression.


Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-style` (from the root directory of the repository) and fix any [flake8](http://flake8.pycqa.org) errors.

    2. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
