### PR TITLE
Bump qiskit to version 0.31 and pin it explicitly in dev requirements

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,5 @@
 # Third-party integration.
-qiskit-terra~=0.18.2
-qiskit-aer~=0.8.2
-qiskit-ibmq-provider~=0.16.0
+qiskit
 pyquil~=3.0.0
 pennylane-qiskit~=0.18.0
 pennylane~=0.18.0

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 # Third-party integration.
-qiskit
+qiskit~=0.25.0
 pyquil~=3.0.0
 pennylane-qiskit~=0.18.0
 pennylane~=0.18.0

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 # Third-party integration.
-qiskit~=0.25.0
+qiskit~=0.31.0
 pyquil~=3.0.0
 pennylane-qiskit~=0.18.0
 pennylane~=0.18.0

--- a/mitiq/interface/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/qiskit_utils.py
@@ -26,10 +26,6 @@ from qiskit.providers.aer.noise.errors.standard_errors import (
     depolarizing_error,
 )
 
-QASM_SIMULATOR = qiskit.Aer.get_backend("qasm_simulator")
-WVF_SIMULATOR = qiskit.Aer.get_backend("statevector_simulator")
-DM_SIMULATOR = qiskit.Aer.get_backend("aer_simulator_density_matrix")
-
 
 def initialized_depolarizing_noise(noise: float) -> NoiseModel:
     """Initializes a depolarizing noise Qiskit NoiseModel.
@@ -55,7 +51,7 @@ def initialized_depolarizing_noise(noise: float) -> NoiseModel:
 
 
 def execute(circ: QuantumCircuit, obs: np.ndarray) -> float:
-    """Simulates noiseless wavefunction evolution and returns the
+    """Simulates a noiseless evolution and returns the
     expectation value of some observable.
 
     Args:
@@ -65,9 +61,7 @@ def execute(circ: QuantumCircuit, obs: np.ndarray) -> float:
     Returns:
         The expectation value of obs as a float.
     """
