### PR TITLE
A few changes / fixes to mirror circuits

### DIFF
--- a/mitiq/benchmarks/mirror_circuits.py
+++ b/mitiq/benchmarks/mirror_circuits.py
@@ -99,7 +99,9 @@ def random_cliffords(
     ]
     qubits = nx.Graph()
     qubits.add_nodes_from(nx.isolates(connectivity_graph))
-    gates.append(random_single_cliffords(qubits, random_state))
+    gates.extend(
+        list(random_single_cliffords(qubits, random_state).all_operations())
+    )
     return cirq.Circuit(gates)
 
 

--- a/mitiq/benchmarks/mirror_circuits.py
+++ b/mitiq/benchmarks/mirror_circuits.py
@@ -29,18 +29,18 @@ paulis = [cirq.X, cirq.Y, cirq.Z, cirq.I]
 
 
 def random_paulis(
-    nqubits: int, random_state: random.RandomState
+    connectivity_graph: nx.Graph, random_state: random.RandomState
 ) -> cirq.Circuit:
     """Returns a circuit with randomly selected Pauli gates on each qubit.
 
     Args:
-        nqubits: The number of qubits in the circuit.
+        connectivity_graph: Connectivity graph of device to run circuit on.
         random_state: Random state to select Paulis I, X, Y, Z uniformly at
             random.
     """
     return cirq.Circuit(
         paulis[random_state.randint(len(paulis))](cirq.LineQubit(x))
-        for x in range(nqubits)
+        for x in connectivity_graph.nodes
     )
 
 
