### PR TITLE
Update "google-style docstring" URLs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Check off the following once complete (or if not applicable) after opening the P
 
 - [ ] I added unit tests for new code.
 - [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
-- [ ] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
+- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
 - [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
 - [ ] Added myself / the copyright holder to the AUTHORS file
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ Mitiq code is developed according the best practices of Python development.
 * Please get familiar with [PEP 8](https://www.python.org/dev/peps/pep-0008/) (code)
   and [PEP 257](https://www.python.org/dev/peps/pep-0257/) (docstrings) guidelines.
 * Use annotations for type hints in the objects' signature.
-* Write [google-style docstrings](https://google.github.io/styleguide/pyguide.html#doc-function-args).
+* Write [google-style docstrings](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods).
 
 We use [Black](https://black.readthedocs.io/en/stable/index.html) and `flake8` to automatically
 lint the code and enforce style requirements as part of the CI pipeline. You can run these style


### PR DESCRIPTION
While going through some documentation I found that we use two different links when referring to (presumably) the same thing. I've removed the non-google controlled URL as it seems less helpful, and perhaps slightly different from the Google recommendations, as well as update the URL to a slightly different part of the same page.

If there is a reason we were using the docs from the other URL please let me know!