### PR TITLE
Fix links and typos in vqe-pyquil-demo.myst and pyquil_demo.myst

### DIFF
--- a/docs/source/examples/pyquil_demo.myst
+++ b/docs/source/examples/pyquil_demo.myst
@@ -16,7 +16,7 @@ In this example we demonstrate how to use Zero Noise Extrapolation (ZNE) in Miti
 
 When adding the noise mitigation function `zne.execute_with_zne` the `memory_map` is still passed to the executor function and the circuit parameters are updated without the need for repeated compilation. 
 
-The PyQuil parametric compilation example shown here is adapted from https://pyquil-docs.rigetti.com/en/v2.28.1/migration3-declare.html
+The example shown here is adapted from the [pyQuil parametric compilation tutorial](https://pyquil-docs.rigetti.com/en/v2.28.1/migration3-declare.html).
 
 
 ```{code-cell}

--- a/docs/source/examples/vqe-pyquil-demo.myst
+++ b/docs/source/examples/vqe-pyquil-demo.myst
@@ -248,8 +248,8 @@ convergence.
 
 This is done by wrapping the noisy executor into a mitigated executor. 
 We will fold the gates from the right and apply a linear inference (using a Linear 
-Factory object) to implement ZNE. Read more about noise scaling by unitary folding 
-in the [Mitiq user guide]
+Factory object) to implement ZNE. Read more about [noise scaling by unitary folding]
+(https://mitiq--959.org.readthedocs.build/en/959/guide/guide-zne.html) in the Mitiq user guide.
 
 ```{code-cell} ipython3
 def mitigated_expectation(
@@ -281,8 +281,8 @@ def mitigated_expectation(
 ```
 
 Here we use a linear inference for the extrapolation. 
-See the section on Factory Objects in the [Mitiq user guide] (https://mitiq.readthedocs.io/en/latest/guide/guide-zne.html#classical-fitting-and-extrapolation-factory-objects) 
-for more information:
+See the section on [Factory Objects](https://mitiq.readthedocs.io/en/latest/guide/guide-zne.html#classical-fitting-and-extrapolation-factory-objects) 
+in the Mitiq user guide for more information:
 
 ```{code-cell} ipython3
 fac = mitiq.zne.inference.LinearFactory(scale_factors=[1.0, 3.0])

--- a/docs/source/examples/vqe-pyquil-demo.myst
+++ b/docs/source/examples/vqe-pyquil-demo.myst
@@ -248,8 +248,8 @@ convergence.
 
 This is done by wrapping the noisy executor into a mitigated executor. 
 We will fold the gates from the right and apply a linear inference (using a Linear 
-Factory object) to implement ZNE. Read more about [noise scaling by unitary folding]
-(https://mitiq--959.org.readthedocs.build/en/959/guide/guide-zne.html) in the Mitiq user guide.
+Factory object) to implement ZNE. Read more about [noise scaling by unitary folding](https://mitiq--959.org.readthedocs.build/en/959/guide/guide-zne.html) 
+in the Mitiq user guide.
 
 ```{code-cell} ipython3
 def mitigated_expectation(

--- a/docs/source/examples/vqe-pyquil-demo.myst
+++ b/docs/source/examples/vqe-pyquil-demo.myst
@@ -18,13 +18,13 @@ convergence when applied to a variational problem. ZNE works by computing the
 observable of interest at increased noise levels, i.e. beyond the minimum noise 
 strength in the computer, and then extrapolating back to the zero-noise limit. 
 The two main components of ZNE are noise scaling and extrapolation. Read more about 
-ZNE in the [[Mitiq User Guide]](https://mitiq.readthedocs.io/en/stable/guide/guide-zne.html#noise-scaling-by-unitary-folding).
+ZNE in the [Mitiq Users Guide](https://mitiq.readthedocs.io/en/stable/guide/guide-zne.html#noise-scaling-by-unitary-folding).
 
 
 The Variational Quantum Eigensolver (VQE) is a hybrid quantum-classical algorithm used to
 solve eigenvalue and optimization problems. The VQE algorithm consists of a quantum 
 subroutine run inside of a classical optimization loop. In this example, the goal of the 
-optimization is to find the smallest eigenvalue of a matix H, which is the Hamiltonian 
+optimization is to find the smallest eigenvalue of a matrix H, which is the Hamiltonian 
 of a simple quantum system. The quantum subroutine prepares the quantum state 
 |Ψ(vec(θ))⟩ and measures the expectation value ⟨Ψ(vec(θ))|H|Ψ(vec(θ))⟩. By the 
 variational principle, ⟨Ψ(vec(θ))|H|Ψ(vec(θ))⟩ is always greater than the smallest 
@@ -332,7 +332,7 @@ We can see that the convergence to the minimum energy is enhanced by applying ZN
 
 While the VQE algorithm is generally considered to be robust to noise 
 [[2]](#References), at the noise level modeled in this example, the 
-accumluation of errors results in loss of accuracy and additional iterations 
+accumulation of errors results in loss of accuracy and additional iterations 
 required to reach convergence. Adding ZNE then improves the convergence of the 
 algorithm to the minimum energy. The result is also demonstrated in the energy 
 landscape plot, where the noisy landscape is noticeably flatter than the landscape 


### PR DESCRIPTION
Fixing typos in VQE example and pyQuil parametric compilation example

Description
-----------

Fixes #958 

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [X] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [X] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
