### PR TITLE
Docstring for GHZ-circuits reformatted

### DIFF
--- a/mitiq/benchmarks/ghz_circuits.py
+++ b/mitiq/benchmarks/ghz_circuits.py
@@ -28,10 +28,10 @@ def generate_ghz_circuit(
 
         Args:
             n_qubits: The number of qubits in the circuit.
-            return_type: String which specifies the type of the
-            returned circuits. See the keys of
-            ``mitiq.SUPPORTED_PROGRAM_TYPES`` for options. If ``None``, the
-            returned circuits have type ``cirq.Circuit``.
+            return_type: String which specifies the type of the returned
+                circuits. See the keys of ``mitiq.SUPPORTED_PROGRAM_TYPES``
+                for options. If ``None``, the returned circuits have type
+                ``cirq.Circuit``.
 
         Returns:
             A GHZ circuit acting on ``n_qubits`` qubits.


### PR DESCRIPTION
Description
-----------
Fixes #1097 by reformatting docs so that API docs for ghz_circuits.py is properly rendered
See #1098 for additional details on the change, which was accidentally reverted.


Checklist
-----------

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.


