### PR TITLE
Add references for DDD theory section

### DIFF
--- a/docs/source/guide/ddd-5-theory.myst
+++ b/docs/source/guide/ddd-5-theory.myst
@@ -13,7 +13,7 @@ kernelspec:
 
 # What is the theory behind DDD?
 
-Dynamical decoupling (DD) [Viola and Lloyd PRA 1998, Viola, Knill, Lloyd, PRL 1999, Peng,Suter1, Lidar JPB 2011]
+Dynamical decoupling (DD) {cite}`Viola_1998_PRA, Viola_1999_PRL, Zhang_2014_PRL`
 is a quantum control technique to effectively reduce the interaction of a quantum system with its environment.
 The protocol works by driving a quantum system with rapid sequences of periodic control pulses.
 The application of DD sequences can have in two effects depending on the correlation time of the environment:
@@ -54,7 +54,7 @@ to distinguish it from the standard pulse-level formulation.
 This type of gate-level approach is very similar to the gate-level abstraction used in Mitiq to implement
 _digital zero-noise extrapolation_ via _unitary folding_ (see [What is the theory behind ZNE?](zne-5-theory.myst)).
 ```
-Experimental evidence showing the practical utility gate-level decoupling sequences is given in several publications [extract some references form RFC for DDD].
+Experimental evidence showing the practical utility gate-level decoupling sequences is given in several publications {cite}`Pokharel_2018_PRL, Jurcevic_2021_arxiv, GoogleQuantum_2021_nature, Smith_2021_arxiv, Das_2021_ACM`.
 
 
 ```{warning}

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -109,6 +109,23 @@
 }
 
 # Letter D
