### PR TITLE
Initial support for executors which return measurement results: part 1/2

### DIFF
--- a/mitiq/collector.py
+++ b/mitiq/collector.py
@@ -21,12 +21,21 @@ import inspect
 from typing import Any, Callable, Iterable, List, Sequence, Tuple, Union
 
 import numpy as np
+from cirq import Result as MeasurementResult  # TODO: Generalize frontend.
 
 from mitiq import QPROGRAM
-from mitiq.interface import (
-    convert_from_mitiq,
-    convert_to_mitiq,
-)
+from mitiq.interface import convert_from_mitiq, convert_to_mitiq
+
+# An `executor` function inputs a quantum program and outputs an object from
+# which expectation values can be computed. Explicitly, this object can be one
+# of the following types:
+QuantumResult = Union[
+    float,  # The expectation value itself.
+    MeasurementResult,  # Sampled bitstrings.
+    # TODO: Support the following:
+    # np.ndarray,  # Density matrix.
+    # Sequence[np.ndarray],  # Wavefunctions sampled via quantum trajectories.
+]
 
 
 def generate_collected_executor(
@@ -97,7 +106,7 @@ class Collector:
         self._max_batch_size = max_batch_size
 
         self._executed_circuits: List[QPROGRAM] = []
-        self._computed_results: List[float] = []
+        self._computed_results: List[QuantumResult] = []
 
         self._calls_to_executor: int = 0
 
@@ -114,9 +123,10 @@ class Collector:
         circuits: Sequence[QPROGRAM],
         force_run_all: bool = False,
         **kwargs: Any,
-    ) -> List[float]:
+    ) -> List[QuantumResult]:
         """Runs all input circuits using the least number of possible calls to
         the executor.
+
         Args:
             circuits: Sequence of circuits to execute using the executor.
             force_run_all: If True, force every circuit in the input sequence
@@ -155,15 +165,17 @@ class Collector:
         if force_run_all:
             return self._computed_results
 
-        expval_dict = dict(zip(collection.keys(), self._computed_results))
-        results = [expval_dict[key] for key in hashable_circuits]
+        results_dict = dict(zip(collection.keys(), self._computed_results))
+        results = [results_dict[key] for key in hashable_circuits]
 
         return results
 
     def _call_executor(
         self, to_run: Union[QPROGRAM, Sequence[QPROGRAM]], **kwargs: Any
     ) -> None:
-        """Calls the executor on the input circuit(s) to run.
+        """Calls the executor on the input circuit(s) to run. Stores the
+        executed circuits in ``self._executed_circuits`` and the computed
+        results in ``self._computed_results``.
 
         Args:
             to_run: Circuit(s) to run.
@@ -189,11 +201,13 @@ class Collector:
         The executor is detected as "batched" if and only if it is annotated
         with a return type that is one of the following:
 
-            * Iterable[float]
-            * List[float]
-            * Sequence[float]
-            * Tuple[float]
-            * numpy.ndarray
+            * ``Iterable[QuantumResult]``
+            * ``List[QuantumResult]``
+            * ``Sequence[QuantumResult]``
+            * ``Tuple[QuantumResult]``
+
+        where a ``QuantumResult`` is a ``float`` or a ``cirq.Result``.
+        Otherwise, it is considered "serial".
 
         Batched executors can run several quantum programs in a single call.
         See below.
@@ -201,10 +215,10 @@ class Collector:
         Args:
             executor: A "serial executor" (1) or a "batched executor" (2).
 
-                (1) A function which inputs a single `QPROGRAM` and outputs a
-                single expectation value as a float.
-                (2) A function which inputs a list of `QPROGRAM`s and outputs a
-                list of expectation values (one for each `QPROGRAM`).
+                (1) A function which inputs a single ``QPROGRAM`` and outputs a
+                single ``QuantumResult``.
+                (2) A function which inputs a list of ``QPROGRAM``s and outputs
+                a list of ``QuantumResult``s (one for each ``QPROGRAM``).
 
         Returns:
             True if the executor is detected as batched, else False.
@@ -212,9 +226,7 @@ class Collector:
         executor_annotation = inspect.getfullargspec(executor).annotations
 
         return executor_annotation.get("return") in (
-            List[float],
-            Sequence[float],
-            Tuple[float],
-            Iterable[float],
-            np.ndarray,
+            BatchedType[T]
+            for BatchedType in [Iterable, List, Sequence, Tuple]
+            for T in QuantumResult.__args__
         )

--- a/mitiq/collector.py
+++ b/mitiq/collector.py
@@ -61,7 +61,6 @@ def generate_collected_executor(
             * List[float]
             * Sequence[float]
             * Tuple[float]
-            * numpy.ndarray
 
         max_batch_size: The maximum number of circuits which can be processed
             with one call to the executor. If the executor is serial, this

--- a/mitiq/collector.py
+++ b/mitiq/collector.py
@@ -43,7 +43,7 @@ def generate_collected_executor(
     max_batch_size: int = 75,
     force_run_all: bool = False,
     **kwargs: Any,
-) -> Callable[[Any], List[float]]:
+) -> Callable[[Any], List[QuantumResult]]:
     """Returns a new executor function which efficiently collects expectation
     values by detecting identical circuits and calling the executor as few
     times as possible.
