### PR TITLE
Foldability check includes a check for inverse

### DIFF
--- a/mitiq/zne/scaling/folding.py
+++ b/mitiq/zne/scaling/folding.py
@@ -67,10 +67,11 @@ def _check_foldable(circuit: Circuit) -> None:
         )
 
     if not has_unitary(circuit):
-        raise UnfoldableCircuitError(
-            "Circuit contains non-unitary channels which are not terminal "
-            "measurements and cannot be folded."
-        )
+        if inverse(circuit, None) is None:
+            raise UnfoldableCircuitError(
+                "Circuit contains non-invertible channels which are not"
+                "terminal measurements and cannot be folded."
+            )
 
 
 def _squash_moments(circuit: Circuit) -> Circuit:

--- a/mitiq/zne/scaling/tests/test_folding.py
+++ b/mitiq/zne/scaling/tests/test_folding.py
@@ -407,14 +407,14 @@ def test_fold_with_intermediate_measurements_raises_error(fold_method):
 )
 def test_fold_with_channels_raises_error(fold_method):
     """Tests local folding functions raise an error on circuits with
-    non-unitary channels (which are not measurements).
+    non-invertible channels (which are not measurements).
     """
     qbit = LineQubit(0)
     circ = Circuit(
         ops.H.on(qbit), ops.depolarize(p=0.1).on(qbit), ops.measure(qbit)
     )
     with pytest.raises(
-        UnfoldableCircuitError, match="Circuit contains non-unitary channels"
+        UnfoldableCircuitError, match="Circuit contains non-invertible"
     ):
         fold_method(circ, scale_factor=3.0)
 


### PR DESCRIPTION
Description
-----------
Fixes #911 

- [ ] For a Cirq circuit, before an error is raised, checks if the circuit operations have valid inverse. 
- [ ] Add tests for Cirq - When there is a valid inverse, non-valid inverse (measurements)
- [ ] Braket inverse check + tests
- [ ] Pyquil inverse check + tests
- [ ] Qiskit inverse check + tests 