-    result = qiskit.execute(circ, WVF_SIMULATOR).result()
-    final_wvf = result.get_statevector()
-    return np.real(final_wvf.conj().T @ obs @ final_wvf)
+    return execute_with_noise(circ, obs, noise_model=None)
 
 
 def execute_with_shots(
@@ -85,40 +79,17 @@ def execute_with_shots(
         The expectation value of obs as a float.
 
     """
-    circ = copy.deepcopy(circ)
-    # we need to modify the circuit to measure obs in its eigenbasis
-    # we do this by appending a unitary operation
-    # obtains a U s.t. obs = U diag(eigvals) U^dag
-    eigvals, U = np.linalg.eigh(obs)
-    circ.unitary(np.linalg.inv(U), qubits=range(circ.num_qubits))
 
-    circ.measure_all()
-
-    # execution of the experiment
-    job = qiskit.execute(
-        circ,
-        backend=QASM_SIMULATOR,
-        # we want all gates to be actually applied,
-        # so we skip any circuit optimization
-        optimization_level=0,
-        shots=shots,
+    return execute_with_shots_and_noise(
+        circ, obs, noise_model=None, shots=shots,
     )
-    results = job.result()
-    counts = results.get_counts()
-    expectation = 0
-
-    for bitstring, count in counts.items():
-        expectation += (
-            eigvals[int(bitstring[0 : circ.num_qubits], 2)] * count / shots
-        )
-    return expectation
 
 
 def execute_with_noise(
     circ: QuantumCircuit, obs: np.ndarray, noise_model: NoiseModel
 ) -> float:
     """Simulates the evolution of the noisy circuit and returns
-    the expectation value of the observable.
+    the exact expectation value of the observable.
 
     Args:
         circ: The input Qiskit circuit.
@@ -130,14 +101,19 @@ def execute_with_noise(
     """
     circ.save_density_matrix()
 
+    if noise_model is None:
+        basis_gates = None,
+    else:
+        basis_gates = noise_model.basis_gates + ["save_density_matrix"]
+
     # execution of the experiment
     job = qiskit.execute(
         circ,
-        backend=DM_SIMULATOR,
+        backend=qiskit.Aer.get_backend("aer_simulator_density_matrix"),
         noise_model=noise_model,
+        basis_gates=basis_gates,
         # we want all gates to be actually applied,
         # so we skip any circuit optimization
-        basis_gates=noise_model.basis_gates + ["save_density_matrix"],
         optimization_level=0,
         shots=1,
     )
@@ -155,7 +131,7 @@ def execute_with_shots_and_noise(
     seed: Optional[int] = None,
 ) -> float:
     """Simulates the evolution of the noisy circuit and returns
-    the expectation value of the observable.
+    the statistical estimate of the expectation value of the observable.
 
     Args:
         circ: The input Qiskit circuit.
@@ -176,15 +152,20 @@ def execute_with_shots_and_noise(
 
     circ.measure_all()
 
+    if noise_model is None:
+        basis_gates = None,
+    else:
+        basis_gates = noise_model.basis_gates
+
     # execution of the experiment
     job = qiskit.execute(
         circ,
-        backend=QASM_SIMULATOR,
+        backend=qiskit.Aer.get_backend("aer_simulator"),
         backend_options={"method": "density_matrix"},
         noise_model=noise_model,
         # we want all gates to be actually applied,
         # so we skip any circuit optimization
-        basis_gates=noise_model.basis_gates,
+        basis_gates=basis_gates,
         optimization_level=0,
         shots=shots,
         seed_simulator=seed,

--- a/mitiq/interface/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/qiskit_utils.py
@@ -102,7 +102,7 @@ def execute_with_noise(
     circ.save_density_matrix()
 
     if noise_model is None:
-        basis_gates = None,
+        basis_gates = None
     else:
         basis_gates = noise_model.basis_gates + ["save_density_matrix"]
 
@@ -153,7 +153,7 @@ def execute_with_shots_and_noise(
     circ.measure_all()
 
     if noise_model is None:
-        basis_gates = None,
+        basis_gates = None
     else:
         basis_gates = noise_model.basis_gates
 

--- a/mitiq/interface/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/qiskit_utils.py
@@ -137,7 +137,7 @@ def execute_with_noise(
         noise_model=noise_model,
         # we want all gates to be actually applied,
         # so we skip any circuit optimization
-        basis_gates=noise_model.basis_gates + ['save_density_matrix'],
+        basis_gates=noise_model.basis_gates + ["save_density_matrix"],
         optimization_level=0,
         shots=1,
     )

--- a/mitiq/zne/tests/test_zne.py
+++ b/mitiq/zne/tests/test_zne.py
@@ -59,7 +59,6 @@ from mitiq.observable import Observable, PauliString
 BASE_NOISE = 0.007
 TEST_DEPTH = 30
 ONE_QUBIT_GS_PROJECTOR = np.array([[1, 0], [0, 0]])
-QASM_SIMULATOR = qiskit.Aer.get_backend("qasm_simulator")
 
 npX = np.array([[0, 1], [1, 0]])
 """Defines the sigma_x Pauli matrix in SU(2) algebra as a (2,2) `np.array`."""
@@ -281,7 +280,7 @@ def qiskit_executor(qp: QPROGRAM, shots: int = 500) -> float:
 def get_counts(circuit: qiskit.QuantumCircuit):
     return (
         qiskit.execute(
-            circuit, qiskit.Aer.get_backend("qasm_simulator"), shots=100
+            circuit, qiskit.Aer.get_backend("aer_simulator"), shots=100
         )
         .result()
         .get_counts()
@@ -486,7 +485,8 @@ def test_execute_with_zne_transpiled_qiskit_circuit():
     """
     from qiskit.test.mock import FakeSantiago
 
-    backend = FakeSantiago()
+    santiago = FakeSantiago()
+    backend = qiskit.providers.aer.AerSimulator.from_backend(santiago)
 
     def execute(circuit: qiskit.QuantumCircuit, shots: int = 8192) -> float:
         job = qiskit.execute(circuit, backend, shots=shots)


### PR DESCRIPTION
According to the discussion of the last Mitiq community call, this PR adds `qiskit`  in  `dev_requirements.txt`
and remove individual qiskit sub-packages to avoid conflicts.

Moreover it also updates `qiskit_utils.py ` for bumping Qiskit to the current latest version.