### PR TITLE
Avoid creation of empty moments when using fold_global

### DIFF
--- a/mitiq/utils.py
+++ b/mitiq/utils.py
@@ -105,7 +105,7 @@ def _pop_measurements(
     if measurements:
         circuit.batch_remove(measurements)
         # Remove the last moment too if left empty.
-        if len(circuit[-1])==0:
+        if len(circuit[-1]) == 0:
             del circuit[-1]
     return measurements
 

--- a/mitiq/utils.py
+++ b/mitiq/utils.py
@@ -102,7 +102,11 @@ def _pop_measurements(
         measurements: List of measurements in the circuit.
     """
     measurements = list(circuit.findall_operations(_is_measurement))
-    circuit.batch_remove(measurements)
+    if measurements:
+        circuit.batch_remove(measurements)
+        # Remove the last moment too if left empty.
+        if len(circuit[-1])==0:
+            del circuit[-1]
     return measurements
 
 

--- a/mitiq/zne/scaling/tests/test_folding.py
+++ b/mitiq/zne/scaling/tests/test_folding.py
@@ -912,6 +912,8 @@ def test_global_fold_stretch_factor_of_three_with_terminal_measurements():
     folded = fold_global(circ + meas, scale_factor=3.0)
     correct = Circuit(circ, inverse(circ), circ, meas)
     assert _equal(folded, correct)
+    # Test the number of moments too
+    assert len(folded) == len(correct)
 
 
 def test_global_fold_stretch_factor_nine_with_terminal_measurements():


### PR DESCRIPTION
After recent changes (#653), `fold_global` preserves the moment structure and this is good!
However, since now moment are not squashed, one can have unexpected appearance of empty moments when using the `fold_global()` function. 

E.g., with the current code we have:

```
>>> c = Circuit(X(LineQubit(0)), measure(LineQubit(0)))
>>> folded = zne.scaling.fold_global(c, 3)
>>> print(c)
0: ───X───M───
>>> print(folded)
0: ───X────────X───X───M───
```

After this PR, the function pop_measurements is updated, such that we get the expected behavior:

```
>>> c = Circuit(X(LineQubit(0)), measure(LineQubit(0)))
>>> folded = zne.scaling.fold_global(c, 3)
>>> print(c)
0: ───X───M───
>>> print(folded)
0: ───X───X───X───M───
```