@@ -73,7 +73,7 @@ def generate_collected_executor(
     if not callable(executor):
         raise ValueError("Arg `executor` must be callable.")
 
-    def collected(circuits: Any) -> List[float]:
+    def collected(circuits: Any) -> List[QuantumResult]:
         return Collector(executor, max_batch_size).run(
             circuits, force_run_all=force_run_all, **kwargs
         )
@@ -225,7 +225,7 @@ class Collector:
         executor_annotation = inspect.getfullargspec(executor).annotations
 
         return executor_annotation.get("return") in (
-            BatchedType[T]
+            BatchedType[T]  # type: ignore[index]
             for BatchedType in [Iterable, List, Sequence, Tuple]
-            for T in QuantumResult.__args__
+            for T in QuantumResult.__args__  # type: ignore[attr-defined]
         )

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -136,10 +136,6 @@ def execute_with_pec(
     )
     results = collected_executor(sampled_circuits)
 
-    # TODO: Remove when all executors are supported.
-    if not all(isinstance(result, float) for result in results):
-        raise ValueError("PEC requires an executor which returns floats.")
-
     # Evaluate unbiased estimators [Temme2017] [Endo2018] [Takagi2020]
     unbiased_estimators = [
         norm * s * val  # type: ignore[operator]

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -134,10 +134,17 @@ def execute_with_pec(
     collected_executor = generate_collected_executor(
         executor, force_run_all=force_run_all
     )
-    exp_values = collected_executor(sampled_circuits)
+    results = collected_executor(sampled_circuits)
+
+    # TODO: Remove when all executors are supported.
+    if not all(isinstance(result, float) for result in results):
+        raise ValueError("PEC requires an executor which returns floats.")
 
     # Evaluate unbiased estimators [Temme2017] [Endo2018] [Takagi2020]
-    unbiased_estimators = [norm * s * val for s, val in zip(signs, exp_values)]
+    unbiased_estimators = [
+        norm * s * val  # type: ignore[operator]
+        for s, val in zip(signs, results)
+    ]
 
     pec_value = np.average(unbiased_estimators)
 
@@ -153,7 +160,7 @@ def execute_with_pec(
         "pec_value": pec_value,
         "pec_error": np.std(unbiased_estimators) / np.sqrt(num_samples),
         "unbiased_estimators": unbiased_estimators,
-        "measured_expectation_values": exp_values,
+        "measured_expectation_values": results,
         "sampled_circuits": sampled_circuits,
     }
 

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -82,8 +82,8 @@ def serial_executor(circuit: QPROGRAM, noise: float = BASE_NOISE) -> float:
     return noisy_simulation(circuit, noise, obs)
 
 
-def batched_executor(circuits) -> np.ndarray:
-    return np.array([serial_executor(circuit) for circuit in circuits])
+def batched_executor(circuits) -> List[float]:
+    return [serial_executor(circuit) for circuit in circuits]
 
 
 def noiseless_serial_executor(circuit: QPROGRAM) -> float:

--- a/mitiq/tests/test_collector.py
+++ b/mitiq/tests/test_collector.py
@@ -25,11 +25,15 @@ import pyquil
 from mitiq.collector import Collector, generate_collected_executor
 
 
-def executor_batched(circuits, **kwargs) -> np.ndarray:
-    return np.full(
-        shape=(len(circuits),),
-        fill_value=kwargs.setdefault("return_value", 0.0),
-    )
+# Serial / batched executors which return floats.
+def executor_batched(circuits, **kwargs) -> List[float]:
+    return [
+        float(v)
+        for v in np.full(
+            shape=(len(circuits),),
+            fill_value=kwargs.setdefault("return_value", 0.0),
+        )
+    ]
 
 
 def executor_batched_unique(circuits) -> List[float]:
@@ -56,6 +60,17 @@ def executor_pyquil_batched(programs) -> List[float]:
     return [0.0] * len(programs)
 
 
+# Serial / batched executors which return measurements.
+def executor_serial_measurements(circuit) -> cirq.Result:
+    return cirq.Simulator().run(circuit, repetitions=10)
+
+
+def executor_batched_measurements(circuits) -> List[cirq.Result]:
+    return [
+        cirq.Simulator().run(circuit, repetitions=10) for circuit in circuits
+    ]
+
+
 def test_collector_simple():
     collector = Collector(executor=executor_batched, max_batch_size=10)
     assert collector.can_batch
@@ -64,9 +79,11 @@ def test_collector_simple():
 
 
 def test_collector_is_batched_executor():
-    assert Collector.is_batched_executor(executor=executor_batched)
-    assert not Collector.is_batched_executor(executor=executor_serial_typed)
-    assert not Collector.is_batched_executor(executor=executor_serial)
+    assert Collector.is_batched_executor(executor_batched)
+    assert not Collector.is_batched_executor(executor_serial_typed)
+    assert not Collector.is_batched_executor(executor_serial)
+    assert not Collector.is_batched_executor(executor_serial_measurements)
+    assert Collector.is_batched_executor(executor_batched_measurements)
 
 
 @pytest.mark.parametrize("ncircuits", (5, 10, 25))

--- a/mitiq/tests/test_collector.py
+++ b/mitiq/tests/test_collector.py
@@ -179,8 +179,6 @@ def test_generate_collected_executor(executor, ncircuits, rval):
         executor, return_value=rval
     )
     expvals = collected_executor([cirq.Circuit()] * ncircuits)
-    print(rval)
-    print(expvals)
     assert np.allclose(expvals, np.full(shape=(ncircuits,), fill_value=rval))
 
 


### PR DESCRIPTION
Description
-----------

Part of #623. Here all measurement results must be `cirq.Result`s. Part 2/2 will add and handle conversions to/from any supported library (Qiskit, pyQuil, braket).

Note: This is technically a breaking change since `-> np.ndarray` executors are no longer recognized as a batched. (We want executors which return density matrices which are `np.ndarray`s.)

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
