### PR TITLE
Change Binder link from jupyterlab to classic view

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Repository](https://img.shields.io/badge/GitHub-5C5C5C.svg?logo=github)](https://github.com/unitaryfund/mitiq)
 [![Unitary Fund](https://img.shields.io/badge/Supported%20By-Unitary%20Fund-FFFF00.svg)](https://unitary.fund)
 [![Discord Chat](https://img.shields.io/badge/dynamic/json?color=blue&label=Discord&query=approximate_presence_count&suffix=%20online.&url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FJqVGmpkP96%3Fwith_counts%3Dtrue)](http://discord.unitary.fund)
-[![Binder](https://mybinder.org/v2/gh/unitaryfund/mitiq/master/?urlpath=%2Ftree%2Fdocs%2Fsource%2Fexamples)
+[![Binder]([![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/unitaryfund/mitiq/master?urlpath=%2Ftree%2Fdocs%2Fsource%2Fexamples)
 
 Mitiq is a Python toolkit for implementing error mitigation techniques on
 quantum computers.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Repository](https://img.shields.io/badge/GitHub-5C5C5C.svg?logo=github)](https://github.com/unitaryfund/mitiq)
 [![Unitary Fund](https://img.shields.io/badge/Supported%20By-Unitary%20Fund-FFFF00.svg)](https://unitary.fund)
 [![Discord Chat](https://img.shields.io/badge/dynamic/json?color=blue&label=Discord&query=approximate_presence_count&suffix=%20online.&url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FJqVGmpkP96%3Fwith_counts%3Dtrue)](http://discord.unitary.fund)
-[![Binder]([![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/unitaryfund/mitiq/master?urlpath=%2Ftree%2Fdocs%2Fsource%2Fexamples)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/unitaryfund/mitiq/master?urlpath=%2Ftree%2Fdocs%2Fsource%2Fexamples)
 
 Mitiq is a Python toolkit for implementing error mitigation techniques on
 quantum computers.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Repository](https://img.shields.io/badge/GitHub-5C5C5C.svg?logo=github)](https://github.com/unitaryfund/mitiq)
 [![Unitary Fund](https://img.shields.io/badge/Supported%20By-Unitary%20Fund-FFFF00.svg)](https://unitary.fund)
 [![Discord Chat](https://img.shields.io/badge/dynamic/json?color=blue&label=Discord&query=approximate_presence_count&suffix=%20online.&url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FJqVGmpkP96%3Fwith_counts%3Dtrue)](http://discord.unitary.fund)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/unitaryfund/mitiq/master?filepath=%2Fdocs%2Fsource%2Fexamples)
+[![Binder](https://mybinder.org/v2/gh/unitaryfund/mitiq/master/?urlpath=%2Ftree%2Fdocs%2Fsource%2Fexamples)
 
 Mitiq is a Python toolkit for implementing error mitigation techniques on
 quantum computers.


### PR DESCRIPTION
Description
-----------
The new version of Binder opens a Jupyterlab interface by default. This has problems with visualizing `myst` notebooks.
This PR changes the Binder link such that the classic Jupyter Notebook view is used.

 