### PR TITLE
Rename parameter calibration function and make it visible

### DIFF
--- a/mitiq/zne/scaling/__init__.py
+++ b/mitiq/zne/scaling/__init__.py
@@ -21,4 +21,7 @@ from mitiq.zne.scaling.folding import (
     fold_gates_at_random,
     fold_global,
 )
-from mitiq.zne.scaling.parameter import scale_parameters
+from mitiq.zne.scaling.parameter import (
+    scale_parameters,
+    compute_parameter_variance,
+)

--- a/mitiq/zne/scaling/parameter.py
+++ b/mitiq/zne/scaling/parameter.py
@@ -56,8 +56,7 @@ class CircuitMismatchException(Exception):
 def _generate_parameter_calibration_circuit(
     qubits: List[Qid], depth: int, gate: EigenGate
 ) -> Circuit:
-    """
-    Generates a circuit which should be the identity. Given a rotation
+    """Generates a circuit which should be the identity. Given a rotation
     gate R(param), it applies R(2 * pi / depth) depth times, resulting
     in R(2*pi). Requires that the gate is periodic in 2*pi.
 
@@ -81,17 +80,17 @@ def _generate_parameter_calibration_circuit(
     )
 
 
-def _parameter_calibration(
+def compute_parameter_variance(
     executor: Callable[..., float],
     gate: EigenGate,
     qubit: Qid,
     depth: int = 100,
 ) -> float:
-    """
-    Given an executor and a gate, determines the effective
-    variance in the control parameter
-    that can be used for parameter noise scaling later on.
-    Only works for one qubit gates for now.
+    """Given an executor and a gate, determines the effective variance in the
+    control parameter that can be used as the ``base_variance`` argument in
+    ``mitiq.zne.scaling.scale_parameters``.
+
+    Note: Only works for one qubit gates for now.
 
     Args:
         executor: A function that takes in a quantum circuit and returns

--- a/mitiq/zne/scaling/tests/test_parameter.py
+++ b/mitiq/zne/scaling/tests/test_parameter.py
@@ -28,7 +28,7 @@ from mitiq.zne.scaling.parameter import (
     CircuitMismatchException,
     GateTypeException,
     _generate_parameter_calibration_circuit,
-    _parameter_calibration,
+    compute_parameter_variance,
 )
 
 
@@ -137,14 +137,14 @@ def test_gate_type():
         _get_base_gate(forbidden_op)
 
 
-def test_parameter_calibration():
+def test_compute_parameter_variance():
     def noiseless_executor_mock(circuit):
         return 1
 
     # Perfect executor should have sigma = 0
     qubit = LineQubit(0)
     gate = ops.H.on(qubit).gate
-    sigma = _parameter_calibration(
+    sigma = compute_parameter_variance(
         noiseless_executor_mock, gate, qubit, depth=10
     )
     assert sigma == 0
@@ -157,7 +157,7 @@ def test_parameter_calibration():
     gate = ops.H.on(qubit).gate
     with pytest.warns(RuntimeWarning):
         # Runtime warning for divide by zero
-        sigma = _parameter_calibration(
+        sigma = compute_parameter_variance(
             noisy_executor_mock, gate, qubit, depth=10
         )
     assert sigma == np.inf


### PR DESCRIPTION
Description
-----------

This is kind of a necessary function to use parameter noise scaling. We mention it in the paper, but its private and not imported anywhere. I renamed it to be more descriptive. cc @yhindy 

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
