### PR TITLE
Fix multiplication order when adding NoisyOperations

### DIFF
--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -203,18 +203,23 @@ def test_unknown_channel_matrix():
 
 
 def test_add_simple():
-    ideal = cirq.Circuit([cirq.X.on(cirq.NamedQubit("Q"))])
-    real = np.random.rand(4, 4)
+    circuit1 = cirq.Circuit([cirq.X.on(cirq.NamedQubit("Q"))])
+    circuit2 = cirq.Circuit([cirq.Y.on(cirq.NamedQubit("Q"))])
+    
+    super_op1 = np.random.rand(4, 4)
+    super_op2 = np.random.rand(4, 4)
 
-    noisy_op1 = NoisyOperation(ideal, real)
-    noisy_op2 = NoisyOperation(ideal, real)
+    noisy_op1 = NoisyOperation(circuit1, super_op1)
+    noisy_op2 = NoisyOperation(circuit2, super_op2)
 
     noisy_op = noisy_op1 + noisy_op2
 
-    correct = cirq.Circuit([cirq.X.on(cirq.NamedQubit("Q"))] * 2)
+    correct = cirq.Circuit(
+        [cirq.X.on(cirq.NamedQubit("Q")), cirq.Y.on(cirq.NamedQubit("Q"))],
+    )
 
     assert _equal(noisy_op._circuit, correct, require_qubit_equality=True)
-    assert np.allclose(noisy_op.channel_matrix, real @ real)
+    assert np.allclose(noisy_op.channel_matrix, super_op2 @ super_op1)
 
 
 def test_add_pyquil_noisy_operations():

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -205,7 +205,7 @@ def test_unknown_channel_matrix():
 def test_add_simple():
     circuit1 = cirq.Circuit([cirq.X.on(cirq.NamedQubit("Q"))])
     circuit2 = cirq.Circuit([cirq.Y.on(cirq.NamedQubit("Q"))])
-    
+
     super_op1 = np.random.rand(4, 4)
     super_op2 = np.random.rand(4, 4)
 

--- a/mitiq/pec/types/types.py
+++ b/mitiq/pec/types/types.py
@@ -295,7 +295,7 @@ class NoisyOperation:
         if self._channel_matrix is None or other._channel_matrix is None:
             matrix = None
         else:
-            matrix = self._channel_matrix @ other._channel_matrix
+            matrix = other._channel_matrix @ self._channel_matrix
 
         return NoisyOperation(self._circuit + other._circuit, matrix)
 


### PR DESCRIPTION
Description
-----------

If we add two noisy operations ([A] +[B]) we get the circuit -[A]-[B]- . The corresponding superoperator should be `S_AB = S_B @ S_A`, while in the current implementation we get  `S_AB = S_A @ S_B`.
