### PR TITLE
Add `PauliString` multiplication; Positional arguments in constructor

### DIFF
--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -37,8 +37,7 @@ class PauliString:
 
     def __init__(
         self,
-        *,
-        spec: str,
+        spec: str = "",
         coeff: complex = 1.0,
         support: Optional[Sequence[int]] = None,
     ) -> None:
@@ -141,6 +140,11 @@ class PauliString:
         return PauliStringCollection(self)._expectation_from_measurements(
             measurements
         )
+
+    def __mul__(self, other: "PauliString") -> "PauliString":
+        result = PauliString()
+        result._pauli = self._pauli * other._pauli
+        return result
 
     def __eq__(self, other: Any) -> bool:
         return self._pauli == other._pauli

--- a/mitiq/observable/tests/test_pauli.py
+++ b/mitiq/observable/tests/test_pauli.py
@@ -44,6 +44,13 @@ def test_pauli_init():
     assert str(pauli) == "Z(1)*X(2)*Y(3)"
 
 
+def test_pauli_init_empty():
+    pauli = PauliString()
+    assert pauli.support() == set()
+    assert pauli.weight() == 0
+    assert np.allclose(pauli.matrix(), [[1]])
+
+
 def test_pauli_init_with_support():
     support = (2, 37)
     pauli = PauliString(spec="XZ", support=support)
@@ -179,6 +186,21 @@ def test_weight():
     assert PauliString(spec="X" * n).weight() == n
     assert PauliString(spec="IX" * n).weight() == n
     assert PauliString(spec="ZX" * n).weight() == 2 * n
+
+
+def test_multiplication():
+    Pauli = PauliString
+    assert Pauli("X") * Pauli("I") == Pauli("X")
+    assert Pauli("X") * Pauli("Y") == Pauli("Z", coeff=1j)
+    assert Pauli("X") * Pauli("Y", support=(1,)) == Pauli("XY")
+    assert Pauli("ZI", coeff=2) * Pauli("IZ", coeff=3) == Pauli("ZZ", coeff=6)
+
+    zz_mult = Pauli("ZI") * Pauli("IZ")
+    zz_expected = Pauli("ZZ")
+    assert zz_mult.support() == zz_expected.support()
+    assert np.allclose(zz_mult.matrix(), zz_expected.matrix())
+    assert str(zz_mult) == str(zz_expected)
+    assert zz_mult.weight() == zz_expected.weight()
 
 
 # Note: For testing `PauliString._expectation_from_measurements`, it makes no


### PR DESCRIPTION
Description
-----------

Adds multiplication and stops requiring keyword arguments in constructor.

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
