### PR TITLE
Add rules for dynamical decoupling 

### DIFF
--- a/mitiq/ddd/__init__.py
+++ b/mitiq/ddd/__init__.py
@@ -14,3 +14,4 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Digital dynamical decoupling (DDD) module."""
+from mitiq.ddd import rules

--- a/mitiq/ddd/rules/__init__.py
+++ b/mitiq/ddd/rules/__init__.py
@@ -14,3 +14,4 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Built-in rules determining what DDD sequence should be applied in a given slack window."""
+from mitiq.ddd.rules.rules import xx, xyxy, yy

--- a/mitiq/ddd/rules/rules.py
+++ b/mitiq/ddd/rules/rules.py
@@ -16,3 +16,143 @@
 """Built-in rules determining what DDD sequence should be applied in a given
 slack window.
 """
+
+from cirq import Circuit, X, Y, I, LineQubit  # , Z
+
+
+def xx(
+    slack_length: int, num_repetitions: int = 1, spacing: int = -1
+) -> Circuit:
+    """Returns an XX digital dynamical decoupling sequence, based on inputs.
+
+    Args:
+        slack_length: Length of idle window to fill.
+        num_repetitions: How many repetitions of the dd rule to apply. Default
+            to 1.
+        spacing: How many identity spacing gates to apply between dynamical
+            decoupling gates, as a positive-value int. Defaults to evenly
+            spaced.
+    Returns:
+        An XX digital dynamical decoupling sequence, as a cirq circuit
+    """
+    default_length = 2
+    num_decoupling_gates = default_length * num_repetitions
+    slack_difference = slack_length - num_decoupling_gates
+    if spacing < 0:
+        spacing = slack_difference // num_decoupling_gates
+    uniform_spacing = (
+        1
+        if spacing == 1
+        else spacing * num_decoupling_gates // (num_decoupling_gates + 1)
+    )
+    slack_remainder = slack_difference - num_decoupling_gates * spacing
+    q = LineQubit(0)
+    slack_gates = [I(q) for _ in range(uniform_spacing)]
+    slack_fill = [I(q) for _ in range(slack_remainder)]
+    ddd_circuit = Circuit(
+        slack_fill[: slack_remainder // 2],
+        slack_gates,
+        [
+            (
+                X(q),
+                slack_gates,
+            )
+            for _ in range(num_decoupling_gates)
+        ],
+        slack_fill[slack_remainder // 2 :],
+    )
+    return ddd_circuit
+
+
+def xyxy(
+    slack_length: int, num_repetitions: int = 1, spacing: int = -1
+) -> Circuit:
+    """Returns an XYXY digital dynamical decoupling sequence, based on inputs.
+
+    Args:
+        slack_length: Length of idle window to fill.
+        num_repetitions: How many repetitions of the dd rule to apply. Default
+            to 1.
+        spacing: How many identity spacing gates to apply between dynamical
+            decoupling gates, as a positive-value int. Defaults to evenly
+            spaced.
+    Returns:
+        An XYXY digital dynamical decoupling sequence, as a cirq circuit
+    """
+    default_length = 4
+    num_decoupling_gates = default_length * num_repetitions
+    slack_difference = slack_length - num_decoupling_gates
+    if spacing < 0:
+        spacing = slack_difference // num_decoupling_gates
+    uniform_spacing = (
+        1
+        if spacing == 1
+        else spacing * num_decoupling_gates // (num_decoupling_gates + 1)
+    )
+    slack_remainder = slack_difference - num_decoupling_gates * spacing
+    q = LineQubit(0)
+    slack_gates = [I(q) for _ in range(uniform_spacing)]
+    slack_fill = [I(q) for _ in range(slack_remainder)]
+    ddd_circuit = Circuit(
+        slack_fill[: slack_remainder // 2],
+        slack_gates,
+        [
+            (
+                X(q),
+                slack_gates,
+                Y(q),
+                slack_gates,
+                X(q),
+                slack_gates,
+                Y(q),
+                slack_gates,
+            )
+            for _ in range(num_repetitions)
+        ],
+        slack_fill[slack_remainder // 2 :],
+    )
+    return ddd_circuit
+
+
+def yy(
+    slack_length: int, num_repetitions: int = 1, spacing: int = -1
+) -> Circuit:
+    """Returns a YY digital dynamical decoupling sequence, based on inputs.
+
+    Args:
+        slack_length: Length of idle window to fill.
+        num_repetitions: How many repetitions of the dd rule to apply. Default
+            to 1.
+        spacing: How many identity spacing gates to apply between dynamical
+            decoupling gates, as a positive-value int. Defaults to evenly
+            spaced.
+    Returns:
+        An YY digital dynamical decoupling sequence, as a cirq circuit
+    """
+    default_length = 2
+    num_decoupling_gates = default_length * num_repetitions
+    slack_difference = slack_length - num_decoupling_gates
+    if spacing < 0:
+        spacing = slack_difference // num_decoupling_gates
+    uniform_spacing = (
+        1
+        if spacing == 1
+        else spacing * num_decoupling_gates // (num_decoupling_gates + 1)
+    )
+    slack_remainder = slack_difference - num_decoupling_gates * spacing
+    q = LineQubit(0)
+    slack_gates = [I(q) for _ in range(uniform_spacing)]
+    slack_fill = [I(q) for _ in range(slack_remainder)]
+    ddd_circuit = Circuit(
+        slack_fill[: slack_remainder // 2],
+        slack_gates,
+        [
+            (
+                Y(q),
+                slack_gates,
+            )
+            for _ in range(num_decoupling_gates)
+        ],
+        slack_fill[slack_remainder // 2 :],
+    )
+    return ddd_circuit


### PR DESCRIPTION
Description
-----------

Please explain the changes you made here.

Checklist
---------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

License
-------

- [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.


Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).

- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
