### PR TITLE
Make sure stale marking of issues happens

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -18,7 +18,5 @@ jobs:
           days-before-close: 7
           stale-issue-message: This issue had no activity for **2 months**, and will be closed in **one week** unless there is new activity. Cheers!
           stale-issue-label: stale
-          exempt-issue-labels: priority/p0,priority/p1,priority/p2
           stale-pr-message: This pull request had no activity for **2 months**, and will be closed in **one week** unless there is new activity. Cheers!
           stale-pr-label: stale
-          exempt-pr-labels: priority/p0,priority/p1,priority/p2

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -13,3 +13,12 @@ jobs:
     steps:
       - name: Close Stale Issues
         uses: actions/stale@v3.0.19
+        with:
+          days-before-stale: 60
+          days-before-close: 7
+          stale-issue-message: This issue had no activity for **2 months**, and will be closed in **one week** unless there is new activity. Cheers!
+          stale-issue-label: stale
+          exempt-issue-labels: priority/p0,priority/p1,priority/p2
+          stale-pr-message: This pull request had no activity for **2 months**, and will be closed in **one week** unless there is new activity. Cheers!
+          stale-pr-label: stale
+          exempt-pr-labels: priority/p0,priority/p1,priority/p2


### PR DESCRIPTION
Description
-----------

Updating the GH action workflow so the stale tagging action works. Fixes #848.

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

