### PR TITLE
Making execute_with_zne accept a Count object from the qiskit library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/
 build/
 coverage.xml
 jupyter_execute/
+.venv

--- a/mitiq/__init__.py
+++ b/mitiq/__init__.py
@@ -14,7 +14,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Quantum computer input/output.
-from mitiq._typing import SUPPORTED_PROGRAM_TYPES, QPROGRAM, QuantumResult
+from mitiq._typing import (
+    SUPPORTED_PROGRAM_TYPES,
+    QPROGRAM,
+    QuantumResult,
+    QiskitCounts
+)
 from mitiq.rem.measurement_result import MeasurementResult
 
 # Executors and observables.

--- a/mitiq/_typing.py
+++ b/mitiq/_typing.py
@@ -23,7 +23,7 @@
        a quantum program from which expectation values to be mitigated can be
        computed. Note this includes expectation values themselves.
 """
-from typing import Union
+from typing import Union, NewType, Dict
 
 import numpy as np
 
@@ -64,8 +64,7 @@ except ImportError:  # pragma: no cover
 
 # Supported + installed quantum programs.
 QPROGRAM = Union[_Circuit, _Program, _QuantumCircuit, _BKCircuit, _QuantumTape]
-
-
+QiskitCounts = NewType("QiskitCounts", Dict[str, float])
 # An `executor` function inputs a quantum program and outputs an object from
 # which expectation values can be computed. Explicitly, this object can be one
 # of the following types:
@@ -73,6 +72,7 @@ QuantumResult = Union[
     float,  # The expectation value itself.
     MeasurementResult,  # Sampled bitstrings.
     np.ndarray,  # Density matrix.
+    QiskitCounts,  # Qiskit Counts Object
     # TODO: Support the following:
     # Sequence[np.ndarray],  # Wavefunctions sampled via quantum trajectories.
 ]

--- a/mitiq/cdr/cdr.py
+++ b/mitiq/cdr/cdr.py
@@ -43,7 +43,7 @@ def execute_with_cdr(
     scale_factors: Sequence[float] = (1,),
     scale_noise: Callable[[QPROGRAM, float], QPROGRAM] = fold_gates_at_random,
     **kwargs: Any,
-) -> float:
+) -> Union[float, np.ndarray]:
     """Function for the calculation of an observable from some circuit of
     interest to be mitigated with CDR (or vnCDR) based on
     Ref. :cite:`Czarnik_2021_Quantum` and Ref. :cite:`Lowe_2021_PRR`.

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -69,7 +69,7 @@ CountsLike = [
     Dict[Key, ExpVal],
     Dict[str, float],
     QiskitCounts
-]  # CHANGE: added Counts type
+]  # List of what could be interpreted as a count object
 
 class Executor:
     """Tool for efficiently scheduling/executing quantum programs and storing
@@ -187,18 +187,20 @@ class Executor:
                 )
                 for i in range(len(all_results) // result_step)
             ]
-        # CHANGE: Added elif clause
+
         elif self._executor_return_type in CountsLike:  # NOTE: type Counts is a dict("byte": exp_value)
             observable = cast(Observable, observable)
             results = [0 for x in range(len(all_results))]
             index = 0
-            # CHANGE: Iterated through the counts to return a sorted matrix
-            for experiment in all_results:  # Looking through the results
+
+            # Iterate through all_result to create the sorted matrix
+            for experiment in all_results:
                 bit_len = len(list(experiment.keys())[0])
+                # Empty matrix, if it's not in the dictionnary, then it's 0
                 exp_values = np.array([0 for x in range(2 ** bit_len)])
                 for elem in experiment.items():
                     for i in range(2 ** bit_len):
-                        if i == int(elem[0], 2):
+                        if i == int(elem[0], 2):  # If it exists, place it in our matrix
                             exp_values[i] = elem[1]
                             break
                 results[index] = exp_values  # The final result is of the form:

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -127,7 +127,7 @@ class Executor:
         observable: Optional[Observable] = None,
         force_run_all: bool = False,
         **kwargs: Any,
-    ) -> List[complex]:
+    ) -> List[Union[complex, np.ndarray]]:
         """Returns the expectation value Tr[ρ O] for each circuit in
         ``circuits`` where O is the observable provided or implicitly defined
         by the ``executor``. (The observable is implicitly defined when the
@@ -190,6 +190,7 @@ class Executor:
 
         elif self._executor_return_type in CountsLike:  # NOTE: type Counts is a dict("byte": exp_value)
             observable = cast(Observable, observable)
+            all_results = cast(List[QiskitCounts], all_results)
             results = [0 for x in range(len(all_results))]
             index = 0
 

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -28,18 +28,15 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    Union,
-    NewType
+    Union
 )
 
 import numpy as np
 
