### PR TITLE
Use `raw.execute` in asv benchmarks and remove GHZ circuits from asv benchmarks

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -21,14 +21,14 @@ import networkx as nx
 import numpy as np
 
 import cirq
-from mitiq import benchmarks, pec, zne, Observable, PauliString
+from mitiq import benchmarks, raw, pec, zne, Observable, PauliString
 from mitiq.interface import mitiq_cirq
 
 
 compute_density_matrix_noiseless = functools.partial(
     mitiq_cirq.compute_density_matrix, noise_level=(0.0,)
 )
-benchmark_circuit_types = ("rb", "mirror", "ghz")
+benchmark_circuit_types = ("rb", "mirror")
 
 
 def get_benchmark_circuit(
@@ -55,8 +55,6 @@ def get_benchmark_circuit(
             two_qubit_gate_prob=1.0,
             connectivity_graph=nx.complete_graph(nqubits),
         )
-    elif circuit_type == "ghz":
-        circuit = benchmarks.generate_ghz_circuit(n_qubits=nqubits)
     return circuit
 
 
@@ -75,11 +73,11 @@ def track_zne(
     """
     circuit = get_benchmark_circuit(circuit_type, nqubits, depth)
 
-    true_value = observable.expectation(
-        circuit, compute_density_matrix_noiseless
+    true_value = raw.execute(
+        circuit, compute_density_matrix_noiseless, observable
     )
-    raw_value = observable.expectation(
-        circuit, mitiq_cirq.compute_density_matrix
+    raw_value = raw.execute(
+        circuit, mitiq_cirq.compute_density_matrix, observable
     )
     zne_value = zne.execute_with_zne(
         circuit, mitiq_cirq.compute_density_matrix, observable,
@@ -134,10 +132,10 @@ def track_pec(
         noise_level=(noise_level,),
     )
 
-    true_value = observable.expectation(
-        circuit, compute_density_matrix_noiseless
+    true_value = raw.execute(
+        circuit, compute_density_matrix_noiseless, observable
     )
-    raw_value = observable.expectation(circuit, compute_density_matrix)
+    raw_value = raw.execute(circuit, compute_density_matrix, observable)
     pec_value = pec.execute_with_pec(
         circuit,
         compute_density_matrix,

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -28,7 +28,7 @@ from mitiq.interface import mitiq_cirq
 compute_density_matrix_noiseless = functools.partial(
     mitiq_cirq.compute_density_matrix, noise_level=(0.0,)
 )
-benchmark_circuit_types = ("rb", "mirror"," ghz")
+benchmark_circuit_types = ("rb", "mirror", "ghz")
 
 
 def get_benchmark_circuit(
@@ -56,7 +56,7 @@ def get_benchmark_circuit(
             connectivity_graph=nx.complete_graph(nqubits),
         )
     elif circuit_type == "ghz":
-        circuit, _ = benchmarks.generate_ghz_circuit(n_qubits=nqubits)
+        circuit = benchmarks.generate_ghz_circuit(n_qubits=nqubits)
     return circuit
 
 


### PR DESCRIPTION
Description
-----------

GHZ circuits have a fixed depth and don't directly fit with the other types (where nqubits and depth can be varied independently). Also uses `raw.execute`.

Indirectly fixes failing asv test on master (due to typo, see first commit).


Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
