### PR TITLE
Raise error if executor and observable not compatible

### DIFF
--- a/docs/source/guide/observables.myst
+++ b/docs/source/guide/observables.myst
@@ -127,6 +127,10 @@ obs.expectation(circuit, execute=mitiq_cirq.sample_bitstrings)
 
 In error mitigation techniques, you can provide an observable to specify the expectation value to mitigate.
 
+```{admonition} Note:
+When specifying an `Observable`, you must ensure that the return type of the executor function is `MeasurementResultLike` or `DensityMatrixLike`.
+```
+
 ```{code-cell} ipython3
 from mitiq import zne
 ```

--- a/docs/source/guide/zne-3-options.myst
+++ b/docs/source/guide/zne-3-options.myst
@@ -335,11 +335,11 @@ noise_scaling_function = partial(
 factory = zne.inference.ExpFactory(scale_factors=[1, 2, 3], asymptote=0.25)
 
 zne_value = zne.execute_with_zne(
-    circuit,
-    executor,
-    execute,
-    scale_noise=noise_scaling_function,
+    circuit=circuit,
+    executor=executor,
+    observable=None,
     factory=factory,
+    scale_noise=noise_scaling_function,
     num_to_average=3,
 )
 

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -151,6 +151,16 @@ class Executor:
                 for circuit_with_measurements in observable.measure_in(circuit)
             ]
             result_step = observable.ngroups
+        elif (
+            observable is not None
+            and self._executor_return_type not in MeasurementResultLike
+            and self._executor_return_type not in DensityMatrixLike
+        ):
+            raise ValueError(
+                """Executor and observable are not compatible. Executors
+                returning expectation values as float must be used with
+                observable=None"""
+            )
         else:
             all_circuits = circuits
             result_step = 1

--- a/mitiq/executor/tests/test_executor.py
+++ b/mitiq/executor/tests/test_executor.py
@@ -206,6 +206,35 @@ def test_executor_evaluate_float(execute):
 
 
 @pytest.mark.parametrize(
+    "execute",
+    [
+        executor_batched,
+        executor_batched_unique,
+        executor_serial_unique,
+        executor_serial_typed,
+        executor_serial,
+        executor_pyquil_batched,
+    ],
+)
+@pytest.mark.parametrize(
+    "obs",
+    [
+        PauliString("X"),
+        PauliString("XZ"),
+        PauliString("Z"),
+    ],
+)
+def test_executor_observable_compatibility_check(execute, obs):
+    q = cirq.LineQubit(0)
+    circuits = [cirq.Circuit(cirq.X(q)), cirq.Circuit(cirq.H(q), cirq.Z(q))]
+
+    executor = Executor(execute)
+
+    with pytest.raises(ValueError, match="are not compatible"):
+        executor.evaluate(circuits, obs)
+
+
+@pytest.mark.parametrize(
     "execute", [executor_measurements, executor_measurements_batched]
 )
 def test_executor_evaluate_measurements(execute):


### PR DESCRIPTION


Description
-----------

Replaces PR #1186, attempted workaround for GH Action issue

Fixes #1140 

Checklist
---------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [X] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [X] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [X] Added myself / the copyright holder to the AUTHORS file

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

License
-------

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.


Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).

- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
