### PR TITLE
Update API doc with REM, executors and observables

### DIFF
--- a/docs/source/apidoc.rst
+++ b/docs/source/apidoc.rst
@@ -75,6 +75,24 @@ Qiskit Utils
 .. automodule:: mitiq.interface.mitiq_qiskit.qiskit_utils
    :members:
 
+Executors
+---------
+.. automodule:: mitiq.executor.executor
+   :members:
+
+Observables
+-----------
+
+Observable
+^^^^^^^^^^
+.. automodule:: mitiq.observable.observable
+   :members:
+
+Pauli
+^^^^^^^^^^^
+.. automodule:: mitiq.observable.pauli
+   :members:
+
 Probabilistic Error Cancellation
 --------------------------------
 

--- a/docs/source/apidoc.rst
+++ b/docs/source/apidoc.rst
@@ -109,6 +109,18 @@ Utilities for Quantum Channels
 .. automodule:: mitiq.pec.channels
    :members:
 
+Readout Error Mitigation
+------------------------
+
+Result Measurement
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: mitiq.rem.measurement_result
+   :members:
+
+Post-selection
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: mitiq.rem.post_select
+   :members:
 
 Zero Noise Extrapolation
 ------------------------

--- a/docs/source/apidoc.rst
+++ b/docs/source/apidoc.rst
@@ -112,7 +112,7 @@ Utilities for Quantum Channels
 Readout Error Mitigation
 ------------------------
 
-Result Measurement
+Measurement Result
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: mitiq.rem.measurement_result
    :members:

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -24,6 +24,7 @@ from mitiq._typing import MeasurementResult, QuantumResult, QPROGRAM
 
 
 class Observable:
+    """An observable."""
     def __init__(self, *paulis: PauliString) -> None:
         # TODO: Add option to Combine duplicates. E.g. [Z(0, Z(0)] -> [2*Z(0)].
         self._paulis = list(paulis)

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -27,7 +27,6 @@ class Observable:
     """A quantum observable typically used to compute its mitigated expectation
      value.
 
-    It can be defined on a selection of the total qubits in a quantum register.
     """
 
     def __init__(self, *paulis: PauliString) -> None:

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -24,7 +24,11 @@ from mitiq._typing import MeasurementResult, QuantumResult, QPROGRAM
 
 
 class Observable:
-    """An observable."""
+    """A quantum observable typically used to compute its mitigated expectation value.
+
+    It can be defined on a selection of the total qubits in a quantum register.
+    It can be initialized with :class:`.PauliString` objects.
+    """
 
     def __init__(self, *paulis: PauliString) -> None:
         # TODO: Add option to Combine duplicates. E.g. [Z(0, Z(0)] -> [2*Z(0)].

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -28,10 +28,15 @@ class Observable:
      value.
 
     It can be defined on a selection of the total qubits in a quantum register.