@@ -92,6 +92,7 @@ def random_cliffords(
         connectivity_graph: A graph with the edges for which the
             two-qubit Clifford gate is to be applied.
         random_state: Random state to choose Cliffords (uniformly at random).
+        two_qubit_gate: Two-qubit gate to use.
     """
     gates = [
         two_qubit_gate.on(cirq.LineQubit(a), cirq.LineQubit(b))
@@ -161,7 +162,7 @@ def generate_mirror_circuit(
     two_qubit_gate = supported_two_qubit_gates[two_qubit_gate_name]
 
     random_state = random.RandomState(seed)
-    nqubits = connectivity_graph.number_of_nodes()
+
     single_qubit_cliffords = random_single_cliffords(
         connectivity_graph, random_state=random_state
     )
@@ -172,7 +173,7 @@ def generate_mirror_circuit(
     quasi_inverse_gates = []
 
     for _ in range(nlayers):
-        forward_circuit.append(random_paulis(nqubits, random_state))
+        forward_circuit.append(random_paulis(connectivity_graph, random_state))
 
         selected_edges = edge_grab(
             two_qubit_gate_prob, connectivity_graph, random_state
@@ -180,14 +181,16 @@ def generate_mirror_circuit(
         circ = random_cliffords(selected_edges, random_state, two_qubit_gate)
         forward_circuit.append(circ)
 
-        quasi_inverse_gates.append(random_paulis(nqubits, random_state))
+        quasi_inverse_gates.append(
+            random_paulis(connectivity_graph, random_state)
+        )
         quasi_inverse_gates.append(cirq.inverse(circ))
 
     quasi_inversion_circuit.append(
         gate for gate in reversed(quasi_inverse_gates)
     )
 
-    rand_paulis = cirq.Circuit(random_paulis(nqubits, random_state))
+    rand_paulis = cirq.Circuit(random_paulis(connectivity_graph, random_state))
     circuit = (
         single_qubit_cliffords
         + forward_circuit

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -45,8 +45,9 @@ def generate_rb_circuits(
             random circuits. This is proportional to the depth per circuit.
         trials: The number of random circuits at each num_cfd.
         return_type: String which specifies the type of the
-            returned circuits. See the keys of ``mitiq.QPROGRAM`` for options.
-            If ``None``, the returned circuits are type ``cirq.Circuit``.
+            returned circuits. See the keys of
+            ``mitiq.SUPPORTED_PROGRAM_TYPES`` for options. If ``None``, the
+            returned circuits are ``cirq.Circuit``s.
 
     Returns:
         A list of randomized benchmarking circuits.

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -47,7 +47,7 @@ def generate_rb_circuits(
         return_type: String which specifies the type of the
             returned circuits. See the keys of
             ``mitiq.SUPPORTED_PROGRAM_TYPES`` for options. If ``None``, the
-            returned circuits are ``cirq.Circuit``s.
+            returned circuits have type ``cirq.Circuit``.
 
     Returns:
         A list of randomized benchmarking circuits.

--- a/mitiq/benchmarks/tests/test_mirror_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_circuits.py
@@ -168,3 +168,27 @@ def test_mirror_circuits_conversions(return_type):
         return_type=return_type,
     )
     assert return_type in circuit.__module__
+
+
+@pytest.mark.parametrize(
+    "twoq_name_and_gate", [("CNOT", cirq.CNOT), ("CZ", cirq.CZ)]
+)
+def test_two_qubit_gate(twoq_name_and_gate):
+    twoq_name, twoq_gate = twoq_name_and_gate
+    circuit = mirror_circuits.generate_mirror_circuit(
+        nlayers=2,
+        two_qubit_gate_prob=1.0,
+        connectivity_graph=nx.complete_graph(5),
+        two_qubit_gate_name=twoq_name,
+    )
+    two_qubit_gates = {
+        op.gate for op in circuit.all_operations() if len(op.qubits) == 2
+    }
+    assert two_qubit_gates == {twoq_gate}
+
+
+def test_two_qubit_gate_unsupported():
+    with pytest.raises(ValueError, match="Supported two-qubit gate names are"):
+        mirror_circuits.generate_mirror_circuit(
+            1, 1.0, nx.complete_graph(2), two_qubit_gate_name="bad_gate_name"
+        )

--- a/mitiq/benchmarks/tests/test_mirror_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_circuits.py
@@ -127,7 +127,7 @@ def test_random_single_cliffords():
 def test_generate_mirror_circuit(depth_twoqprob_graph):
     depth, xi, connectivity_graph = depth_twoqprob_graph
     n = connectivity_graph.number_of_nodes()
-    circ = mirror_circuits.generate_mirror_circuit(
+    circ, _ = mirror_circuits.generate_mirror_circuit(
         depth, xi, connectivity_graph
     )
     assert isinstance(circ, cirq.Circuit)
@@ -149,11 +149,11 @@ def test_mirror_circuit_seeding(seed):
     nlayers = 5
     two_qubit_gate_prob = 0.4
     connectivity_graph = nx.complete_graph(5)
-    circuit = mirror_circuits.generate_mirror_circuit(
+    circuit, _ = mirror_circuits.generate_mirror_circuit(
         nlayers, two_qubit_gate_prob, connectivity_graph, seed=seed
     )
     for _ in range(5):
-        circ = mirror_circuits.generate_mirror_circuit(
+        circ, _ = mirror_circuits.generate_mirror_circuit(
             nlayers, two_qubit_gate_prob, connectivity_graph, seed=seed
         )
         assert _equal(
@@ -169,7 +169,7 @@ def test_mirror_circuits_conversions(return_type):
     nlayers = 5
     two_qubit_gate_prob = 0.4
     connectivity_graph = nx.complete_graph(5)
-    circuit = mirror_circuits.generate_mirror_circuit(
+    circuit, _ = mirror_circuits.generate_mirror_circuit(
         nlayers,
         two_qubit_gate_prob,
         connectivity_graph,
@@ -183,7 +183,7 @@ def test_mirror_circuits_conversions(return_type):
 )
 def test_two_qubit_gate(twoq_name_and_gate):
     twoq_name, twoq_gate = twoq_name_and_gate
-    circuit = mirror_circuits.generate_mirror_circuit(
+    circuit, _ = mirror_circuits.generate_mirror_circuit(
         nlayers=2,
         two_qubit_gate_prob=1.0,
         connectivity_graph=nx.complete_graph(5),

--- a/mitiq/benchmarks/tests/test_mirror_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_circuits.py
@@ -32,14 +32,22 @@ all_gates = paulis + all_cliffords
 all_gates.append(cirq.measure)
 
 
-@pytest.mark.parametrize("n", (0, 5))
-def test_random_paulis(n):
+@pytest.mark.parametrize(
+    "graph",
+    [
+        nx.Graph({3: (4,), 4: (3, 6), 5: (6,)}),
+        nx.Graph({0: (99,), 10: (20,), 5: (6,)}),
+    ],
+)
+def test_random_paulis(graph):
     circuit = mirror_circuits.random_paulis(
-        nqubits=n, random_state=random.RandomState()
+        connectivity_graph=graph, random_state=random.RandomState()
     )
     assert isinstance(circuit, cirq.Circuit)
-    assert len(circuit.all_qubits()) == n
-    assert len(list(circuit.all_operations())) == n
+    assert len(circuit.all_qubits()) == len(graph.nodes)
+    for qubit in circuit.all_qubits():
+        assert qubit.x in graph.nodes
+    assert len(list(circuit.all_operations())) == len(graph.nodes)
     assert set(op.gate for op in circuit.all_operations()).issubset(paulis)
 
 


### PR DESCRIPTION
Description
-----------

This allows for any two-qubit gate in mirror circuits and fixes #905, and also fixes #918. Additionally, change `generate_mirror_circuit` to also return the bitstring that should be sampled by the circuit for convenience. 

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
