### PR TITLE
Wait more time before issues are marked as stale and exempt important labels

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -14,9 +14,11 @@ jobs:
       - name: Close Stale Issues
         uses: actions/stale@v5
         with:
-          days-before-stale: 60
-          days-before-close: 7
-          stale-issue-message: This issue had no activity for **2 months**, and will be closed in **one week** unless there is new activity. Cheers!
+          days-before-stale: 120
+          days-before-close: 14
+          stale-issue-message: This issue had no activity for **4 months**, and will be closed in **2 weeks** unless there is new activity. Cheers!
           stale-issue-label: stale
-          stale-pr-message: This pull request had no activity for **2 months**, and will be closed in **one week** unless there is new activity. Cheers!
+          stale-pr-message: This pull request had no activity for **4 months**, and will be closed in **2 weeks** unless there is new activity. Cheers!
           stale-pr-label: stale
+          exempt-issue-labels: 'bug,roadmap,priority/p0'
+          exempt-pr-labels: 'bug,roadmap,priority/p0'


### PR DESCRIPTION
Description
-----------

This PR doubles the time before issues are marked as stale and exempt important labels: `roadmap`, `priority/p0` and `bug`.
Fixes #1215.

License
-------

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.