### PR TITLE
Fixes unexpected error from repeated rule

### DIFF
--- a/mitiq/ddd/rules/rules.py
+++ b/mitiq/ddd/rules/rules.py
@@ -174,6 +174,8 @@ def repeated_rule(slack_length: int, gates: List[Gate]) -> Circuit:
         the sequence: ──X──Y──X──Y──X──Y──X──Y──.
     """
     num_decoupling_gates = len(gates)
+    if num_decoupling_gates > slack_length:
+        return Circuit()
     sequence = general_rule(
         slack_length=slack_length,
         spacing=0,

--- a/mitiq/ddd/rules/tests/test_rules.py
+++ b/mitiq/ddd/rules/tests/test_rules.py
@@ -200,6 +200,7 @@ def test_repeated_sequences(slack_length, gates):
     assert len(sequence) == slack_length
     assert gates * num_reps == [gate for gate in seq_gates if gate in gate_set]
 
+
 @pytest.mark.parametrize(
     "slack_length",
     [2, 3],
@@ -217,6 +218,7 @@ def test_short_repeated_sequences(slack_length, gates):
         gates=gates,
     )
     assert len(sequence) == 0
+
 
 @pytest.mark.parametrize(
     "gates",

--- a/mitiq/ddd/rules/tests/test_rules.py
+++ b/mitiq/ddd/rules/tests/test_rules.py
@@ -200,6 +200,23 @@ def test_repeated_sequences(slack_length, gates):
     assert len(sequence) == slack_length
     assert gates * num_reps == [gate for gate in seq_gates if gate in gate_set]
 
+@pytest.mark.parametrize(
+    "slack_length",
+    [2, 3],
+)
+@pytest.mark.parametrize(
+    "gates",
+    [
+        [X, Y, X, Y],
+        [Y, Y, Y, Y],
+    ],
+)
+def test_short_repeated_sequences(slack_length, gates):
+    sequence = repeated_rule(
+        slack_length=slack_length,
+        gates=gates,
+    )
+    assert len(sequence) == 0
 
 @pytest.mark.parametrize(
     "gates",


### PR DESCRIPTION
Description
-----------

Fixes #1260. Returns an empty circuit when the slack length is shorter than the number of gates in a repeated sequence.

License
-------

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

