### PR TITLE
Add linkcheck to docs build and fix broken links

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           make docs
           make doctest
+          make linkcheck
 
   # This is to make sure Mitiq works without optional 3rd party packages like Qiskit, pyQuil, etc.
   # E.g., if we accidentally `import qiskit` in Mitiq where we shouldn't, this test will catch that.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ In order to check if `black` would reformat the code, use
 ```bash
 (myenv) make check-format
 ```
-If above format check fails then you will be presented with a [diff](https://black.readthedocs.io/en/stable/installation_and_usage.html#command-line-options) which can be resolved by running
+If above format check fails then you will be presented with a [diff](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#diffs) which can be resolved by running
 ```bash
 (myenv) make format
 ```

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ docs-clean:
 doctest:
 	make -C docs doctest
 
+.PHONY: linkcheck
+linkcheck:
+	make -C docs linkcheck
+
 .PHONY: format
 format:
 	black mitiq

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Error in simulation (with mitigation): 0.000519
 Mitiq currently implements:
 
 * [Zero-Noise Extrapolation](https://mitiq.readthedocs.io/en/stable/guide/guide-zne.html),
-* [Probabilistic Error Cancellation](https://mitiq.readthedocs.io/en/stable/guide/guide-getting-started.html#error-mitigation-with-probabilistic-error-cancellation),
+* [Probabilistic Error Cancellation](https://mitiq.readthedocs.io/en/stable/guide/guide-getting-started.html#probabilistic-error-cancellation),
 * [(Variable noise) Clifford data regression](https://mitiq.readthedocs.io/en/stable/examples/cdr_api.html),
 
 and is designed to support [additional techniques](https://github.com/unitaryfund/mitiq/wiki).

--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -59,7 +59,7 @@ the extended MyST syntax. Just add the file to `source` directory and a TOC some
 
 ```{warning}
 Currently, `.rst` is supported for any of the files in the docs, but the current migration plan is to move everything to MyST serialization, to make it easier to include Jupyter notebooks and more consistent with documentation in the project root.
-If you want a good intro to MyST and how it compares to `.rst` see [this guide](https://myst-parser.readthedocs.io/en/latest/using/intro.html#intro-writing).
+If you want a good intro to MyST and how it compares to `.rst` see [this guide](https://myst-parser.readthedocs.io/en/latest/sphinx/intro.html#intro-writing).
 ```
 
 The main table of contents (TOC) file for the docs is `index.myst`. It includes `guide\guide.myst` and `apidoc.myst`, among other files. To add a new file to the base TOC, make sure it gets listed in the `toctree` directive like this:
@@ -87,7 +87,7 @@ To include `.md` files outside of the documentation `source` directory, you can 
 ```
 ````
 
-where `file.md` is the one to be added. For more information on including files external to the docs, see the [MyST docs](https://myst-parser.readthedocs.io/en/latest/using/howto.html#include-a-file-from-outside-the-docs-folder-like-readme-md).
+where `file.md` is the one to be added. For more information on including files external to the docs, see the [MyST docs](https://myst-parser.readthedocs.io/en/latest/).
 
 ### Adding files to the user guide
 

--- a/docs/source/examples/template.myst
+++ b/docs/source/examples/template.myst
@@ -47,7 +47,7 @@ For example, here's the MyST-NB logo:
 
 ![myst-nb logo](../img/unitary_fund_logo.png)
 
-By adding `"html_image"` to the `myst_enable_extensions` list in the sphinx configuration ([see here](https://myst-parser.readthedocs.io/en/latest/using/syntax-optional.html#images)), you can even add HTML `img` tags with attributes:
+By adding `"html_image"` to the `myst_enable_extensions` list in the sphinx configuration ([see here](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#images)), you can even add HTML `img` tags with attributes:
 
 ```html
 <img src="../img/unitary_fund_logo.png" alt="logo" width="200px" class="shadow mb-2">
@@ -60,7 +60,7 @@ For example, here's a note admonition block:
 
 :::::{note}
 **Wow**, a note!
-It was generated with this code ([as explained here](https://myst-parser.readthedocs.io/en/latest/using/syntax-optional.html#html-admonitions)):
+It was generated with this code ([as explained here](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#html-admonitions)):
 
 ````md
 :::{note}
@@ -71,7 +71,7 @@ It was generated with this code ([as explained here](https://myst-parser.readthe
 :::::
 
 If you wish to use "bare" LaTeX equations, then you should add `"amsmath"` to the `myst_enable_extensions` list in the sphinx configuration.
-This is [explained here](https://myst-parser.readthedocs.io/en/latest/using/syntax-optional.html#direct-latex-math), and works as such:
+This is [explained here](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#direct-latex-math), and works as such:
 
 ```latex
 \begin{equation}
@@ -104,7 +104,7 @@ $$e^{i\pi} + 1 = 0$$ (euler)
 Euler's identity, equation {math:numref}`euler`, was elected one of the
 most beautiful mathematical formulas.
 
-You can see the syntax used for this example [here in the MyST documentation](https://myst-parser.readthedocs.io/en/latest/using/syntax.html#math-shortcuts).
+You can see the syntax used for this example [here in the MyST documentation](https://myst-parser.readthedocs.io/en/latest/syntax/syntax.html#roles-an-in-line-extension-point).
 
 ## Code cells and outputs
 

--- a/docs/source/guide/guide-error-mitigation.rst
+++ b/docs/source/guide/guide-error-mitigation.rst
@@ -306,4 +306,4 @@ can be found `here`_ and on `Unitary Fund`_'s list of supported projects.
 
 .. _here: https://github.com/qosf/awesome-quantum-software
 
-.. _Unitary Fund: https://unitary.fund#grants-made
+.. _Unitary Fund: https://unitary.fund/grants.html

--- a/docs/source/research.rst
+++ b/docs/source/research.rst
@@ -8,7 +8,7 @@ Research
 
 Mitiq is designed to aid researchers in quantum computing and quantum error mitigation. Given the quick growth of the techniques for quantum error mitigation (you can read an overview in the `Users Guide <https://mitiq.readthedocs.io/en/stable/guide/guide-error-mitigation.html>`_ ), it is natural to update the toolchain with new techniques and features.
 
-If you'd like to contribute new features to Mitiq, discuss it in an issue and once ready to upload the code, review the `contributing <contributing.html>`_ guidelines for the steps to take. If you have an example of using Mitiq with other software packages, or on a specific problem, we'd be glad to add it to the `Examples <examples/examples.html>`_ section of the documentation: please review the `contributing to the documentation <contributing_docs.html>`_ instructions.
+If you'd like to contribute new features to Mitiq, discuss it in an issue and once ready to upload the code, review the `contributing <https://mitiq.readthedocs.io/en/stable/contributing.html>`_ guidelines for the steps to take. If you have an example of using Mitiq with other software packages, or on a specific problem, we'd be glad to add it to the `Examples <https://mitiq.readthedocs.io/en/stable/examples/examples.html>`_ section of the documentation: please review the `contributing to the documentation <https://mitiq.readthedocs.io/en/stable/contributing_docs.html>`_ instructions.
 
 
 .. _citing:
@@ -34,7 +34,7 @@ If you are using Mitiq for your research, please cite the related `white paper <
 You can download the :download:`bibtex file <mitiq.bib>`.
 
 
-If you have developed new features for error mitigation, or found bugs in Mitiq, please consider `contributing <contributing.html>`_ your code.
+If you have developed new features for error mitigation, or found bugs in Mitiq, please consider `contributing <https://mitiq.readthedocs.io/en/stable/contributing.html>`_ your code.
 
 .. _cited_by:
 
@@ -56,4 +56,3 @@ The following papers use or cite Mitiq:
 
 An up-to-date list of papers citing the Mitiq paper can be found on `Semantic Scholar <https://www.semanticscholar.org/paper/Mitiq%3A-A-software-package-for-error-mitigation-on-LaRose-Mari/dc55b366d5b2212c6df8cd5c0bf05bab13104bd7#citing-papers>`_
 and on `Google Scholar <https://scholar.google.com/scholar?cites=12810395086731011605>`_.
-


### PR DESCRIPTION
Description
-----------

This is a no-brainer to include to me. There were ~15 broken links in the docs.

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
