### PR TITLE
Idle qubits in conversion

### DIFF
--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -232,6 +232,12 @@ def noise_scaling_converter(
     def new_scaling_function(
         circuit: QPROGRAM, *args: Any, **kwargs: Any
     ) -> QPROGRAM:
+        if "qiskit" in circuit.__module__:
+            from mitiq.interface.mitiq_qiskit.conversions import (
+                _add_identity_to_idle
+            )
+            _add_identity_to_idle(circuit)
+
         scaled_circuit = atomic_converter(noise_scaling_function)(
             circuit, *args, **kwargs
         )

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -278,6 +278,7 @@ def noise_scaling_converter(
             from mitiq.interface.mitiq_qiskit.conversions import (
                 _transform_registers,
                 _measurement_order,
+                _remove_identity,
             )
 
             scaled_circuit.remove_final_measurements()
@@ -285,6 +286,7 @@ def noise_scaling_converter(
                 scaled_circuit,
                 new_qregs=circuit.qregs,  # type: ignore
             )
+            _remove_identity(scaled_circuit)
             if circuit.cregs and not scaled_circuit.cregs:  # type: ignore
                 scaled_circuit.add_register(*circuit.cregs)  # type: ignore
 

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -274,7 +274,6 @@ def from_qiskit(circuit: qiskit.QuantumCircuit) -> cirq.Circuit:
     Returns:
         Mitiq circuit representation equivalent to the input Qiskit circuit.
     """
-    _add_identity_to_idle(circuit)
     return from_qasm(circuit.qasm())
 
 


### PR DESCRIPTION
Description
-----------

Naive approach to preserve idle qubits on conversion: insert identity gate, which then gets folded, and then remove all id gates (current flow can be made to target only idle qubits, but doesn't yet). Introduces test failures and folding inefficiency because id gates are folded then removed, but otherwise works.

Checklist
---------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

License
-------

- [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.


Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).

- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