+@inproceedings{Das_2021_ACM,
+  author = {Das, Poulami and Tannu, Swamit and Dangwal, Siddharth and Qureshi, Moinuddin},
+  title = {ADAPT: Mitigating Idling Errors in Qubits via Adaptive Dynamical Decoupling},
+  year = {2021},
+  isbn = {9781450385572},
+  publisher = {Association for Computing Machinery},
+  address = {New York, NY, USA},
+  url = {https://doi.org/10.1145/3466752.3480059},
+  doi = {10.1145/3466752.3480059},
+  booktitle = {MICRO-54: 54th Annual IEEE/ACM International Symposium on Microarchitecture},
+  pages = {950–962},
+  numpages = {13},
+  keywords = {Quantum computing, NISQ, Idling errors, Dynamical decoupling},
+  location = {Virtual Event, Greece},
+  series = {MICRO '21}
+}
+
 @article{De2020polynomial,
   title={Polynomial interpolation via mapped bases without resampling},
   author={De Marchi, Stefano and Marchetti, Francesco and Perracchione, Emma and Poggiali, Davide},
@@ -171,9 +188,36 @@
     archivePrefix={arXiv},
     primaryClass={quant-ph}
 }
+
+@article{GoogleQuantum_2021_nature,
+  doi = {10.1038/s41586-021-03588-y},
+  url = {https://doi.org/10.1038/s41586-021-03588-y},
+  year = {2021},
+  month = {jul},
+  publisher = {Springer Science and Business Media {LLC}},
+  volume = {595},
+  number = {7867},
+  pages = {383--387},
+  author = {Zijun Chen and Kevin J. Satzinger and Juan Atalaya and Alexander N. Korotkov and Andrew Dunsworth and Daniel Sank and Chris Quintana and Matt McEwen and Rami Barends and Paul V. Klimov and Sabrina Hong and Cody Jones and Andre Petukhov and Dvir Kafri and Sean Demura and Brian Burkett and Craig Gidney and Austin G. Fowler and Alexandru Paler and Harald Putterman and Igor Aleiner and Frank Arute and Kunal Arya and Ryan Babbush and Joseph C. Bardin and Andreas Bengtsson and Alexandre Bourassa and Michael Broughton and Bob B. Buckley and David A. Buell and Nicholas Bushnell and Benjamin Chiaro and Roberto Collins and William Courtney and Alan R. Derk and Daniel Eppens and Catherine Erickson and Edward Farhi and Brooks Foxen and Marissa Giustina and Ami Greene and Jonathan A. Gross and Matthew P. Harrigan and Sean D. Harrington and Jeremy Hilton and Alan Ho and Trent Huang and William J. Huggins and L. B. Ioffe and Sergei V. Isakov and Evan Jeffrey and Zhang Jiang and Kostyantyn Kechedzhi and Seon Kim and Alexei Kitaev and Fedor Kostritsa and David Landhuis and Pavel Laptev and Erik Lucero and Orion Martin and Jarrod R. McClean and Trevor McCourt and Xiao Mi and Kevin C. Miao and Masoud Mohseni and Shirin Montazeri and Wojciech Mruczkiewicz and Josh Mutus and Ofer Naaman and Matthew Neeley and Charles Neill and Michael Newman and Murphy Yuezhen Niu and Thomas E. O'Brien and Alex Opremcak and Eric Ostby and B{\'{a}}lint Pat{\'{o}} and Nicholas Redd and Pedram Roushan and Nicholas C. Rubin and Vladimir Shvarts and Doug Strain and Marco Szalay and Matthew D. Trevithick and Benjamin Villalonga and Theodore White and Z. Jamie Yao and Ping Yeh and Juhwan Yoo and Adam Zalcman and Hartmut Neven and Sergio Boixo and Vadim Smelyanskiy and Yu Chen and Anthony Megrant and Julian Kelly},
+  title = {Exponential suppression of bit or phase errors with cyclic error correction},
+  journal = {Nature}
+}
+
 # Letter H
 # Letter I
 # Letter J
+
+@misc{Jurcevic_2021_arxiv,
+  author = {{Jurcevic}, Petar and {Javadi-Abhari}, Ali and {Bishop}, Lev S. and {Lauer}, Isaac and {Bogorin}, Daniela F. and {Brink}, Markus and {Capelluto}, Lauren and {G{\"u}nl{\"u}k}, Oktay and {Itoko}, Toshinari and {Kanazawa}, Naoki and {Kandala}, Abhinav and {Keefe}, George A. and {Krsulich}, Kevin and {Landers}, William and {Lewandowski}, Eric P. and {McClure}, Douglas T. and {Nannicini}, Giacomo and {Narasgond}, Adinath and {Nayfeh}, Hasan M. and {Pritchett}, Emily and {Rothwell}, Mary Beth and {Srinivasan}, Srikanth and {Sundaresan}, Neereja and {Wang}, Cindy and {Wei}, Ken X. and {Wood}, Christopher J. and {Yau}, Jeng-Bang and {Zhang}, Eric J. and {Dial}, Oliver E. and {Chow}, Jerry M. and {Gambetta}, Jay M.},
+  title = "{Demonstration of quantum volume 64 on a superconducting quantum computing system}",
+  year = {2021},
+  month = {apr},
+  archivePrefix = {arXiv},
+  eprint = {2008.08571},
+  primaryClass = {quant-ph}
+}
+
+
 # Letter K
 
 @article{Kandala_2019_Nature,
@@ -371,6 +415,22 @@
   url = {https://link.aps.org/doi/10.1103/PhysRevLett.115.070501}
 }
 
+@article{Pokharel_2018_PRL,
+  title = {Demonstration of Fidelity Improvement Using Dynamical Decoupling with Superconducting Qubits},
+  author = {Pokharel, Bibek and Anand, Namit and Fortman, Benjamin and Lidar, Daniel A.},
+  journal = {Phys. Rev. Lett.},
+  volume = {121},
+  issue = {22},
+  pages = {220502},
+  numpages = {6},
+  year = {2018},
+  month = {Nov},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevLett.121.220502},
+  url = {https://link.aps.org/doi/10.1103/PhysRevLett.121.220502}
+}
+
+
 @article{Preskill_2018_Quantum,
    title={Quantum Computing in the {N}{I}{S}{Q} era and beyond},
    volume={2},
@@ -415,6 +475,16 @@
    author={Zhang, Shuaining and Lu, Yao and Zhang, Kuan and Chen, Wentao and Li, Ying and Zhang, Jing-Ning and Kim, Kihwan},
    year={2020},
    month={Jan}
+}
+
+@misc{Smith_2021_arxiv,
+  author = {{Smith}, Kaitlin N. and {Subramanian Ravi}, Gokul and {Murali}, Prakash and {Baker}, Jonathan M. and {Earnest}, Nathan and {Javadi-Abhari}, Ali and {Chong}, Frederic T.},
+  title = "{Error Mitigation in Quantum Computers through Instruction Scheduling}",
+  year = {2021},
+  month = {may},
+  archivePrefix = {arXiv},
+  eprint = {2105.01760},
+  primaryClass = {quant-ph}
 }
 
 @article{Strikis_2021_PRXQuantum,
@@ -494,6 +564,22 @@
    pages={2417–2421}
 }
 
+@article{Viola_1998_PRA,
+  title = {Dynamical suppression of decoherence in two-state quantum systems},
+  author = {Viola, Lorenza and Lloyd, Seth},
+  journal = {Phys. Rev. A},
+  volume = {58},
+  issue = {4},
+  pages = {2733--2744},
+  numpages = {0},
+  year = {1998},
+  month = {Oct},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevA.58.2733},
+  url = {https://link.aps.org/doi/10.1103/PhysRevA.58.2733}
+}
+
+
 # Letter W
 @article{Wallman_2016_PRA,
   title = {Noise tailoring for scalable quantum computation via randomized compiling},
@@ -526,3 +612,17 @@
    month={Jan}
 }
 
+@article{Zhang_2014_PRL,
+  title = {Protected Quantum Computing: Interleaving Gate Operations with Dynamical Decoupling Sequences},
+  author = {Zhang, Jingfu and Souza, Alexandre M. and Brandao, Frederico Dias and Suter, Dieter},
+  journal = {Phys. Rev. Lett.},
+  volume = {112},
+  issue = {5},
+  pages = {050502},
+  numpages = {5},
+  year = {2014},
+  month = {Feb},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevLett.112.050502},
+  url = {https://link.aps.org/doi/10.1103/PhysRevLett.112.050502}
+}


### PR DESCRIPTION
## Description

Add references for theory section of DDD documentation in preparation of https://github.com/unitaryfund/mitiq/pull/1311 going out.

**Note**: this PR is being merged into https://github.com/unitaryfund/mitiq/pull/1311.