-    It can be initialized with :class:`.PauliString` objects.
     """
 
     def __init__(self, *paulis: PauliString) -> None:
+        """Initializes an `Observable` with :class:`.PauliString` objects.
+
+        Args:
+            paulis: PauliStrings used to define the observable.
+
+        """
         # TODO: Add option to Combine duplicates. E.g. [Z(0, Z(0)] -> [2*Z(0)].
         self._paulis = list(paulis)
         self._groups: List[PauliStringCollection]

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -25,6 +25,7 @@ from mitiq._typing import MeasurementResult, QuantumResult, QPROGRAM
 
 class Observable:
     """An observable."""
+
     def __init__(self, *paulis: PauliString) -> None:
         # TODO: Add option to Combine duplicates. E.g. [Z(0, Z(0)] -> [2*Z(0)].
         self._paulis = list(paulis)

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -24,7 +24,8 @@ from mitiq._typing import MeasurementResult, QuantumResult, QPROGRAM
 
 
 class Observable:
-    """A quantum observable typically used to compute its mitigated expectation value.
+    """A quantum observable typically used to compute its mitigated expectation
+     value.
 
     It can be defined on a selection of the total qubits in a quantum register.
     It can be initialized with :class:`.PauliString` objects.

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -33,8 +33,10 @@ from mitiq.interface import atomic_converter
 
 
 class PauliString:
-    """A sequence of Pauli operators defined on the space spanned by the qubits
-     in the qubit register of the quantum circuit."""
+    """A `PauliString` is a (tensor) product of single-qubit Pauli gates I, X,
+    Y, and Z, with a leading (real or complex) coefficient. `PauliString`s can
+    be measured in any `mitiq.QPROGRAM`.
+    """
 
     _string_to_gate_map = {"I": cirq.I, "X": cirq.X, "Y": cirq.Y, "Z": cirq.Z}
 

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -33,6 +33,7 @@ from mitiq.interface import atomic_converter
 
 
 class PauliString:
+    """A Pauli string."""
     _string_to_gate_map = {"I": cirq.I, "X": cirq.X, "Y": cirq.Y, "Z": cirq.Z}
 
     def __init__(

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -34,6 +34,7 @@ from mitiq.interface import atomic_converter
 
 class PauliString:
     """A Pauli string."""
+
     _string_to_gate_map = {"I": cirq.I, "X": cirq.X, "Y": cirq.Y, "Z": cirq.Z}
 
     def __init__(

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -165,6 +165,7 @@ class PauliStringCollection:
     """A collection of ``PauliString``s that qubit-wise commute and so can be measured with
         a single circuit.
     """
+
     def __init__(
         self, *paulis: PauliString, check_precondition: bool = True
     ) -> None:

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -162,8 +162,7 @@ class PauliString:
 
 
 class PauliStringCollection:
-    """A collection of ``PauliString``s that qubit-wise commute and so can be measured with
-        a single circuit.
+    """A collection of ``PauliString``s that qubit-wise commute and so can be measured with a single circuit.
     """
 
     def __init__(

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -33,7 +33,7 @@ from mitiq.interface import atomic_converter
 
 
 class PauliString:
-    """A Pauli string."""
+    """A sequence of Pauli operators defined on the space spanned by the qubits in the qubit register of the quantum circuit."""
 
     _string_to_gate_map = {"I": cirq.I, "X": cirq.X, "Y": cirq.Y, "Z": cirq.Z}
 
@@ -162,12 +162,13 @@ class PauliString:
 
 
 class PauliStringCollection:
+    """A collection of ``PauliString``s that qubit-wise commute and so can be measured with
+        a single circuit.
+    """
     def __init__(
         self, *paulis: PauliString, check_precondition: bool = True
     ) -> None:
-        """Initializes a ``PauliStringCollection``, a collection of
-        ``PauliString``s which qubit-wise commute and so can be measured with
-        a single circuit.
+        """Initializes a ``PauliStringCollection``.
 
         Args:
             paulis: PauliStrings to add to the collection.

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -163,19 +163,19 @@ class PauliString:
 
 
 class PauliStringCollection:
-    """A collection of ``PauliString``s that qubit-wise commute and so can be
+    """A collection of PauliStrings that qubit-wise commute and so can be
     measured with a single circuit.
     """
 
     def __init__(
         self, *paulis: PauliString, check_precondition: bool = True
     ) -> None:
-        """Initializes a ``PauliStringCollection``.
+        """Initializes a `PauliStringCollection`.
 
         Args:
             paulis: PauliStrings to add to the collection.
             check_precondition: If True, raises an error if some of the
-                ``PauliString``s do not qubit-wise commute.
+                `PauliString`s do not qubit-wise commute.
 
         Example:
             >>> pcol = PauliStringCollection(

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -33,7 +33,8 @@ from mitiq.interface import atomic_converter
 
 
 class PauliString:
-    """A sequence of Pauli operators defined on the space spanned by the qubits in the qubit register of the quantum circuit."""
+    """A sequence of Pauli operators defined on the space spanned by the qubits
+     in the qubit register of the quantum circuit."""
 
     _string_to_gate_map = {"I": cirq.I, "X": cirq.X, "Y": cirq.Y, "Z": cirq.Z}
 
@@ -162,7 +163,8 @@ class PauliString:
 
 
 class PauliStringCollection:
-    """A collection of ``PauliString``s that qubit-wise commute and so can be measured with a single circuit.
+    """A collection of ``PauliString``s that qubit-wise commute and so can be
+    measured with a single circuit.
     """
 
     def __init__(


### PR DESCRIPTION
Add the readout error mitigation (REM) subpackage to the API doc in the documentation. We can later on add the technique to the user guide. This helps with #1043 but wanted to merge before as there are fewer blockers.