### PR TITLE
Increase shots in test_zne.py

### DIFF
--- a/mitiq/zne/tests/test_zne.py
+++ b/mitiq/zne/tests/test_zne.py
@@ -296,8 +296,6 @@ def test_qiskit_execute_with_zne():
     )
     base = qiskit_executor(circuit)
     zne_value = execute_with_zne(circuit, qiskit_executor)
-    print(true_zne_value - zne_value)
-    print(true_zne_value - base)
     assert abs(true_zne_value - zne_value) < abs(true_zne_value - base)
 
 

--- a/mitiq/zne/tests/test_zne.py
+++ b/mitiq/zne/tests/test_zne.py
@@ -260,7 +260,7 @@ def qiskit_measure(circuit, qid) -> qiskit.QuantumCircuit:
     return circuit
 
 
-def qiskit_executor(qp: QPROGRAM, shots: int = 500) -> float:
+def qiskit_executor(qp: QPROGRAM, shots: int = 10000) -> float:
     # initialize a qiskit noise model
     expectation = execute_with_shots_and_noise(
         qp,
@@ -296,7 +296,8 @@ def test_qiskit_execute_with_zne():
     )
     base = qiskit_executor(circuit)
     zne_value = execute_with_zne(circuit, qiskit_executor)
-
+    print(true_zne_value - zne_value)
+    print(true_zne_value - base)
     assert abs(true_zne_value - zne_value) < abs(true_zne_value - base)
 
 


### PR DESCRIPTION
Hopefully, this will fix the flaky zne tests (https://github.com/unitaryfund/mitiq/pull/993#issuecomment-958386702). 

Note: I tested locally and it only increased the pytest duration for `test_zne.py` by 6 seconds. So timing is not an issue.
