### PR TITLE
Add `qubit_indices` to `MeasurementResult`

### DIFF
--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -272,7 +272,11 @@ class PauliStringCollection:
         total = 0.0
         for pauli in self.elements:
             bitstrings = measurements[sorted(pauli.support())]
-            value = np.average([(-1) ** np.sum(bits) for bits in bitstrings])
+            value = (
+                np.average([(-1) ** np.sum(bits) for bits in bitstrings])
+                if len(bitstrings) > 0
+                else 1.0
+            )
             total += pauli.coeff * value
         return total
 

--- a/mitiq/observable/tests/test_pauli.py
+++ b/mitiq/observable/tests/test_pauli.py
@@ -319,3 +319,18 @@ def test_pstringcollection_expectation_from_measurements():
         PauliString(spec="ZI", coeff=-2.0), PauliString(spec="IZ", coeff=5.0)
     )
     assert np.isclose(pset._expectation_from_measurements(measurements), 0.0)
+
+
+def test_pstringcollection_expectation_from_measurements_qubit_indices():
+    measurements = MeasurementResult(
+        [[0, 0], [0, 0], [0, 1], [0, 1]], qubit_indices=(1, 5)
+    )
+    pset = PauliStringCollection(
+        PauliString(spec="Z", coeff=-2.0, support=(1,))
+    )
+    assert np.isclose(pset._expectation_from_measurements(measurements), -2.0)
+
+    pset = PauliStringCollection(
+        PauliString(spec="Z", coeff=-2.0, support=(5,))
+    )
+    assert np.isclose(pset._expectation_from_measurements(measurements), 0.0)

--- a/mitiq/rem/measurement_result.py
+++ b/mitiq/rem/measurement_result.py
@@ -26,19 +26,7 @@ Bitstring = List[int]
 
 @dataclass
 class MeasurementResult:
-    """Bitstrings sampled from a quantum computer.
-
-    Example:
-        >>> # Sample result of measuring three qubits twice.
-        >>> result = MeasurementResult([[0, 1, 0], [0, 0, 1]])
-        >>> print(result.nqubits)  # 3
-        >>> print(result.shots)  # 2
-        >>> print(result.asarray)
-        >>> # [[0 1 0]
-        >>> #  [0 0 1]]
-        >>> print(result)
-        >>> # MeasurementResult(result=[[0, 1, 0], [0, 0, 1]])
-    """
+    """Bitstrings sampled from a quantum computer."""
 
     result: List[Bitstring]
     qubit_indices: Optional[Tuple[int, ...]] = None

--- a/mitiq/rem/measurement_result.py
+++ b/mitiq/rem/measurement_result.py
@@ -16,7 +16,7 @@
 """Defines MeasurementResult, a result obtained by measuring qubits on a
 quantum computer."""
 from dataclasses import dataclass
-from typing import cast, Iterable, List
+from typing import cast, Iterable, List, Optional, Tuple
 
 import numpy as np
 
@@ -41,6 +41,7 @@ class MeasurementResult:
     """
 
     result: List[Bitstring]
+    qubit_indices: Optional[Tuple[int, ...]] = None
 
     def __post_init__(self) -> None:
         if not set(b for bits in self.result for b in bits).issubset({0, 1}):
@@ -51,6 +52,16 @@ class MeasurementResult:
         self._bitstrings = np.array(self.result)
         if isinstance(self.result, np.ndarray):
             self.result = cast(List[Bitstring], self.result.tolist())
+
+        if not self.qubit_indices:
+            self.qubit_indices = tuple(range(self.nqubits))
+        else:
+            if len(self.qubit_indices) != self.nqubits:
+                raise ValueError(
+                    f"MeasurementResult has {self.nqubits} qubit(s) but there "
+                    f"are {len(self.qubit_indices)} `qubit_indices`."
+                )
+        self._measurements = dict(zip(self.qubit_indices, self._bitstrings.T))
 
     @property
     def shots(self) -> int:
@@ -69,7 +80,7 @@ class MeasurementResult:
         return self._bitstrings
 
     def __getitem__(self, indices: List[int]) -> np.ndarray:
-        return self._bitstrings[:, indices]
+        return np.array([self._measurements[i] for i in indices]).T
 
     def __iter__(self) -> Iterable[Bitstring]:
         yield from self.result

--- a/mitiq/rem/tests/test_measurement_result.py
+++ b/mitiq/rem/tests/test_measurement_result.py
@@ -21,16 +21,26 @@ from mitiq.rem.measurement_result import MeasurementResult
 
 
 @pytest.mark.parametrize("asarray", (True, False))
-def test_measurement_result(asarray):
+@pytest.mark.parametrize("qubit_indices", ((0, 1), (1, 20)))
+def test_measurement_result(asarray, qubit_indices):
     bitstrings = [[0, 0], [0, 1], [1, 0]]
     if asarray:
         bitstrings = np.array(bitstrings)
-    result = MeasurementResult(bitstrings)
+    result = MeasurementResult(bitstrings, qubit_indices=qubit_indices)
 
     assert result.nqubits == 2
+    assert result.qubit_indices == qubit_indices
     assert result.shots == 3
     assert np.allclose(result.result, bitstrings)
-    assert repr(result) == "MeasurementResult(result=[[0, 0], [0, 1], [1, 0]])"
+    assert (
+        repr(result) == f"MeasurementResult(result=[[0, 0], [0, 1], [1, 0]], "
+        f"qubit_indices={qubit_indices})"
+    )
+
+
+def test_measurement_result_bad_qubit_indices():
+    with pytest.raises(ValueError, match="MeasurementResult has"):
+        MeasurementResult([[0], [1]], qubit_indices=(1, 5))
 
 
 def test_measurement_result_not_bits():
@@ -50,8 +60,6 @@ def test_getitem():
     assert np.allclose(result[[0, 1]], np.array([[0, 0], [0, 1], [1, 0]]))
     assert np.allclose(result[[0, 2]], np.array([[0, 1], [0, 0], [1, 0]]))
     assert np.allclose(result[[1, 2]], np.array([[0, 1], [1, 0], [0, 0]]))
-
-    assert np.allclose(result[:], result._bitstrings)
 
 
 def test_empty():


### PR DESCRIPTION
Description
-----------

Imagine you prepare the two-qubit ansatz

```python
a, b = cirq.LineQubit.range(2)
circuit = cirq.Circuit(cirq.H.on_each(a, b))
```

and want to compute the expectation value of

```python
obs = mitiq.Observable(mitiq.PauliString(spec="Z", support=(1,))
```

`obs.measure_in(circuit)` returns a circuit which measures the qubit index `1`, but this is the only measurement. Thus the returned `MeasurementResult` indexed by `1` (the support of the `PauliString` being measured) raises an `IndexError` - it only has index `0`. We therefore need to know the qubit indices of the measured bitstrings in `MeasurementResult`.

This PR adds support for this in a mostly backwards compatible way (not that it matters at the moment).

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
