### PR TITLE
Set measurement result type and add post-selection

### DIFF
--- a/mitiq/_typing.py
+++ b/mitiq/_typing.py
@@ -57,13 +57,14 @@ QPROGRAM = Union[_Circuit, _Program, _QuantumCircuit, _BKCircuit]
 
 # Supported measurement results.
 Bitstring = List[int]
+MeasurementResult = List[Bitstring]
 
 # An `executor` function inputs a quantum program and outputs an object from
 # which expectation values can be computed. Explicitly, this object can be one
 # of the following types:
 QuantumResult = Union[
     float,  # The expectation value itself.
-    List[Bitstring],  # Sampled bitstrings.
+    MeasurementResult,  # Sampled bitstrings.
     # TODO: Support the following:
     # np.ndarray,  # Density matrix.
     # Sequence[np.ndarray],  # Wavefunctions sampled via quantum trajectories.

--- a/mitiq/_typing.py
+++ b/mitiq/_typing.py
@@ -13,15 +13,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Defines SUPPORTED_PROGRAM_TYPES - all supported packages / circuits which
-Mitiq can interface with - and QPROGRAM - all supported packages / circuits
-which are installed in the environment Mitiq is run in.
+"""Defines input / output types for a quantum computer (simulator):
+
+  * SUPPORTED_PROGRAM_TYPES: All supported packages / circuits which Mitiq can
+       interface with,
+  * QPROGRAM: All supported packages / circuits which are installed in the
+       environment Mitiq is run in, and
+  * QuantumResult: An object returned by a quantum computer (simulator) running
+       a quantum program from which expectation values to be mitigated can be
+       computed. Note this includes expectation values themselves.
 """
-from typing import Union
+from typing import List, Union
 
 from cirq import Circuit as _Circuit
 
 
+# Supported quantum programs.
 SUPPORTED_PROGRAM_TYPES = {
     "cirq": "Circuit",
     "pyquil": "Program",
@@ -45,4 +52,19 @@ try:
 except ImportError:  # pragma: no cover
     _BKCircuit = _Circuit
 
+# Supported + installed quantum programs.
 QPROGRAM = Union[_Circuit, _Program, _QuantumCircuit, _BKCircuit]
+
+# Supported measurement results.
+Bitstring = List[int]
+
+# An `executor` function inputs a quantum program and outputs an object from
+# which expectation values can be computed. Explicitly, this object can be one
+# of the following types:
+QuantumResult = Union[
+    float,  # The expectation value itself.
+    List[Bitstring],  # Sampled bitstrings.
+    # TODO: Support the following:
+    # np.ndarray,  # Density matrix.
+    # Sequence[np.ndarray],  # Wavefunctions sampled via quantum trajectories.
+]

--- a/mitiq/collector.py
+++ b/mitiq/collector.py
@@ -22,20 +22,8 @@ from typing import Any, Callable, Iterable, List, Sequence, Tuple, Union
 
 import numpy as np
 
-from mitiq import QPROGRAM
+from mitiq._typing import QPROGRAM, QuantumResult
 from mitiq.interface import convert_from_mitiq, convert_to_mitiq
-
-# An `executor` function inputs a quantum program and outputs an object from
-# which expectation values can be computed. Explicitly, this object can be one
-# of the following types:
-Bitstring = List[int]
-QuantumResult = Union[
-    float,  # The expectation value itself.
-    List[Bitstring],  # Sampled bitstrings.
-    # TODO: Support the following:
-    # np.ndarray,  # Density matrix.
-    # Sequence[np.ndarray],  # Wavefunctions sampled via quantum trajectories.
-]
 
 
 def generate_collected_executor(

--- a/mitiq/collector.py
+++ b/mitiq/collector.py
@@ -21,7 +21,6 @@ import inspect
 from typing import Any, Callable, Iterable, List, Sequence, Tuple, Union
 
 import numpy as np
-from cirq import Result as MeasurementResult  # TODO: Generalize frontend.
 
 from mitiq import QPROGRAM
 from mitiq.interface import convert_from_mitiq, convert_to_mitiq
@@ -29,9 +28,10 @@ from mitiq.interface import convert_from_mitiq, convert_to_mitiq
 # An `executor` function inputs a quantum program and outputs an object from
 # which expectation values can be computed. Explicitly, this object can be one
 # of the following types:
+Bitstring = List[int]
 QuantumResult = Union[
     float,  # The expectation value itself.
-    MeasurementResult,  # Sampled bitstrings.
+    List[Bitstring],  # Sampled bitstrings.
     # TODO: Support the following:
     # np.ndarray,  # Density matrix.
     # Sequence[np.ndarray],  # Wavefunctions sampled via quantum trajectories.

--- a/mitiq/rem/__init__.py
+++ b/mitiq/rem/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Readout error mitigation (REM) techniques."""
+
+from mitiq.rem.post_select import post_select

--- a/mitiq/rem/post_select.py
+++ b/mitiq/rem/post_select.py
@@ -27,8 +27,7 @@ def post_select(
 
     Args:
         measurement_result: List of bitstrings.
-        hamming_weight: Hamming weight of each returned bitstring (possibly
-            none).
+        hamming_weight: Hamming weight of each returned bitstring (if any).
         inverted: If True, 0s count towards the Hamming weight instead of 1s.
             E.g., the inverted Hamming weight of ``[1, 0, 1]`` is 1 whereas the
             "regular" Hamming weight of this bitstring is 2.

--- a/mitiq/rem/post_select.py
+++ b/mitiq/rem/post_select.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from mitiq._typing import MeasurementResult
+
+
+def post_select(
+    measurement_result: MeasurementResult,
+    hamming_weight: int,
+    inverted: bool = False,
+) -> MeasurementResult:
+    """Discards bitstrings which do not satisfy the provided Hamming weight
+    (i.e., number of 1s in the bitstring) and returns this new
+    ``MeasurementResult``.
+
+    Args:
+        measurement_result: List of bitstrings.
+        hamming_weight: Hamming weight of each returned bitstring (possibly
+            none).
+        inverted: If True, 0s count towards the Hamming weight instead of 1s.
+            E.g., the inverted Hamming weight of ``[1, 0, 1]`` is 1 whereas the
+            "regular" Hamming weight of this bitstring is 2.
+
+            Note: If ``inverted`` is True, the first bitstring in
+            ``measurement_result`` is used to determine the new target weight,
+            so this assumes all bitstrings have the same length.
+    """
+    if len(measurement_result) == 0:
+        return []
+
+    if inverted:
+        hamming_weight = len(measurement_result[0]) - hamming_weight
+
+    return [bits for bits in measurement_result if sum(bits) == hamming_weight]

--- a/mitiq/rem/tests/test_post_select.py
+++ b/mitiq/rem/tests/test_post_select.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Unit tests for post-selection of measurement results."""
+import pytest
+
+from mitiq.rem import post_select
+
+
+def test_post_select():
+    measurement = [[0, 1, 1], [1, 1, 0], [0, 0, 0], [0, 0, 1], [1, 1, 1]]
+
+    assert post_select(measurement, hamming_weight=3) == [[1, 1, 1]]
+    assert post_select(measurement, hamming_weight=2) == [[0, 1, 1], [1, 1, 0]]
+    assert post_select(measurement, hamming_weight=1) == [[0, 0, 1]]
+    assert post_select(measurement, hamming_weight=0) == [[0, 0, 0]]
+
+
+def test_post_select_inverted():
+    res = [[0, 0, 1], [1, 1, 0], [0, 0, 0]]
+
+    assert post_select(res, hamming_weight=1) == [[0, 0, 1]]
+    assert post_select(res, hamming_weight=1, inverted=True) == [[1, 1, 0]]
+
+    assert post_select(res, hamming_weight=3) == []
+    assert post_select(res, hamming_weight=3, inverted=True) == [[0, 0, 0]]
+
+
+@pytest.mark.parametrize("inverted", (True, False))
+def test_post_select_empty_measurement_result(inverted):
+    assert post_select([], hamming_weight=3, inverted=inverted) == []
+
+
+def test_post_select_edge_cases():
+    samples = [[1], [0], [1], [0], [0], [1], [1], [1]]
+
+    assert post_select(samples, hamming_weight=-1) == []
+    assert post_select(samples, hamming_weight=23) == []

--- a/mitiq/rem/tests/test_post_select.py
+++ b/mitiq/rem/tests/test_post_select.py
@@ -20,31 +20,47 @@ from mitiq.rem import post_select
 
 
 def test_post_select():
-    measurement = [[0, 1, 1], [1, 1, 0], [0, 0, 0], [0, 0, 1], [1, 1, 1]]
+    res = [[0, 1, 1], [1, 1, 0], [0, 0, 0], [0, 0, 1], [1, 1, 1]]
 
-    assert post_select(measurement, hamming_weight=3) == [[1, 1, 1]]
-    assert post_select(measurement, hamming_weight=2) == [[0, 1, 1], [1, 1, 0]]
-    assert post_select(measurement, hamming_weight=1) == [[0, 0, 1]]
-    assert post_select(measurement, hamming_weight=0) == [[0, 0, 0]]
+    assert post_select(res, lambda bits: sum(bits) == 3) == [[1, 1, 1]]
+    assert post_select(res, lambda b: sum(b) == 2) == [[0, 1, 1], [1, 1, 0]]
+    assert post_select(res, lambda bits: sum(bits) == 1) == [[0, 0, 1]]
+    assert post_select(res, lambda bits: sum(bits) == 0) == [[0, 0, 0]]
 
 
 def test_post_select_inverted():
     res = [[0, 0, 1], [1, 1, 0], [0, 0, 0]]
 
-    assert post_select(res, hamming_weight=1) == [[0, 0, 1]]
-    assert post_select(res, hamming_weight=1, inverted=True) == [[1, 1, 0]]
+    assert post_select(res, lambda bits: sum(bits) == 1) == [[0, 0, 1]]
+    assert post_select(res, lambda bits: sum(bits) == 1, inverted=True) == [
+        [1, 1, 0],
+        [0, 0, 0],
+    ]
 
-    assert post_select(res, hamming_weight=3) == []
-    assert post_select(res, hamming_weight=3, inverted=True) == [[0, 0, 0]]
+    assert post_select(res, lambda bits: sum(bits) == 3) == []
+    assert post_select(res, lambda bits: sum(bits) == 3, inverted=True) == res
 
 
 @pytest.mark.parametrize("inverted", (True, False))
 def test_post_select_empty_measurement_result(inverted):
-    assert post_select([], hamming_weight=3, inverted=inverted) == []
+    assert post_select([], lambda bits: sum(bits) == 3, inverted) == []
+
+
+def test_post_select_hamming_weight_less_than():
+    res = [[0, 1, 1], [1, 1, 0], [0, 0, 0], [0, 0, 1], [1, 1, 1]]
+
+    assert post_select(res, lambda bits: sum(bits) < 1) == [[0, 0, 0]]
+    assert post_select(res, lambda b: sum(b) < 2) == [[0, 0, 0], [0, 0, 1]]
+
+
+def test_post_select_hamming_weight_specific_bit():
+    res = [[0, 1, 1], [1, 1, 0], [0, 0, 0], [0, 0, 1], [1, 1, 1]]
+
+    assert post_select(res, lambda b: b[1] == 0) == [[0, 0, 0], [0, 0, 1]]
 
 
 def test_post_select_edge_cases():
     samples = [[1], [0], [1], [0], [0], [1], [1], [1]]
 
-    assert post_select(samples, hamming_weight=-1) == []
-    assert post_select(samples, hamming_weight=23) == []
+    assert post_select(samples, lambda bits: sum(bits) == -1) == []
+    assert post_select(samples, lambda bits: sum(bits) == 23) == []

--- a/mitiq/tests/test_collector.py
+++ b/mitiq/tests/test_collector.py
@@ -66,15 +66,16 @@ def executor_serial_measurements(circuit) -> List[List[int]]:
     assert len(circuit.all_measurement_keys()) == 1
 
     key = circuit.all_measurement_keys().pop()
-    return cirq.Simulator().run(
-        circuit, repetitions=10
-    ).measurements[key].tolist()
+    return (
+        cirq.Simulator()
+        .run(circuit, repetitions=10)
+        .measurements[key]
+        .tolist()
+    )
 
 
 def executor_batched_measurements(circuits) -> List[List[List[int]]]:
-    return [
-        executor_serial_measurements(circuit) for circuit in circuits
-    ]
+    return [executor_serial_measurements(circuit) for circuit in circuits]
 
 
 def test_collector_simple():

--- a/mitiq/tests/test_collector.py
+++ b/mitiq/tests/test_collector.py
@@ -66,12 +66,8 @@ def executor_serial_measurements(circuit) -> List[List[int]]:
     assert len(circuit.all_measurement_keys()) == 1
 
     key = circuit.all_measurement_keys().pop()
-    return (
-        cirq.Simulator()
-        .run(circuit, repetitions=10)
-        .measurements[key]
-        .tolist()
-    )
+    backend = cirq.Simulator()
+    return backend.run(circuit, repetitions=10).measurements[key].tolist()
 
 
 def executor_batched_measurements(circuits) -> List[List[List[int]]]:

--- a/mitiq/tests/test_collector.py
+++ b/mitiq/tests/test_collector.py
@@ -61,13 +61,19 @@ def executor_pyquil_batched(programs) -> List[float]:
 
 
 # Serial / batched executors which return measurements.
-def executor_serial_measurements(circuit) -> cirq.Result:
-    return cirq.Simulator().run(circuit, repetitions=10)
+def executor_serial_measurements(circuit) -> List[List[int]]:
+    # Assume there is only one measurement key in the circuit.
+    assert len(circuit.all_measurement_keys()) == 1
+
+    key = circuit.all_measurement_keys().pop()
+    return cirq.Simulator().run(
+        circuit, repetitions=10
+    ).measurements[key].tolist()
 
 
-def executor_batched_measurements(circuits) -> List[cirq.Result]:
+def executor_batched_measurements(circuits) -> List[List[List[int]]]:
     return [
-        cirq.Simulator().run(circuit, repetitions=10) for circuit in circuits
+        executor_serial_measurements(circuit) for circuit in circuits
     ]
 
 


### PR DESCRIPTION
Description
-----------

This is part 2/2 of #826 except we decided to not add conversions at all and assume a simple format (for now) for measurement results. Also adds post-selection in a new readout error mitigation (REM) module, closing #816. 

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
