### PR TITLE
Improve PEC efficiency with batched sampling

### DIFF
--- a/docs/source/guide/guide-getting-started.rst
+++ b/docs/source/guide/guide-getting-started.rst
@@ -310,7 +310,7 @@ We can now implement PEC by importing the function :func:`~mitiq.pec.pec.execute
 .. testoutput::
 
     Error without mitigation: 0.0387
-    Error with mitigation (PEC): 0.00364
+    Error with mitigation (PEC): 0.00363
 
 In addition to :func:`~mitiq.pec.pec.execute_with_pec`, you can also use Mitiq to wrap your
 backend execution function into an error-mitigated version like you can with zero-noise

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -109,8 +109,12 @@ def execute_with_pec(
             f" but precision is {precision}."
         )
 
+    converted_circuit, _ = convert_to_mitiq(circuit)
+
     # Get the 1-norm of the circuit quasi-probability representation
-    _, _, norm = sample_circuit(circuit, representations)
+    _, _, norm = sample_circuit(
+        converted_circuit, representations, num_samples=1,
+    )
 
     # Deduce the number of samples (if not given by the user)
     if not isinstance(num_samples, int):
@@ -120,15 +124,13 @@ def execute_with_pec(
     if num_samples > 10 ** 5:
         warnings.warn(_LARGE_SAMPLE_WARN, LargeSampleWarning)
 
-    sampled_circuits = []
-    signs = []
-    converted_circuit, _ = convert_to_mitiq(circuit)
-    for _ in range(num_samples):
-        sampled_circuit, sign, _ = sample_circuit(
-            converted_circuit, representations, random_state
-        )
-        sampled_circuits.append(sampled_circuit)
-        signs.append(sign)
+    # Sample all the circuits
+    sampled_circuits, signs, _ = sample_circuit(
+        converted_circuit,
+        representations,
+        random_state=random_state,
+        num_samples=num_samples,
+    )
 
     # Execute all sampled circuits
     collected_executor = generate_collected_executor(

--- a/mitiq/pec/sampling.py
+++ b/mitiq/pec/sampling.py
@@ -152,6 +152,6 @@ def sample_circuit(
             cirq_seq, _ = convert_to_mitiq(sequences[j])
             sampled_circuits[j].append(cirq_seq.all_operations())
 
-    sampled_circuits = [convert_from_mitiq(c, rtype) for c in sampled_circuits]
+    native_circuits = [convert_from_mitiq(c, rtype) for c in sampled_circuits]
 
-    return sampled_circuits, sampled_signs, norm
+    return native_circuits, sampled_signs, norm

--- a/mitiq/pec/sampling.py
+++ b/mitiq/pec/sampling.py
@@ -31,9 +31,12 @@ def sample_sequence(
     ideal_operation: QPROGRAM,
     representations: List[OperationRepresentation],
     random_state: Optional[Union[int, np.random.RandomState]] = None,
-) -> Tuple[QPROGRAM, int, float]:
-    """Samples an implementable sequence from the PEC representation of the
-    input ideal operation & returns this sequence as well as its sign and norm.
+    num_samples: int = 1,
+) -> Tuple[List[QPROGRAM], List[int], float]:
+    """Samples a list of implementable sequences from the quasi-probability
+    representation of the input ideal operation.
+    Returns the list of sequences, the corresponding list of signs and the
+    one-norm of the quasi-probability representation (of the input operation).
 
     For example, if the ideal operation is U with representation U = a A + b B,
     then this function returns A with probability :math:`|a| / (|a| + |b|)` and
@@ -51,11 +54,13 @@ def sample_sequence(
             noisy basis. If no representation is found for `ideal_operation`,
             a ValueError is raised.
         random_state: Seed for sampling.
+        num_samples: The number of samples.
 
     Returns:
-        imp_seq: The sampled implementable sequence as QPROGRAM.
-        sign: The sign associated to sampled sequence.
-        norm: The one-norm of the decomposition coefficients.
+        The tuple (``sequences``, ``signs``, norm) where:
+        ``sequences`` are the sampled sequences,
+        ``signs`` are the signs associated to the sampled ``sequences`` and
+        ``norm`` is the one-norm of the quasi-probability distribution.
 
     Raises:
         ValueError: If no representation is found for `ideal_operation`.
@@ -75,21 +80,27 @@ def sample_sequence(
         )
 
     # Sample from this representation.
-    noisy_operation, sign, _ = operation_representation.sample(random_state)
-    return noisy_operation.circuit(), sign, operation_representation.norm
+    norm = operation_representation.norm
+    sequences = []
+    signs = []
+    for _ in range(num_samples):
+        noisy_op, sign, _ = operation_representation.sample(random_state)
+        sequences.append(noisy_op.circuit())
+        signs.append(sign)
+
+    return sequences, signs, norm
 
 
 def sample_circuit(
     ideal_circuit: QPROGRAM,
     representations: List[OperationRepresentation],
     random_state: Optional[Union[int, np.random.RandomState]] = None,
-) -> Tuple[QPROGRAM, int, float]:
-    """Samples an implementable circuit from the PEC representation of the
-    input ideal circuit & returns this circuit as well as its sign and norm.
-
-    This function iterates through each operation in the circuit and samples
-    an implementable sequence. The returned sign (norm) is the product of signs
-    (norms) sampled for each operation.
+    num_samples: int = 1,
+) -> Tuple[List[QPROGRAM], List[int], float]:
+    """Samples a list of implementable circuits from the PEC representation of the
+    input ideal circuit.
+    Returns the list of circuits, the corresponding list of signs and the
+    one-norm of the quasi-probability representation (of the full circuit).
 
     Args:
         ideal_circuit: The ideal circuit from which an implementable circuit
@@ -97,12 +108,15 @@ def sample_circuit(
         representations: List of representations of every operation in the
             input circuit. If a representation cannot be found for an operation
             in the circuit, a ValueError is raised.
+        num_samples: The number of samples.
         random_state: Seed for sampling.
+        num_samples: The number of samples.
 
     Returns:
-        imp_circuit: The sampled implementable circuit.
-        sign: The sign associated to sampled_circuit.
-        norm: The one norm of the PEC coefficients of the circuit.
+        The tuple (``sampled_circuits``, ``signs``, ``norm``) where
+        ``sampled_circuits`` are the sampled implementable circuits,
+        ``signs`` are the signs associated to sampled_circuits and
+        ``norm`` is the one-norm of the circuit representation.
 
     Raises:
         ValueError:
@@ -116,22 +130,29 @@ def sample_circuit(
     ideal, rtype = convert_to_mitiq(ideal_circuit)
 
     # copy and remove all moments
-    sampled_circuit = deepcopy(ideal)[0:0]
-
-    # Iterate over all operations
-    sign = 1
+    sampled_circuits = [deepcopy(ideal)[0:0] for _ in range(num_samples)]
+    sampled_signs = [1 for _ in range(num_samples)]
     norm = 1.0
+
     for op in ideal.all_operations():
         # Ignore all measurements.
         if cirq.is_measurement(op):
             continue
 
-        imp_seq, loc_sign, loc_norm = sample_sequence(
-            cirq.Circuit(op), representations, random_state
+        sequences, loc_signs, loc_norm = sample_sequence(
+            cirq.Circuit(op),
+            representations,
+            num_samples=num_samples,
+            random_state=random_state,
         )
-        cirq_seq, _ = convert_to_mitiq(imp_seq)
-        sign *= loc_sign
-        norm *= loc_norm
-        sampled_circuit.append(cirq_seq.all_operations())
 
-    return convert_from_mitiq(sampled_circuit, rtype), sign, norm
+        norm *= loc_norm
+
+        for j in range(num_samples):
+            sampled_signs[j] *= loc_signs[j]
+            cirq_seq, _ = convert_to_mitiq(sequences[j])
+            sampled_circuits[j].append(cirq_seq.all_operations())
+
+    native_circuits = [convert_from_mitiq(c, rtype) for c in sampled_circuits]
+
+    return native_circuits, sampled_signs, norm

--- a/mitiq/pec/sampling.py
+++ b/mitiq/pec/sampling.py
@@ -97,8 +97,8 @@ def sample_circuit(
     random_state: Optional[Union[int, np.random.RandomState]] = None,
     num_samples: int = 1,
 ) -> Tuple[List[QPROGRAM], List[int], float]:
-    """Samples a list of implementable circuits from the PEC representation of the
-    input ideal circuit.
+    """Samples a list of implementable circuits from the quasi-probability
+    representation of the input ideal circuit.
     Returns the list of circuits, the corresponding list of signs and the
     one-norm of the quasi-probability representation (of the full circuit).
 
@@ -108,7 +108,6 @@ def sample_circuit(
         representations: List of representations of every operation in the
             input circuit. If a representation cannot be found for an operation
             in the circuit, a ValueError is raised.
-        num_samples: The number of samples.
         random_state: Seed for sampling.
         num_samples: The number of samples.
 
@@ -153,6 +152,6 @@ def sample_circuit(
             cirq_seq, _ = convert_to_mitiq(sequences[j])
             sampled_circuits[j].append(cirq_seq.all_operations())
 
-    native_circuits = [convert_from_mitiq(c, rtype) for c in sampled_circuits]
+    sampled_circuits = [convert_from_mitiq(c, rtype) for c in sampled_circuits]
 
-    return native_circuits, sampled_signs, norm
+    return sampled_circuits, sampled_signs, norm

--- a/mitiq/pec/sampling.py
+++ b/mitiq/pec/sampling.py
@@ -57,7 +57,7 @@ def sample_sequence(
         num_samples: The number of samples.
 
     Returns:
-        The tuple (``sequences``, ``signs``, norm) where
+        The tuple (``sequences``, ``signs``, ``norm``) where
         ``sequences`` are the sampled sequences,
         ``signs`` are the signs associated to the sampled ``sequences`` and
         ``norm`` is the one-norm of the quasi-probability distribution.

--- a/mitiq/pec/sampling.py
+++ b/mitiq/pec/sampling.py
@@ -57,7 +57,7 @@ def sample_sequence(
         num_samples: The number of samples.
 
     Returns:
-        The tuple (``sequences``, ``signs``, norm) where:
+        The tuple (``sequences``, ``signs``, norm) where
         ``sequences`` are the sampled sequences,
         ``signs`` are the signs associated to the sampled ``sequences`` and
         ``norm`` is the one-norm of the quasi-probability distribution.


### PR DESCRIPTION
PEC is very slow. This is partially an intrinsic aspect of PEC but there is space for improving the efficiency of the Mitiq implementation.
I noticed that the main bottleneck is not the execution of the sampled circuits but their sampling.

So, instead of sampling the circuits sequentially, with this PR I try to sample all of them in a batched way.

The main difference is that now, for each operation, we search the corresponding representation in `representations`  only once and this gives a significant speed up.

Note: this a small but breaking change since `sample_sequence` and `sample_circuits` now returns lists of objects instead of objects.

## Speed test before this PR
`pytest mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise --durations=0
`
```
0.51s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[pyquil-serial_executor-circuit0]
0.46s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[cirq-batched_executor-circuit0]
0.44s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[braket-serial_executor-circuit0]
0.43s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[cirq-serial_executor-circuit0]
0.43s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[pyquil-batched_executor-circuit0]
0.43s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[braket-batched_executor-circuit0]
0.39s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[qiskit-batched_executor-circuit1]
0.39s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[cirq-batched_executor-circuit1]
0.37s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[pyquil-serial_executor-circuit1]
0.37s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[qiskit-serial_executor-circuit1]
0.37s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[braket-batched_executor-circuit1]
0.37s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[pyquil-batched_executor-circuit1]
0.37s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[cirq-serial_executor-circuit1]
0.36s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[braket-serial_executor-circuit1]
0.34s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[qiskit-batched_executor-circuit0]
0.33s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[qiskit-serial_executor-circuit0]
```

## Speed test after this PR
```
0.17s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[qiskit-serial_executor-circuit0]
0.13s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[qiskit-batched_executor-circuit1]
0.13s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[qiskit-serial_executor-circuit1]
0.09s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[qiskit-batched_executor-circuit0]
0.09s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[braket-serial_executor-circuit1]
0.09s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[cirq-serial_executor-circuit1]
0.09s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[pyquil-serial_executor-circuit1]
0.09s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[pyquil-batched_executor-circuit1]
0.09s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[braket-batched_executor-circuit1]
0.09s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[cirq-batched_executor-circuit1]
0.06s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[pyquil-serial_executor-circuit0]
0.05s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[cirq-serial_executor-circuit0]
0.05s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[braket-serial_executor-circuit0]
0.05s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[pyquil-batched_executor-circuit0]
0.05s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[braket-batched_executor-circuit0]
0.05s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[cirq-batched_executor-circuit0]
0.01s call     mitiq/pec/tests/test_pec.py::test_execute_with_pec_mitigates_noise[braket-batched_executor-circuit0]
```
