### PR TITLE
[Bug fix] Add back-conversions in execute_with_pec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please use `mitiq.about()` to document your dependencies and working environment
 You can open a [pull request](https://github.com/unitaryfund/mitiq/pulls) by pushing changes from a local branch, explaining the bug fix or new feature.
 
 ### Version control with git
-git is a language that helps keeping track of the changes made. Have a look at these guidelines for getting started with [git workflow](https://www.asmeurer.com/git-workflow/).
+git is a language that helps keeping track of the changes made. Have a look at these guidelines for getting started with [git workflow](https://github.com/asmeurer/git-workflow).
 Use short and explanatory comments to document the changes with frequent commits.
 
 ### Forking the repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please use `mitiq.about()` to document your dependencies and working environment
 You can open a [pull request](https://github.com/unitaryfund/mitiq/pulls) by pushing changes from a local branch, explaining the bug fix or new feature.
 
 ### Version control with git
-git is a language that helps keeping track of the changes made. Have a look at these guidelines for getting started with [git workflow](https://github.com/asmeurer/git-workflow).
+git is a language that helps keeping track of the changes made. Have a look at these guidelines for getting started with [git workflow](https://www.asmeurer.com/git-workflow/).
 Use short and explanatory comments to document the changes with frequent commits.
 
 ### Forking the repository

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -23,14 +23,15 @@ from typing import (
     Tuple,
     Dict,
     Any,
+    cast,
 )
 from functools import wraps
 import warnings
-
 import numpy as np
 
-from mitiq import Executor, Observable, QPROGRAM, QuantumResult
+from cirq import Circuit as CirqCircuit
 
+from mitiq import Executor, Observable, QPROGRAM, QuantumResult
 from mitiq.pec import sample_circuit, OperationRepresentation
 from mitiq.interface import convert_to_mitiq, convert_from_mitiq
 
@@ -148,7 +149,8 @@ def execute_with_pec(
 
     # Convert back to the original type
     sampled_circuits = [
-        convert_from_mitiq(c, input_type) for c in sampled_circuits
+        convert_from_mitiq(cast(CirqCircuit, c), input_type)
+        for c in sampled_circuits
     ]
 
     # Execute all sampled circuits

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -32,7 +32,7 @@ import numpy as np
 from mitiq import Executor, Observable, QPROGRAM, QuantumResult
 
 from mitiq.pec import sample_circuit, OperationRepresentation
-from mitiq.interface import convert_to_mitiq
+from mitiq.interface import convert_to_mitiq, convert_from_mitiq
 
 
 class LargeSampleWarning(Warning):
@@ -123,7 +123,7 @@ def execute_with_pec(
             f" but precision is {precision}."
         )
 
-    converted_circuit, _ = convert_to_mitiq(circuit)
+    converted_circuit, input_type = convert_to_mitiq(circuit)
 
     # Get the 1-norm of the circuit quasi-probability representation
     _, _, norm = sample_circuit(
@@ -145,6 +145,11 @@ def execute_with_pec(
         random_state=random_state,
         num_samples=num_samples,
     )
+
+    # Convert back to the original type
+    sampled_circuits = [
+        convert_from_mitiq(c, input_type) for c in sampled_circuits
+    ]
 
     # Execute all sampled circuits
     if not isinstance(executor, Executor):

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -593,6 +593,7 @@ def test_doc_is_preserved():
 
     assert second_executor.__doc__ == first_executor.__doc__
 
+
 @pytest.mark.parametrize("circuit_type", SUPPORTED_PROGRAM_TYPES.keys())
 def test_executed_circuits_have_the_expected_type(circuit_type):
 
@@ -601,7 +602,6 @@ def test_executed_circuits_have_the_expected_type(circuit_type):
 
     # Fake executor just for testing types
     def type_detecting_executor(circuit: QPROGRAM):
-        print(type(circuit))
         assert type(circuit) is circuit_type
         return 0.0
 
@@ -611,5 +611,4 @@ def test_executed_circuits_have_the_expected_type(circuit_type):
         representations=pauli_representations,
         num_samples=1,
     )
-    
     assert np.isclose(mitigated, 0.0)

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -592,3 +592,24 @@ def test_doc_is_preserved():
         return 0
 
     assert second_executor.__doc__ == first_executor.__doc__
+
+@pytest.mark.parametrize("circuit_type", SUPPORTED_PROGRAM_TYPES.keys())
+def test_executed_circuits_have_the_expected_type(circuit_type):
+
+    circuit = convert_from_mitiq(oneq_circ, circuit_type)
+    circuit_type = type(circuit)
+
+    # Fake executor just for testing types
+    def type_detecting_executor(circuit: QPROGRAM):
+        print(type(circuit))
+        assert type(circuit) is circuit_type
+        return 0.0
+
+    mitigated = execute_with_pec(
+        circuit,
+        executor=type_detecting_executor,
+        representations=pauli_representations,
+        num_samples=1,
+    )
+    
+    assert np.isclose(mitigated, 0.0)


### PR DESCRIPTION
A back-conversion of the sample circuits to the native circuit type is missing in `execute_with_pec`. 
This is a bug that makes PEC not working with non-Cirq frontends and so it may justify a patch-release. 

Note: this bug was not detected since we use `convert_to_mitiq` + Cirq simulation in most test executors.
For this reason a specific new test is added in this PR. 
 

