### PR TITLE
Dependabot settings patch: one dependancy per line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,19 @@ updates:
     allow:
       - dependency-type: "all"
     ignore:
-      - dependency-name: "*pytest*", "flake8", "black", "mypy", "*sphinx*", "myst*", "jupytext"
+      - dependency-name: "*pytest*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "flake8"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "black"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "mypy"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "*sphinx*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "myst*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "jupytext"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
     # Allow up to 10 open pull requests for pip dependencies
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       - dependency-name: "flake8"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "black"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "mypy"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "*sphinx*"


### PR DESCRIPTION
Description
-----------

Saw a syntax error here https://github.com/unitaryfund/mitiq/pull/899/checks?check_run_id=3590903600 after #920. I think it (annoyingly) wants one dependency per line in ignore.

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
