### PR TITLE
Fix broken link on master.

### DIFF
--- a/docs/source/examples/vqe-pyquil-demo.myst
+++ b/docs/source/examples/vqe-pyquil-demo.myst
@@ -250,8 +250,7 @@ convergence.
 
 This is done by wrapping the noisy executor into a mitigated executor. 
 We will fold the gates from the right and apply a linear inference (using a Linear 
-Factory object) to implement ZNE. Read more about [noise scaling by unitary folding](https://mitiq--959.org.readthedocs.build/en/959/guide/guide-zne.html) 
-in the Mitiq user guide.
+Factory object) to implement ZNE. You can read more about noise scaling by unitary folding in the Mitiq user guide.
 
 ```{code-cell} ipython3
 def mitigated_expectation(

--- a/docs/source/examples/vqe-pyquil-demo.myst
+++ b/docs/source/examples/vqe-pyquil-demo.myst
@@ -17,8 +17,8 @@ In this example we investigate how Zero Noise Extrapolation (ZNE) can improve
 convergence when applied to a variational problem. ZNE works by computing the 
 observable of interest at increased noise levels, i.e. beyond the minimum noise 
 strength in the computer, and then extrapolating back to the zero-noise limit. 
-The two main components of ZNE are noise scaling and extrapolation. Read more about 
-ZNE in the [Mitiq Users Guide](https://mitiq.readthedocs.io/en/stable/guide/guide-zne.html#noise-scaling-by-unitary-folding).
+The two main components of ZNE are noise scaling and extrapolation. You can read more about 
+ZNE in the Mitiq Users Guide.
 
 
 The Variational Quantum Eigensolver (VQE) is a hybrid quantum-classical algorithm used to


### PR DESCRIPTION
This should fix the failing (docs) tests on master. 
For simplicity I just removed the link. 
If we want to re-add a correct link, the best place to do it is #1021  since the name of the target file will change.