-from mitiq import QPROGRAM, QuantumResult
+from mitiq import QPROGRAM, QuantumResult, QiskitCounts
 from mitiq.observable.observable import Observable
 from mitiq.rem.measurement_result import MeasurementResult
 from mitiq.interface import convert_from_mitiq, convert_to_mitiq
-
-import qiskit.result.Counts as QiskitCounts
 
 DensityMatrixLike = [
     np.ndarray,
@@ -63,13 +60,11 @@ MeasurementResultLike = [
     Sequence[MeasurementResult],
     Tuple[MeasurementResult],
 ]
-Key = NewType("Key", str)
-ExpVal = NewType("ExpVal", float)
 CountsLike = [
-    Dict[Key, ExpVal],
     Dict[str, float],
     QiskitCounts
 ]  # List of what could be interpreted as a count object
+
 
 class Executor:
     """Tool for efficiently scheduling/executing quantum programs and storing
@@ -187,8 +182,8 @@ class Executor:
                 )
                 for i in range(len(all_results) // result_step)
             ]
-
-        elif self._executor_return_type in CountsLike:  # NOTE: type Counts is a dict("byte": exp_value)
+        # NOTE: type Counts is a dict("byte": exp_value)
+        elif self._executor_return_type in CountsLike:
             observable = cast(Observable, observable)
             all_results = cast(List[QiskitCounts], all_results)
             results = [0 for x in range(len(all_results))]
@@ -201,7 +196,8 @@ class Executor:
                 exp_values = np.array([0 for x in range(2 ** bit_len)])
                 for elem in experiment.items():
                     for i in range(2 ** bit_len):
-                        if i == int(elem[0], 2):  # If it exists, place it in our matrix
+                        # If it exists, place it in our matrix
+                        if i == int(elem[0], 2):
                             exp_values[i] = elem[1]
                             break
                 results[index] = exp_values  # The final result is of the form:

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -35,11 +35,11 @@ from typing import (
 import numpy as np
 
 from mitiq import QPROGRAM, QuantumResult
-
 from mitiq.observable.observable import Observable
 from mitiq.rem.measurement_result import MeasurementResult
 from mitiq.interface import convert_from_mitiq, convert_to_mitiq
 
+import qiskit.result.Counts as QiskitCounts
 
 DensityMatrixLike = [
     np.ndarray,
@@ -65,12 +65,10 @@ MeasurementResultLike = [
 ]
 Key = NewType("Key", str)
 ExpVal = NewType("ExpVal", float)
-Counts = Dict[Key, ExpVal]
 CountsLike = [
     Dict[Key, ExpVal],
-    Key,
-    ExpVal,
-    Dict[str, float]
+    Dict[str, float],
+    QiskitCounts
 ]  # CHANGE: added Counts type
 
 class Executor:

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import copy
-from typing import Callable, cast, List, Optional, Set, Tuple  # CHANGE: Added Dict
+from typing import Callable, cast, List, Optional, Set, Tuple
 
 import numpy as np
 import cirq

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import copy
-from typing import Callable, cast, List, Optional, Set, Tuple, Union
+from typing import Callable, cast, List, Optional, Set, Union
 
 import numpy as np
 import cirq

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import copy
-from typing import Callable, cast, List, Optional, Set, Tuple
+from typing import Callable, cast, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import cirq
@@ -125,7 +125,7 @@ class Observable:
 
     def expectation(
         self, circuit: QPROGRAM, execute: Callable[[QPROGRAM], QuantumResult]
-    ) -> complex:
+    ) -> Union[complex, np.ndarray]:
         from mitiq.executor import Executor  # Avoid circular import.
 
         return Executor(execute).evaluate(circuit, observable=self)[0]

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import copy
-from typing import Callable, cast, List, Optional, Set
+from typing import Callable, cast, List, Optional, Set, Tuple  # CHANGE: Added Dict
 
 import numpy as np
 import cirq

--- a/mitiq/raw/raw.py
+++ b/mitiq/raw/raw.py
@@ -15,6 +15,7 @@
 
 """Run experiments without error mitigation."""
 from typing import Callable, Optional, Union
+import numpy.ndarray
 
 from mitiq import Executor, Observable, QPROGRAM, QuantumResult
 
@@ -23,7 +24,7 @@ def execute(
     circuit: QPROGRAM,
     executor: Union[Executor, Callable[[QPROGRAM], QuantumResult]],
     observable: Optional[Observable] = None,
-) -> complex:
+) -> Union[complex, numpy.ndarray]:
     """Evaluates the expectation value associated to the input circuit
     without using error mitigation.
 

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -223,7 +223,7 @@ class Factory(ABC):
 
     def __init__(self) -> None:
         self._instack: List[Dict[str, float]] = []
-        self._outstack: List[Union[float, np.ndarray]] = []  # Change: Changed this list to accept np.array
+        self._outstack: List[Union[float, np.ndarray]] = []
         self._opt_params: Optional[List[float]] = None
         self._params_cov: Optional[np.ndarray] = None
         self._zne_limit: Optional[float] = None
@@ -1483,9 +1483,9 @@ class PolyExpFactory(BatchedFactory):
 
 # Keep a log of the optimization process storing:
 # noise value(s), expectation value(s), parameters, and zero limit
-OptimizationHistory = List[
-    Tuple[List[Dict[str, float]], List[Union[float, np.ndarray]], List[float], float]
-]
+OptimizationHistory = List[Tuple[List[Dict[str, float]],
+                           List[Union[float, np.ndarray]],
+                           List[float], float]]
 
 
 class AdaExpFactory(AdaptiveFactory):

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -570,7 +570,7 @@ class BatchedFactory(Factory, ABC):
             res = []
             for circuit, kwargs in zip(to_run, kwargs_list):
                 res.extend(
-                    executor.evaluate(  # NOTE: Here we spit the result
+                    executor.evaluate(
                         circuit, observable, force_run_all=True, **kwargs
                     )
                 )
@@ -581,13 +581,13 @@ class BatchedFactory(Factory, ABC):
             )
 
         if executor._executor_return_type in CountsLike:
-            self._outstack = res
+            self._outstack = res  # It is already the right shape then, because of executor
         else:
             # Reshape "res" to have "num_to_average" columns
             reshaped = np.array(res).reshape((-1, num_to_average))
 
             # Average the "num_to_average" columns
-            self._outstack = np.average(reshaped, axis=1)  #NOTE: Here is the output
+            self._outstack = np.average(reshaped, axis=1)
         return self
 
     def run_classical(

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -223,7 +223,7 @@ class Factory(ABC):
 
     def __init__(self) -> None:
         self._instack: List[Dict[str, float]] = []
-        self._outstack: List[np.array] = []  # Change: Changed this list to accept np.array
+        self._outstack: List[Union[float, np.ndarray]] = []  # Change: Changed this list to accept np.array
         self._opt_params: Optional[List[float]] = None
         self._params_cov: Optional[np.ndarray] = None
         self._zne_limit: Optional[float] = None
@@ -581,7 +581,8 @@ class BatchedFactory(Factory, ABC):
             )
 
         if executor._executor_return_type in CountsLike:
-            self._outstack = res  # It is already the right shape then, because of executor
+            # The type in this case can only be np.ndarray
+            self._outstack = res  # type: ignore
         else:
             # Reshape "res" to have "num_to_average" columns
             reshaped = np.array(res).reshape((-1, num_to_average))
@@ -1483,7 +1484,7 @@ class PolyExpFactory(BatchedFactory):
 # Keep a log of the optimization process storing:
 # noise value(s), expectation value(s), parameters, and zero limit
 OptimizationHistory = List[
-    Tuple[List[Dict[str, float]], List[float], List[float], float]
+    Tuple[List[Dict[str, float]], List[Union[float, np.ndarray]], List[float], float]
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy~=1.20.1
 scipy~=1.7.3
 cirq~=0.10.0
+qiskit~=0.32.1


### PR DESCRIPTION
Description
-----------

Adding a check in the executor module to look for qiskit Counts object or a dictionary of a specified form. This is to fix having to mitigate a single expectation value at a time. Instead of using a single float value to fit for, this is passing a matrix of size (M, K), having (M) the same size of the scale_factor vector.

Checklist
-----------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [ ] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
  
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
