### PR TITLE
Fix AWS example by fixing a bug in mirror circuits

### DIFF
--- a/mitiq/benchmarks/mirror_circuits.py
+++ b/mitiq/benchmarks/mirror_circuits.py
@@ -205,7 +205,9 @@ def generate_mirror_circuit(
     )
 
     # Compute the bitstring this circuit should sample.
-    res = cirq.Simulator().run(circuit + cirq.measure(*circuit.all_qubits()))
+    res = cirq.Simulator().run(
+        circuit + cirq.measure(*sorted(circuit.all_qubits()))
+    )
     bitstring = list(res.measurements.values())[0][0].tolist()
 
     return_type = "cirq" if not return_type else return_type

--- a/mitiq/benchmarks/tests/test_mirror_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_circuits.py
@@ -200,3 +200,20 @@ def test_two_qubit_gate_unsupported():
         mirror_circuits.generate_mirror_circuit(
             1, 1.0, nx.complete_graph(2), two_qubit_gate_name="bad_gate_name"
         )
+
+
+def test_deterministic_correct_bitstrings():
+    """For a fixed seed, correct bitstrings should be deterministic."""
+    expected_correct_bitstrings = (
+        [[0, 0], [1, 1], [0, 0], [0, 1], [0, 0], [0, 0], [0, 0], [0, 0]]
+        + [[0, 0], [1, 1], [1, 1], [0, 1], [0, 1], [0, 1], [1, 0], [0, 1]]
+        + [[1, 1], [1, 0], [1, 0], [1, 0], [0, 0], [1, 1], [0, 0], [0, 1]]
+    )
+    for j, expected in enumerate(expected_correct_bitstrings):
+        _, bitstring = mirror_circuits.generate_mirror_circuit(
+            nlayers=1,
+            two_qubit_gate_prob=1.0,
+            connectivity_graph=nx.complete_graph(2),
+            seed=j,
+        )
+        assert bitstring == expected


### PR DESCRIPTION
The qubit order of the correct bitstring in mirror circuits is non-deterministic.
This PR fixes this bug and, as a consequence, fixes #937 too (Braket example).
