### PR TITLE
Allow adding qubits when transforming registers in a Qiskit circuit

### DIFF
--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -171,6 +171,9 @@ def _transform_registers(
     if new_qregs is None:
         return
 
+    print("In transform_registers, input circuit is:")
+    print(circuit)
+
     if len(circuit.qregs) > 1:
         raise ValueError(
             "Input circuit is required to have <= 1 quantum register but has "
@@ -180,10 +183,10 @@ def _transform_registers(
     qreg_sizes = [qreg.size for qreg in new_qregs]
     nqubits_in_circuit = sum(qreg.size for qreg in circuit.qregs)
 
-    if len(qreg_sizes) and sum(qreg_sizes) != nqubits_in_circuit:
+    if len(qreg_sizes) and sum(qreg_sizes) < nqubits_in_circuit:
         raise ValueError(
-            f"The circuit has {nqubits_in_circuit} qubits, but the provided "
-            f"quantum registers have {sum(qreg_sizes)} qubits."
+            f"The circuit has {nqubits_in_circuit} qubit(s), but the provided "
+            f"quantum registers have {sum(qreg_sizes)} qubit(s)."
         )
 
     # Assign the new registers.

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -171,9 +171,6 @@ def _transform_registers(
     if new_qregs is None:
         return
 
-    print("In transform_registers, input circuit is:")
-    print(circuit)
-
     if len(circuit.qregs) > 1:
         raise ValueError(
             "Input circuit is required to have <= 1 quantum register but has "


### PR DESCRIPTION
Description
-----------

Fixes #802.

Calling `qiskit.transpile(circuit, backend, *)` adds all qubits from the `backend` even if they are not used in the circuit. When running `zne.execute_with_zne`, the sequence would be

1. (Transpiled) Qiskit circuit with idle qubits.
2. Cirq circuit with no idle qubits (they get removed in Qiskit -> Cirq).
3. Scaled Cirq circuit with no idle qubits.
4. Bug when trying to transform the registers of the scaled circuit (m qubits) to the registers of the circuit in step 1 (n > m qubits).

This PR allows step 4 to happen, and adds tests.

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
