### PR TITLE
Simplify issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,13 +26,10 @@ assignees: ''
 ## Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
+---
 
-
-
-
-
-Environment Context
--------------------
+<details>
+<summary>Environment Context</summary>
 
 Use the `about()` function to summarize information on operating system, python version and dependencies.
 ```python
@@ -45,3 +42,5 @@ Additional Python Environment Details (`pip freeze` or `conda list`):
 ```
 Copy and paste the output of `pip freeze` or `conda list` here.
 ```
+
+</details>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,19 +26,10 @@ assignees: ''
 ## Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
-Otherwise, just fill out the "Code Snippet" and "Error Output" sections below.
 
-### Code Snippet
 
-```python
-Include a snippet of the mitiq code that produces the error here.
-```
 
-### Error Output
 
-```
-Additionally, please copy and paste the output of the above code here.
-```
 
 Environment Context
 -------------------

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,11 +7,10 @@ assignees: ''
 
 ---
 
-Pre-Report Checklist
---------------------
+<!-- Before submitting an issue please make sure you are: -->
+<!-- running the latest version of mitiq -->
+<!-- checked to make sure this bug has not already been reported -->
 
-- [ ] I am running the latest version of mitiq
-- [ ] I checked to make sure that this bug has not already been reported
 
 Issue Description
 -----------------

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,17 +12,19 @@ assignees: ''
 <!-- checked to make sure this bug has not already been reported -->
 
 
-Issue Description
------------------
+## Issue Description
+<!-- A short description of the bug here, along with what you expected the behavior to be. -->
 
-Insert a short description of the bug here, along with what you expected the behavior to be.
+<!-- Thanks for helping us improve mitiq! 🙂 -->
 
-Thanks for helping us improve mitiq! 🙂
+## How to Reproduce
 
-How to Reproduce
-----------------
+1. ...
+2. ...
+3. ...
 
-If useful, provide a numbered list of the steps that result in the error.
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
 Otherwise, just fill out the "Code Snippet" and "Error Output" sections below.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,10 +7,8 @@ assignees: ''
 
 ---
 
-Pre-Request Checklist
----------------------
+<!-- Before submitting an issue please make sure you checked to make sure that this feature has not already been requested. -->
 
-- [ ] I checked to make sure that this feature has not already been requested.
 
 Issue Description
 -----------------

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,24 +10,17 @@ assignees: ''
 <!-- Before submitting an issue please make sure you checked to make sure that this feature has not already been requested. -->
 
 
-Issue Description
------------------
+## Issue Description
 
-Give a detailed description of the new feature, and what problem it is trying to solve.
+<!-- Give a detailed description of the new feature, and what problem it is trying to solve. -->
+<!-- If this is a proposal to change an existing feature, also outline the current implementation and its drawbacks. -->
+<!-- Thanks for helping us improve Mitiq! 🙂 -->
 
-If this is a proposal to change an existing feature, also outline the current
-implementation and its drawbacks.
+## Proposed Solution
 
-Thanks for helping us improve Mitiq! 🙂
-
-Proposed Solution
------------------
-
-Let us know what you'd like to see happen, and be sure to mention
-any alternatives that you've considered.
+<!-- Let us know what you'd like to see happen, and be sure to mention any alternatives that you've considered. -->
 
 
-Additional References
----------------------
+## Additional References
 
-If applicable, provide some references that will help us better understand the request.
+<!-- If applicable, provide some references that will help us better understand the request. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,38 +1,33 @@
-Description
------------
+<!--
+⚠️ Your pull request title should be short, detailed, and understandable for all.
+⚠️ If your pull request fixes an open issue, please link to the issue.
 
-Please explain the changes you made here.
+Ensure you have completed the following before continuing.
+✅ I have read the CONTRIBUTING document.
+✅ I have added tests to cover my changes.
+✅ I updated the documentation, where relevant.
+✅ I used type hints (https://www.python.org/dev/peps/pep-0484/) in function signatures.
+✅ I used Google-style (https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
+✅ I added myself / the copyright holder to the AUTHORS file.
+-->
 
-Checklist
----------
+<!--
+If the validation checks fail
+  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
 
-Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.
+  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.
 
-- [ ] I added unit tests for new code.
-- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
-- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
-- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
-- [ ] Added myself / the copyright holder to the AUTHORS file
+  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.
 
-If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
+For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
+-->
 
-License
--------
+## Description
+
+<!-- Please explain the changes you made here. -->
+
+---
+
+### License
 
 - [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
-
-
-Tips
-----
-
-- If the validation check fails:
-
-    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.
-
-    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.
-
-    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.
-
-  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-
-- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,6 @@
 <!--
 ⚠️ Your pull request title should be short, detailed, and understandable for all.
 ⚠️ If your pull request fixes an open issue, please link to the issue.
-
-Ensure you have completed the following before continuing.
-✅ I have read the CONTRIBUTING document.
-✅ I have added tests to cover my changes.
-✅ I updated the documentation, where relevant.
-✅ I used type hints (https://www.python.org/dev/peps/pep-0484/) in function signatures.
-✅ I used Google-style (https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
-✅ I added myself / the copyright holder to the AUTHORS file.
 -->
 
 <!--
@@ -31,3 +23,10 @@ For more information, check the Mitiq style guidelines (https://mitiq.readthedoc
 ### License
 
 - [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
+
+Before opening the PR, please ensure you have completed the following where appropriate.
+- I added unit tests for new code.
+- I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
+- I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
+- I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
+- Added myself / the copyright holder to the AUTHORS file

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,8 +25,8 @@ For more information, check the Mitiq style guidelines (https://mitiq.readthedoc
 - [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
 
 Before opening the PR, please ensure you have completed the following where appropriate.
-- I added unit tests for new code.
-- I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
-- I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
-- I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
-- Added myself / the copyright holder to the AUTHORS file
+- [ ] I added unit tests for new code.
+- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
+- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
+- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
+- [ ] Added myself / the copyright holder to the AUTHORS file

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-⚠️ Your pull request title should be short, detailed, and understandable for all.
+⚠️ Your pull request title should be short, comprehensive, and understandable for all.
 ⚠️ If your pull request fixes an open issue, please link to the issue.
 -->
 


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

Ensure you have completed the following before continuing.
✅ I have read the CONTRIBUTING document.
✅ I have added tests to cover my changes.
✅ I updated the documentation, where relevant.
✅ I used type hints (https://www.python.org/dev/peps/pep-0484/) in function signatures.
✅ I used Google-style (https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
✅ I added myself / the copyright holder to the AUTHORS file.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.

  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.

  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

This PR moves the majority of the instructions in issue and PR templates to comments, and removes some extraneous material.

### Motivation

As it stands, I think we have too much boilerplate in our issue and PR templates. This both increases the barrier to open an issue, and makes it more difficult to skim issues to obtain an understanding of the problem. For example (but not to pick on), https://github.com/unitaryfund/mitiq/issues/1214 includes 2 lines describing the issue, and a bulk of text that's been left unedited from the boilerplate.

In making these changes I references what other major open source projects use for these templates such as [cirq](https://github.com/quantumlib/Cirq/blob/master/.github/ISSUE_TEMPLATE/bug_report.md), [pennylane](https://github.com/PennyLaneAI/pennylane/blob/master/.github/ISSUE_TEMPLATE/bug_report.yml), [qiskit](https://github.com/Qiskit/qiskit/blob/master/.github/ISSUE_TEMPLATE/bug_report.md), [vscode](https://github.com/microsoft/vscode/blob/main/.github/ISSUE_TEMPLATE/bug_report.md), and [nix](https://github.com/NixOS/nixpkgs/blob/master/.github/ISSUE_TEMPLATE/bug_report.md).

**Question**: I'd like to remove the "License" checkbox in the PR template as well (and perhaps add a line to the hidden comments saying something to the affect of "by opening a PR you are agreeing to ..."), but I'm not sure if there's a reason to keep the checkbox around.

---

It's likely easiest to review this PR commit by commit.

cc @nathanshammah, @andreamari, and @Misty-W since this affects all of us.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
