### PR TITLE
Manual PyPI deployment trigger

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -5,7 +5,9 @@ name: Upload Release Package to PyPI
 
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch:
+    inputs: {}
 
 jobs:
   deploy:


### PR DESCRIPTION
Description
-----------
Adds a manual trigger and modifies the default one to ensure the PyPI deployment can be done from GH.


Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

