### PR TITLE
Function to represent OperationRepresentations for biased noise

### DIFF
--- a/docs/source/apidoc.rst
+++ b/docs/source/apidoc.rst
@@ -121,6 +121,9 @@ Quasi-Probability Representations
 .. automodule:: mitiq.pec.representations.depolarizing
    :members:
 
+.. automodule:: mitiq.pec.representations.biased_noise
+   :members:
+
 Sampling from a Noisy Decomposition of an Ideal Operation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: mitiq.pec.sampling

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -417,6 +417,20 @@
    month={Jan}
 }
 
+@article{Strikis_2021_PRXQuantum,
+   title={Learning-Based Quantum Error Mitigation},
+   volume={2},
+   ISSN={2691-3399},
+   url={http://dx.doi.org/10.1103/PRXQuantum.2.040330},
+   DOI={10.1103/prxquantum.2.040330},
+   number={4},
+   journal={PRX Quantum},
+   publisher={American Physical Society (APS)},
+   author={Strikis, Armands and Qin, Dayue and Chen, Yanzhu and Benjamin, Simon C. and Li, Ying},
+   year={2021},
+   month={Nov} 
+   }
+
 @article{Sun_2021_PRAppl,
   title = {Mitigating Realistic Noise in Practical Noisy Intermediate-Scale Quantum Devices},
   author = {Sun, Jinzhao and Yuan, Xiao and Tsunoda, Takahiro and Vedral, Vlatko and Benjamin, Simon C. and Endo, Suguru},

--- a/mitiq/pec/representations/__init__.py
+++ b/mitiq/pec/representations/__init__.py
@@ -32,3 +32,7 @@ from mitiq.pec.representations.optimal import (
     minimize_one_norm,
     find_optimal_representation,
 )
+
+from mitiq.pec.representations.biased_noise import (
+    represent_operation_with_local_biased_noise,
+)

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -46,9 +46,9 @@ def represent_operation_with_local_biased_noise(
     where :math:`\mathcal{U}` is the unitary associated
     to the input ``ideal_operation``,
     :math:`\mathcal{P}_\alpha` is a Pauli operation and
-    ..math::`\mathcal{D}(\epsilon) = (1 - \epsilon)[mathbb{1}] +
-    \epsilon(frac{\eta}{\eta + 1} mathcal{Z}
-    + frac{1}{3}frac{1}{\eta + 1}(mathcal{X} + mathcal{Y} + mathcal{Z}))` is
+    ..math::`\mathcal{D}(\epsilon) = (1 - \epsilon)[\mathbb{1}] +
+    \epsilon(\frac{\eta}{\eta + 1} \mathcal{Z}
+    + \frac{1}{3}\frac{1}{\eta + 1}(\mathcal{X} + \mathcal{Y} + \mathcal{Z}))` is
     the combined (biased) dephasing and depolarizing channel acting on a single
     qubit. For multi-qubit operations, we use a noise channel that is the
     tensor product of the local single-qubit channels.
@@ -68,7 +68,7 @@ def represent_operation_with_local_biased_noise(
         This representation is based on the ideal assumption that one
         can append Pauli gates to a noisy operation without introducing
         additional noise. For a backend which violates this assumption,
-        it remains a good approximation for small values of ``noise_level``.
+        it remains a good approximation for small values of ``epsilon``.
 
     .. note::
         The input ``ideal_operation`` is typically a QPROGRAM with a single

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -1,0 +1,148 @@
+# Copyright (C) 2022 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Function to generate representations with biased noise."""
+
+from typing import List
+
+from cirq import (
+    Operation,
+    X,
+    Y,
+    Z,
+    Circuit,
+)
+
+from mitiq import QPROGRAM
+from mitiq.pec import OperationRepresentation, NoisyOperation
+from mitiq.interface import convert_to_mitiq, convert_from_mitiq
+
+
+def represent_operation_with_local_biased_noise(
+    ideal_operation: QPROGRAM,
+    epsilon: float,
+    eta: float,
+) -> OperationRepresentation:
+    r"""This function maps an
+    ``ideal_operation`` :math:`\mathcal{U}` into its quasi-probability
+    representation, which is a linear combination of noisy implementable
+    operations :math:`\sum_\alpha \eta_{\alpha} \mathcal{O}_{\alpha}`.
+
+    This function assumes a combined depolarizing and dephasing noise model
+    with a bias factor :math:`\eta` (see :cite:`Strikis_2021_PRXQuantum`)
+    and that the following noisy operations are implementable
+    :math:`\mathcal{O}_{\alpha} = \mathcal{D} \circ \mathcal P_\alpha`
+    where :math:`\mathcal{U}` is the unitary associated
+    to the input ``ideal_operation``,
+    :math:`\mathcal{P}_\alpha` is a Pauli operation and
+    ..math::`\mathcal{D}(\epsilon) = (1 - \epsilon)[mathbb{1}] +
+    \epsilon(frac{\eta}{\eta + 1} mathcal{Z}
+    + frac{1}{3}frac{1}{\eta + 1}(mathcal{X} + mathcal{Y} + mathcal{Z}))` is
+    the combined (biased) dephasing and depolarizing channel acting on a single
+    qubit. For multi-qubit operations, we use a noise channel that is the
+    tensor product of the local single-qubit channels.
+
+    Args:
+        ideal_operation: The ideal operation (as a QPROGRAM) to represent.
+        epsilon: The local noise severity (as a float) of the combined channel.
+        eta: The noise bias between combined dephasing and depolarizing
+            channels with :math:`\eta = 0` describing a fully depolarizing
+            channel and :math:`\eta = \inf` describing a fully dephasing
+            channel.
+
+    Returns:
+        The quasi-probability representation of the ``ideal_operation``.
+
+    .. note::
+        This representation is based on the ideal assumption that one
+        can append Pauli gates to a noisy operation without introducing
+        additional noise. For a backend which violates this assumption,
+        it remains a good approximation for small values of ``noise_level``.
+
+    .. note::
+        The input ``ideal_operation`` is typically a QPROGRAM with a single
+        gate but could also correspond to a sequence of more gates.
+        This is possible as long as the unitary associated to the input
+        QPROGRAM, followed by a single final biased noise channel, is
+        physically implementable.
+    """
+    circ, in_type = convert_to_mitiq(ideal_operation)
+
+    post_ops: List[List[Operation]]
+    qubits = circ.all_qubits()
+
+    # Calculate coefficients in basis expansion in terms of eta and epsilon
+    a = 1 - epsilon
+    b = epsilon * (3 * eta + 1) / (3 * (eta + 1))
+    c = epsilon / (3 * (eta + 1))
+    alpha = (a**2 + a * b - 2 * c**2) / (
+        a**3
+        + a**2 * b
+        - a * b**2
+        - 4 * a * c**2
+        - b**3
+        + 4 * b * c**2
+    )
+    beta = (-a * b - b**2 + 2 * c**2) / (
+        a**3
+        + a**2 * b
+        - a * b**2
+        - 4 * a * c**2
+        - b**3
+        + 4 * b * c**2
+    )
+    gamma = -c / (a**2 + 2 * a * b + b**2 - 4 * c**2)
+    if len(qubits) == 1:
+        q = tuple(qubits)[0]
+        alphas = [alpha] + 2 * [gamma] + [beta]
+        post_ops = [[]]  # for eta_1, we do nothing, rather than I
+        post_ops += [[P(q)] for P in [X, Y, Z]]  # 1Q Paulis
+
+        # The two-qubit case: linear combination of 2Q Paulis
+    elif len(qubits) == 2:
+        q0, q1 = qubits
+
+        alphas = (
+            [alpha**2]
+            + 2 * [alpha * gamma]
+            + [alpha * beta]
+            + 2 * [alpha * gamma]
+            + [alpha * beta]
+            + 2 * [gamma**2]
+            + [beta * gamma]
+            + 2 * [gamma**2]
+            + 3 * [beta * gamma]
+            + [beta**2]
+        )
+        post_ops = [[]]  # for eta_1, we do nothing, rather than I x I
+        post_ops += [[P(q0)] for P in [X, Y, Z]]  # 1Q Paulis for q0
+        post_ops += [[P(q1)] for P in [X, Y, Z]]  # 1Q Paulis for q1
+        post_ops += [
+            [Pi(q0), Pj(q1)] for Pi in [X, Y, Z] for Pj in [X, Y, Z]
+        ]  # 2Q Paulis
+
+    else:
+        raise ValueError(
+            "Can only represent single- and two-qubit gates."
+            "Consider pre-compiling your circuit."
+        )
+    # Basis of implementable operations as circuits.
+    imp_op_circuits = [circ + Circuit(op) for op in post_ops]
+
+    # Convert back to input type.
+    imp_op_circuits = [convert_from_mitiq(c, in_type) for c in imp_op_circuits]
+
+    # Build basis expansion.
+    expansion = {NoisyOperation(c): a for c, a in zip(imp_op_circuits, alphas)}
+    return OperationRepresentation(ideal_operation, expansion)

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -68,7 +68,7 @@ def represent_operation_with_local_biased_noise(
         This representation is based on the ideal assumption that one
         can append Pauli gates to a noisy operation without introducing
         additional noise. For a backend which violates this assumption,
-        it remains a good approximation for small values of ``epsilon``.
+        it remains a good approximation for small values of ``noise_level``.
 
     .. note::
         The input ``ideal_operation`` is typically a QPROGRAM with a single

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -47,11 +47,11 @@ def represent_operation_with_local_biased_noise(
     to the input ``ideal_operation``,
     :math:`\mathcal{P}_\alpha` is a Pauli operation and
 
-    ..math::
-        `\mathcal{D}(\epsilon) = (1 - \epsilon)[\mathbb{1}] +
+    .. math::
+        \mathcal{D}(\epsilon) = (1 - \epsilon)[\mathbb{1}] +
         \epsilon(\frac{\eta}{\eta + 1} \mathcal{Z}
         + \frac{1}{3}\frac{1}{\eta + 1}(\mathcal{X} + \mathcal{Y}
-        + \mathcal{Z}))`
+        + \mathcal{Z}))
 
     is the combined (biased) dephasing and depolarizing channel acting on a
     single qubit. For multi-qubit operations, we use a noise channel that is

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -68,7 +68,7 @@ def represent_operation_with_local_biased_noise(
         This representation is based on the ideal assumption that one
         can append Pauli gates to a noisy operation without introducing
         additional noise. For a backend which violates this assumption,
-        it remains a good approximation for small values of ``noise_level``.
+        it remains a good approximation for small values of ``epsilon``.
 
     .. note::
         The input ``ideal_operation`` is typically a QPROGRAM with a single

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -48,10 +48,10 @@ def represent_operation_with_local_biased_noise(
     :math:`\mathcal{P}_\alpha` is a Pauli operation and
     ..math::`\mathcal{D}(\epsilon) = (1 - \epsilon)[\mathbb{1}] +
     \epsilon(\frac{\eta}{\eta + 1} \mathcal{Z}
-    + \frac{1}{3}\frac{1}{\eta + 1}(\mathcal{X} + \mathcal{Y} + \mathcal{Z}))` is
-    the combined (biased) dephasing and depolarizing channel acting on a single
-    qubit. For multi-qubit operations, we use a noise channel that is the
-    tensor product of the local single-qubit channels.
+    + \frac{1}{3}\frac{1}{\eta + 1}(\mathcal{X} + \mathcal{Y} + \mathcal{Z}))`
+    is the combined (biased) dephasing and depolarizing channel acting on a
+    single qubit. For multi-qubit operations, we use a noise channel that is
+    the tensor product of the local single-qubit channels.
 
     Args:
         ideal_operation: The ideal operation (as a QPROGRAM) to represent.

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -46,9 +46,11 @@ def represent_operation_with_local_biased_noise(
     where :math:`\mathcal{U}` is the unitary associated
     to the input ``ideal_operation``,
     :math:`\mathcal{P}_\alpha` is a Pauli operation and
-    ..math::`\mathcal{D}(\epsilon) = (1 - \epsilon)[\mathbb{1}] +
-    \epsilon(\frac{\eta}{\eta + 1} \mathcal{Z}
+    ..math::
+        `\mathcal{D}(\epsilon) = (1 - \epsilon)[\mathbb{1}] +
+        \epsilon(\frac{\eta}{\eta + 1} \mathcal{Z}
     + \frac{1}{3}\frac{1}{\eta + 1}(\mathcal{X} + \mathcal{Y} + \mathcal{Z}))`
+
     is the combined (biased) dephasing and depolarizing channel acting on a
     single qubit. For multi-qubit operations, we use a noise channel that is
     the tensor product of the local single-qubit channels.

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -46,10 +46,12 @@ def represent_operation_with_local_biased_noise(
     where :math:`\mathcal{U}` is the unitary associated
     to the input ``ideal_operation``,
     :math:`\mathcal{P}_\alpha` is a Pauli operation and
+
     ..math::
         `\mathcal{D}(\epsilon) = (1 - \epsilon)[\mathbb{1}] +
         \epsilon(\frac{\eta}{\eta + 1} \mathcal{Z}
-    + \frac{1}{3}\frac{1}{\eta + 1}(\mathcal{X} + \mathcal{Y} + \mathcal{Z}))`
+        + \frac{1}{3}\frac{1}{\eta + 1}(\mathcal{X} + \mathcal{Y}
+        + \mathcal{Z}))`
 
     is the combined (biased) dephasing and depolarizing channel acting on a
     single qubit. For multi-qubit operations, we use a noise channel that is

--- a/mitiq/pec/representations/tests/test_biased_noise.py
+++ b/mitiq/pec/representations/tests/test_biased_noise.py
@@ -1,0 +1,242 @@
+# Copyright (C) 2022 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+import pytest
+from cirq import (
+    CCNOT,
+    CNOT,
+    CZ,
+    ISWAP,
+    I,
+    X,
+    Y,
+    Z,
+    H,
+    SWAP,
+    Gate,
+    LineQubit,
+    Circuit,
+    ops,
+    unitary,
+)
+
+
+from mitiq.pec.representations.biased_noise import (
+    represent_operation_with_local_biased_noise,
+)
+
+from mitiq.pec.channels import _operation_to_choi, _circuit_to_choi
+
+
+def single_qubit_biased_noise_overhead(epsilon: float, eta: float) -> float:
+    """Overhead calculation similar to that presented in [Temme2017]_ and
+    modified according to combined (biased) noise channel in [Strikis2021]_.
+
+    .. [Temme2017] : Kristan Temme, Sergey Bravyi, Jay M. Gambetta,
+        "Error mitigation for short-depth quantum circuits,"
+        *Phys. Rev. Lett.* **119**, 180509 (2017),
+        (https://arxiv.org/abs/1612.02058).
+
+    .. [Strikis2021] : Armands Strikis, Dayue Qin, Yanzhu Chen,
+        Simon C. Benjamin, and Ying Li,
+        "Learning-Based Quantum Error Mitigation,"
+        *PRX QUANTUM* **2**, 040330 (2021),
+        (https://arxiv.org/abs/2005.07601v2).
+    """
+    a = 1 - epsilon
+    b = epsilon * (3 * eta + 1) / (3 * (eta + 1))
+    c = epsilon / (3 * (eta + 1))
+    eta1 = (a**2 + a * b - 2 * c**2) / (
+        a**3
+        + a**2 * b
+        - a * b**2
+        - 4 * a * c**2
+        - b**3
+        + 4 * b * c**2
+    )
+    eta2 = -c / (a**2 + 2 * a * b + b**2 - 4 * c**2)
+    eta3 = (-a * b - b**2 + 2 * c**2) / (
+        a**3
+        + a**2 * b
+        - a * b**2
+        - 4 * a * c**2
+        - b**3
+        + 4 * b * c**2
+    )
+
+    return abs(eta1) + 2 * abs(eta2) + abs(eta3)
+
+
+def two_qubit_biased_noise_overhead(epsilon: float, eta: float) -> float:
+    """Overhead calculation similar to that presented in [Temme2017]_ and
+    modified according to combined (biased) noise channel in [Strikis2021]_.
+
+    .. [Temme2017] : Kristan Temme, Sergey Bravyi, Jay M. Gambetta,
+        "Error mitigation for short-depth quantum circuits,"
+        *Phys. Rev. Lett.* **119**, 180509 (2017),
+        (https://arxiv.org/abs/1612.02058).
+
+    .. [Strikis2021] : Armands Strikis, Dayue Qin, Yanzhu Chen,
+        Simon C. Benjamin, and Ying Li,
+        "Learning-Based Quantum Error Mitigation,"
+        *PRX QUANTUM* **2**, 040330 (2021),
+        (https://arxiv.org/abs/2005.07601v2).
+    """
+    a = 1 - epsilon
+    b = epsilon * (3 * eta + 1) / (3 * (eta + 1))
+    c = epsilon / (3 * (eta + 1))
+    alpha_sq = (a**2 + a * b - 2 * c**2) ** 2 / (
+        a**3
+        + a**2 * b
+        - a * b**2
+        - 4 * a * c**2
+        - b**3
+        + 4 * b * c**2
+    ) ** 2
+    alpha_beta = (
+        (a**2 + a * b - 2 * c**2)
+        * (-a * b - b**2 + 2 * c**2)
+        / (
+            a**3
+            + a**2 * b
+            - a * b**2
+            - 4 * a * c**2
+            - b**3
+            + 4 * b * c**2
+        )
+        ** 2
+    )
+    alpha_gamma = (
+        -c
+        * (a**2 + a * b - 2 * c**2)
+        / (
+            (a**2 + 2 * a * b + b**2 - 4 * c**2)
+            * (
+                a**3
+                + a**2 * b
+                - a * b**2
+                - 4 * a * c**2
+                - b**3
+                + 4 * b * c**2
+            )
+        )
+    )
+    beta_sq = (-a * b - b**2 + 2 * c**2) ** 2 / (
+        a**3
+        + a**2 * b
+        - a * b**2
+        - 4 * a * c**2
+        - b**3
+        + 4 * b * c**2
+    ) ** 2
+    beta_gamma = (
+        -c
+        * (-a * b - b**2 + 2 * c**2)
+        / (
+            (a**2 + 2 * a * b + b**2 - 4 * c**2)
+            * (
+                a**3
+                + a**2 * b
+                - a * b**2
+                - 4 * a * c**2
+                - b**3
+                + 4 * b * c**2
+            )
+        )
+    )
+    gamma_sq = c**2 / (a**2 + 2 * a * b + b**2 - 4 * c**2) ** 2
+    overhead = (
+        alpha_sq
+        + 4 * abs(alpha_gamma)
+        + 2 * abs(alpha_beta)
+        + 4 * (gamma_sq)
+        + 4 * abs(beta_gamma)
+        + beta_sq
+    )
+
+    return overhead
+
+
+@pytest.mark.parametrize("epsilon", [0, 0.1, 0.7])
+@pytest.mark.parametrize("eta", [0, 1, 1000])
+@pytest.mark.parametrize("gate", [X, Y, Z, H])
+def test_single_qubit_representation_norm(
+    gate: Gate, epsilon: float, eta: float
+):
+    q = LineQubit(0)
+    optimal_norm = single_qubit_biased_noise_overhead(epsilon, eta)
+    norm = represent_operation_with_local_biased_noise(
+        Circuit(gate(q)), epsilon, eta
+    ).norm
+    assert np.isclose(optimal_norm, norm)
+
+
+@pytest.mark.parametrize("epsilon", [0, 0.1, 0.7])
+@pytest.mark.parametrize("eta", [0, 1, 1000])
+@pytest.mark.parametrize("gate", (CZ, CNOT, ISWAP, SWAP))
+def test_two_qubit_representation_norm(gate: Gate, epsilon: float, eta: float):
+    qreg = LineQubit.range(2)
+    optimal_norm = two_qubit_biased_noise_overhead(epsilon, eta)
+    norm = represent_operation_with_local_biased_noise(
+        Circuit(gate(*qreg)), epsilon, eta
+    ).norm
+    assert np.isclose(optimal_norm, norm)
+
+
+def test_three_qubit_biased_noise_representation_error():
+    q0, q1, q2 = LineQubit.range(3)
+    with pytest.raises(ValueError):
+        represent_operation_with_local_biased_noise(
+            Circuit(CCNOT(q0, q1, q2)), 0.05, 10
+        )
+
+
+@pytest.mark.parametrize("epsilon", [0, 0.1, 0.7])
+@pytest.mark.parametrize("eta", [0, 1, 1000])
+@pytest.mark.parametrize("gate", [X, Y, Z, H, CZ, CNOT, ISWAP, SWAP])
+def test_biased_noise_representation_with_choi(
+    gate: Gate, epsilon: float, eta: float
+):
+    """Tests the representation by comparing exact Choi matrices."""
+    qreg = LineQubit.range(gate.num_qubits())
+    ideal_choi = _operation_to_choi(gate.on(*qreg))
+    op_rep = represent_operation_with_local_biased_noise(
+        Circuit(gate.on(*qreg)), epsilon, eta
+    )
+    choi_components = []
+
+    # Define biased noise channel
+    a = 1 - epsilon
+    b = epsilon * (3 * eta + 1) / (3 * (eta + 1))
+    c = epsilon / (3 * (eta + 1))
+
+    mix = [
+        (a, unitary(I)),
+        (b, unitary(Z)),
+        (c, unitary(X)),
+        (c, unitary(Y)),
+    ]
+
+    for noisy_op, coeff in op_rep.basis_expansion.items():
+        implementable_circ = noisy_op.circuit()
+        # Apply noise after each sequence.
+        # NOTE: noise is not applied after each operation.
+        biased_op = ops.MixedUnitaryChannel(mix).on_each(*qreg)
+        implementable_circ.append(biased_op)
+        sequence_choi = _circuit_to_choi(implementable_circ)
+        choi_components.append(coeff * sequence_choi)
+    combination_choi = np.sum(choi_components, axis=0)
+    assert np.allclose(ideal_choi, combination_choi, atol=10**-6)


### PR DESCRIPTION
Description
-----------

Fixes #1109. 

Replaces PR #1134. 
Publish changes on clean branch to work around RTD issue w/ fork. 


Checklist
---------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [X] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [X] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [X] Added myself / the copyright holder to the AUTHORS file

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

License
-------

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.


Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).

- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
