### PR TITLE
Ensure lists are properly displayed

### DIFF
--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -17,6 +17,7 @@ Development work is done on separate branches and forks that get merged into
 ``master`` when they are ready to be included in the next release.
 
 The main steps of our git flow are as follows:
+
 - Feature work and bug fixes are done on branches (external contributors should fork and then work on branches on their fork)
 - Once work is ready for review and inclusion in a release, make a PR from the branch/fork to master on the Mitiq repo. Squash merges are preferred.
 - PRs are then reviewed by the team and the community and then merged into master as appropriate. This means that this feature/fix will be included in the next release.
@@ -49,14 +50,9 @@ Update the changelog
 ^^^^^^^^^^^^^^^^^^^^
 
 This task has two parts:
-1. Make sure that ``CHANGELOG.md`` has an entry for each pull request (PR)
-since the last release (PRs). These entries should contain a short description
-of the PR, as well as the author username and PR number in the form
-(@username, gh-xxx).
-2. The release author should add a "Summary" section with a couple sentences
-describing the latest release, and then update the title of the release
-section to include the release date and remove the "In Development"
-designation.
+
+#. Make sure that ``CHANGELOG.md`` has an entry for each pull request (PR) since the last release (PRs). These entries should contain a short description of the PR, as well as the author username and PR number in the form (@username, gh-xxx).
+#. The release author should add a "Summary" section with a couple sentences describing the latest release, and then update the title of the release section to include the release date and remove the "In Development" designation.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Bump version in VERSION.txt


### PR DESCRIPTION
## Description

Fixes incorrect `rst` formatting. As it stands is not displaying the lists correctly (https://mitiq.readthedocs.io/en/stable/release.html).


| list type | current display | this PR |
| --- | --- | --- |
| unordered | <img width="897" alt="Screen Shot 2022-05-31 at 9 08 49 PM" src="https://user-images.githubusercontent.com/12703123/171325740-1891fe3d-04dd-4440-a0fb-78c8d0210806.png"> | <img width="761" alt="Screen Shot 2022-05-31 at 9 14 24 PM" src="https://user-images.githubusercontent.com/12703123/171326280-4ee605cb-609e-4098-9cf7-a8e628528d5c.png"> |
| ordered | <img width="918" alt="Screen Shot 2022-05-31 at 9 08 55 PM" src="https://user-images.githubusercontent.com/12703123/171325742-fe53f155-ddda-4e8e-9546-895ecd406cea.png"> | <img width="770" alt="Screen Shot 2022-05-31 at 9 14 32 PM" src="https://user-images.githubusercontent.com/12703123/171326313-a07ed29b-1814-4384-8bee-d7682009a4c5.png"> |


