### PR TITLE
Show output of Mitiq paper code blocks in example on RTD

### DIFF
--- a/docs/source/examples/mitiq-paper/mitiq-paper-codeblocks.md
+++ b/docs/source/examples/mitiq-paper/mitiq-paper-codeblocks.md
@@ -1,11 +1,10 @@
 ---
 jupytext:
-  formats: md:myst
   text_representation:
-    extension: .myst
+    extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.10.3
+    jupytext_version: 1.11.3
 kernelspec:
   display_name: Python 3
   language: python


### PR DESCRIPTION
On RTD, in the latest [build](https://mitiq.readthedocs.io/en/latest/examples/mitiq-paper/mitiq-paper-codeblocks.html) the Mitiq paper code blocks outputs are not shown, unlike for the other files, including the CDR API file. I thus enforced the `.md` extension for the paper code blocks file and copied the CDR API file metadata. 

Note that also in the old way (current master), if I was doing `make docs` locally I would see the run code blocks. 