### PR TITLE
Fixing syntax for dependabot to make it work correctly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,17 @@
 version: 2
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
-    directory: "requirements.txt" # Location of package manifests
+    directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "dev_requirements.txt" # Location of package manifests
+    allow:
+      - dependency-type: "all"
+    # Allow up to 10 open pull requests for pip dependencies
+    open-pull-requests-limit: 10
+    labels:
+      - "infrastructure"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
+      # Check for updates to GitHub Actions every weekday
       interval: "daily"


### PR DESCRIPTION
Description
-----------
Realized through other docs that this automation wasn't working. Should check now daily for any out of date/incompatable pip requirements for both requirements and dev-requirements


Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
