### PR TITLE
[Bug fix] Avoid circuit mutation in qiskit executors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please use `mitiq.about()` to document your dependencies and working environment
 You can open a [pull request](https://github.com/unitaryfund/mitiq/pulls) by pushing changes from a local branch, explaining the bug fix or new feature.
 
 ### Version control with git
-git is a language that helps keeping track of the changes made. Have a look at these guidelines for getting started with [git workflow](https://www.asmeurer.com/git-workflow/).
+git is a language that helps keeping track of the changes made. Have a look at these guidelines for getting started with [git workflow](https://github.com/asmeurer/git-workflow).
 Use short and explanatory comments to document the changes with frequent commits.
 
 ### Forking the repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please use `mitiq.about()` to document your dependencies and working environment
 You can open a [pull request](https://github.com/unitaryfund/mitiq/pulls) by pushing changes from a local branch, explaining the bug fix or new feature.
 
 ### Version control with git
-git is a language that helps keeping track of the changes made. Have a look at these guidelines for getting started with [git workflow](https://github.com/asmeurer/git-workflow).
+git is a language that helps keeping track of the changes made. Have a look at these guidelines for getting started with [git workflow](https://www.asmeurer.com/git-workflow/).
 Use short and explanatory comments to document the changes with frequent commits.
 
 ### Forking the repository

--- a/docs/source/examples/ibmq-backends.myst
+++ b/docs/source/examples/ibmq-backends.myst
@@ -4,12 +4,13 @@ jupytext:
     extension: .myst
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.10.2
+    jupytext_version: 1.11.1
 kernelspec:
   display_name: Python 3
   language: python
   name: python3
 ---
+
 (label-zne-example)=
 # Error mitigation on IBMQ backends
 
@@ -23,7 +24,6 @@ backends, broken down in the following steps.
     - [Options](#options)
     - [Cirq frontend](#cirq-frontend)
   - [Lower-level usage](#lower-level-usage)
-
 
 +++
 
@@ -105,7 +105,7 @@ def ibmq_executor(circuit: qiskit.QuantumCircuit, shots: int = 8192) -> float:
         )
     else:
         # Simulate the circuit with noise
-        noise_model = initialized_depolarizing_noise(noise=0.02)
+        noise_model = initialized_depolarizing_noise(noise_level=0.02)
         job = qiskit.execute(
             experiments=circuit,
             backend=qiskit.Aer.get_backend("qasm_simulator"),
@@ -241,7 +241,7 @@ if USE_REAL_HARDWARE:
     )
 else:
     # Simulate the circuit with noise
-    noise_model = initialized_depolarizing_noise(noise=0.05)
+    noise_model = initialized_depolarizing_noise(noise_level=0.05)
     job = qiskit.execute(
         experiments=folded_circuits,
         backend=qiskit.Aer.get_backend("qasm_simulator"),

--- a/mitiq/interface/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/qiskit_utils.py
@@ -98,8 +98,8 @@ def execute_with_noise(
     Returns:
         The expectation value of obs as a float.
     """
-    # Trigger bug
-    circ = circuit
+    # Avoid mutating circuit
+    circ = circuit.copy()
     circ.save_density_matrix()
 
     if noise_model is None:

--- a/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
@@ -53,14 +53,14 @@ def test_execute_with_shots():
 
     circ = QuantumCircuit(1, 1)
     expectation_value = execute_with_shots(
-        circ=circ, obs=ONE_QUBIT_GS_PROJECTOR, shots=SHOTS
+        circuit=circ, obs=ONE_QUBIT_GS_PROJECTOR, shots=SHOTS
     )
     assert expectation_value == 1.0
 
     second_circ = QuantumCircuit(1)
     second_circ.x(0)
     expectation_value = execute_with_shots(
-        circ=second_circ, obs=ONE_QUBIT_GS_PROJECTOR, shots=SHOTS
+        circuit=second_circ, obs=ONE_QUBIT_GS_PROJECTOR, shots=SHOTS
     )
     assert expectation_value == 0.0
 
@@ -78,7 +78,7 @@ def test_execute_with_depolarizing_noise_single_qubit():
     noiseless_exp_value = 1.0
 
     expectation_value = execute_with_noise(
-        circ=single_qubit_circ,
+        circuit=single_qubit_circ,
         obs=ONE_QUBIT_GS_PROJECTOR,
         noise_model=initialized_depolarizing_noise(NOISE),
     )
@@ -100,7 +100,7 @@ def test_execute_with_depolarizing_noise_two_qubit():
     noiseless_exp_value = 1.0
 
     expectation_value = execute_with_noise(
-        circ=two_qubit_circ,
+        circuit=two_qubit_circ,
         obs=TWO_QUBIT_GS_PROJECTOR,
         noise_model=initialized_depolarizing_noise(NOISE),
     )
@@ -122,7 +122,7 @@ def test_execute_with_shots_and_depolarizing_noise_single_qubit():
     noiseless_exp_value = 1.0
 
     expectation_value = execute_with_shots_and_noise(
-        circ=single_qubit_circ,
+        circuit=single_qubit_circ,
         obs=ONE_QUBIT_GS_PROJECTOR,
         noise_model=initialized_depolarizing_noise(NOISE),
         shots=SHOTS,
@@ -145,7 +145,7 @@ def test_execute_with_shots_and_depolarizing_noise_two_qubit():
     noiseless_exp_value = 1.0
 
     expectation_value = execute_with_shots_and_noise(
-        circ=two_qubit_circ,
+        circuit=two_qubit_circ,
         obs=TWO_QUBIT_GS_PROJECTOR,
         noise_model=initialized_depolarizing_noise(NOISE),
         shots=SHOTS,
@@ -153,3 +153,24 @@ def test_execute_with_shots_and_depolarizing_noise_two_qubit():
     # anticipate that the expectation value will be less than
     # the noiseless simulation of the same circuit
     assert expectation_value < noiseless_exp_value
+
+
+def test_circuit_is_not_mutated_by_executors():
+    single_qubit_circ = QuantumCircuit(1, 1)
+    single_qubit_circ.z(0)
+    expected_circuit = single_qubit_circ.copy()
+    execute_with_shots_and_noise(
+        circuit=single_qubit_circ,
+        obs=ONE_QUBIT_GS_PROJECTOR,
+        noise_model=initialized_depolarizing_noise(NOISE),
+        shots=SHOTS,
+    )
+    assert single_qubit_circ.data == expected_circuit.data
+    assert single_qubit_circ == expected_circuit
+    execute_with_noise(
+        circuit=single_qubit_circ,
+        obs=ONE_QUBIT_GS_PROJECTOR,
+        noise_model=initialized_depolarizing_noise(NOISE),
+    )
+    assert single_qubit_circ.data == expected_circuit.data
+    assert single_qubit_circ == expected_circuit


### PR DESCRIPTION
A qiskit executor in `qiskit_utils` mutates the input circuit but it shouldn't.
This PR fixes the problem and ads a small notation update: `circ` --> `circuit`.