### PR TITLE
Test execute_with_pec with all supported programs

### DIFF
--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Unit tests for PEC."""
-
+import warnings
 from typing import List, Optional
 from functools import partial
 import pytest
@@ -24,13 +24,12 @@ import cirq
 import pyquil
 import qiskit
 
-from mitiq import QPROGRAM
+from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES
 from mitiq.interface import convert_to_mitiq, convert_from_mitiq
 from mitiq.benchmarks.utils import noisy_simulation
 
 from mitiq.pec import execute_with_pec, NoisyOperation, OperationRepresentation
 from mitiq.pec import mitigate_executor, pec_decorator
-from mitiq.pec.pec import LargeSampleWarning
 from mitiq.pec.representations import (
     represent_operations_in_circuit_with_local_depolarizing_noise,
 )
@@ -241,7 +240,7 @@ def test_qiskit_noiseless_decomposition_multiqubit(nqubits):
 
 @pytest.mark.parametrize("circuit", [oneq_circ, twoq_circ])
 @pytest.mark.parametrize("executor", [serial_executor, batched_executor])
-@pytest.mark.parametrize("circuit_type", ["cirq", "qiskit", "pyquil"])
+@pytest.mark.parametrize("circuit_type", SUPPORTED_PROGRAM_TYPES.keys())
 def test_execute_with_pec_mitigates_noise(circuit, executor, circuit_type):
     """Tests that execute_with_pec mitigates the error of a noisy
     expectation value.
@@ -362,13 +361,13 @@ def test_bad_precision_argument(bad_value: float):
         )
 
 
-@pytest.mark.skip(reason="Slow test.")
 def test_large_sample_size_warning():
     """Tests whether a warning is raised when PEC sample size
     is greater than 10 ** 5.
     """
-    with pytest.warns(
-        LargeSampleWarning, match=r"The number of PEC samples is very large.",
+    warnings.simplefilter("error")
+    with pytest.raises(
+        Warning, match="The number of PEC samples is very large.",
     ):
         execute_with_pec(
             oneq_circ,


### PR DESCRIPTION
Tests `execute_with_pec` with all `SUPPORTED_PROGRAM_TYPES` ,
in the same way as it is already done for `execute_with_zne` and `execute_with_cdr`.

Fixes #768. 

Additional minor change: I restored a previously skipped PEC test by transforming a warning into an error.