### PR TITLE
Improving the H2 example

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,3 +41,4 @@ Carrie-Anne Rubidge
 Zhaoyi
 Nick Gardner
 Amir Ebrahimi
+Utkarsh Azad

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -21,6 +21,8 @@ pydata-sphinx-theme~=0.8.1
 jupytext==1.11.1
 sphinx-gallery
 nbsphinx
+openfermion
+openfermionpyscf
 
 # The following seems to be necessary for sphinx to run.
 jinja2~=3.0.3

--- a/docs/source/examples/molecular_hydrogen.myst
+++ b/docs/source/examples/molecular_hydrogen.myst
@@ -38,6 +38,10 @@ import numpy as np
 from scipy.optimize import brute
 import cirq
 
+import pennylane as qml
+from pennylane.grouping import pauli_word_to_string
+
+import mitiq
 from mitiq import zne  # Zero-noise extrapolation module
 from mitiq.interface.mitiq_cirq import compute_density_matrix
 ```
@@ -58,31 +62,42 @@ where $g_i$ are numerical values that depend on the bond length $R$. The above H
 1. Uses the Bravyi-Kitaev transform, and
 1. Reduces resources (qubit number) by symmetry considerations (see {cite}`OMalley_2016_PRX` for more details).
 
-Each coefficient $g_i$ is a function of the bond length $g_i = g_i(R)$.
-Their values are specified in the table below, extracted from Table 1 of Appendix C of {cite}`OMalley_2016_PRX`, in which the first column corresponds to the bond length $R$.
+Each coefficient $g_i$ is a function of the bond length $g_i = g_i(R)$. We obtain the `H` for $\rm H_2$ at any given bond length $R$
+by first building the full molecular Hamiltonian using [`PennyLane`](https://pennylane.readthedocs.io/) and then
+tapering it using the symmetries mentioned in the Appendix A of {cite}`OMalley_2016_PRX` to reduce it to a two qubit Hamiltonian, 
+where the qubits `0` and `2` corresponds to the labels `0` and `1` in the Hamiltonian `H` given above.
 
 ```{code-cell} ipython3
-# Data is organized as follow
-#   |   R   |   g0   |   g1   |   g2   |    g3  |   g4   |   g5   |
-table = np.array([
-    [ 0.2   ,  2.8489,  0.5678, -1.4508,  0.6799,  0.0791,  0.0791],
-    [ 0.4   ,  1.1182,  0.4754, -0.9145,  0.6438,  0.0825,  0.0825],
-    [ 0.6   ,  0.4808,  0.3937, -0.595 ,  0.6025,  0.087 ,  0.087 ],
-    [ 0.8   ,  0.1626,  0.3288, -0.3915,  0.5616,  0.0925,  0.0925],
-    [ 1.0   , -0.0172,  0.2779, -0.255 ,  0.5235,  0.0986,  0.0986],
-    [ 1.2   , -0.1253,  0.2374, -0.1603,  0.4892,  0.105 ,  0.105 ],
-    [ 1.4   , -0.1927,  0.2048, -0.0929,  0.4588,  0.1116,  0.1116],
-    [ 1.6   , -0.2355,  0.1782, -0.0442,  0.4323,  0.1181,  0.1181],
-    [ 1.8   , -0.2632,  0.1565, -0.0088,  0.4094,  0.1241,  0.1241],
-    [ 2.0   , -0.2812,  0.139 ,  0.0171,  0.3898,  0.1297,  0.1297],
-    [ 2.2   , -0.2934,  0.1251,  0.0359,  0.373 ,  0.1347,  0.1347],
-    [ 2.4   , -0.3018,  0.1142,  0.0495,  0.3586,  0.1392,  0.1392],
-    [ 2.6   , -0.3079,  0.1059,  0.0594,  0.3461,  0.1432,  0.1432],
-])
 
-# Grab the radius R and the g_j coefficients
-radii = table[:, 0]
-coeffs = table[:, 1:]
+ang_to_bohr = 1.8897259886 # pennylane specifies coordinates in terms of Bohr radius
+def molecular_hamiltonian(bond_length: float) -> mitiq.Observable:
+    """ Builds the Hamiltonian for H2 at a given bond length """
+    symbols = ['H', 'H']
+    geometry = ang_to_bohr * np.array([[0., 0., - 0.5 * bond_length], 
+                                       [0., 0., 0.5 * bond_length]])
+    mol = qml.qchem.Molecule(symbols, geometry)
+    Hamil, qubits = qml.qchem.molecular_hamiltonian(symbols, geometry, basis="sto-6g", 
+                                                    method="pyscf", mapping="bravyi_kitaev")
+
+    # tapering the Hamiltonian using symmetries
+    generators = [qml.PauliZ(1), qml.PauliZ(3)] # symmetries corresponding to qubit 1 and 3 
+    paulix_ops = [qml.PauliX(1), qml.PauliX(3)] # corresponding paulix ops for tapering 
+    eigval_sec = [1, 1] # optimal sector containing the ground state
+    Hamil_tapered = qml.taper(Hamil, generators, paulix_ops, eigval_sec)
+
+    # converting the tapered Hamiltonian to mitiq Observable
+    coeffs, ops = Hamil_tapered.terms()
+    wire_map = {0 : 0, 2 : 1} # for relabeling the qubits in the Pauli representation
+    pauli_str = [mitiq.PauliString(
+                pauli_word_to_string(op, wire_map=wire_map), coeff=coeff.numpy())
+                 for coeff, op in zip(coeffs, ops)]
+    hamil_obs = mitiq.Observable(*pauli_str)
+
+    return hamil_obs
+
+radii = np.linspace(0.2, 2.6, 13)
+hamiltonians = [molecular_hamiltonian(rad) for rad in radii]
+print(f"Hamiltonian at R = {radii[0]} Angstroms is:\n {hamiltonians[0]}")
 ```
 
 We define a function that evaluates the expectation value of the Hamiltonian on a noisy backend and for a given input circuit (ansatz).
@@ -93,21 +108,11 @@ def energy(
     ansatz: cirq.Circuit, radius_index: int, depo_noise_strength: float = 0.05
 ) -> float:
     """Computes the energy at a given bond length (radius)."""
-    npI = np.identity(2)
-    npX = np.array([[0.0, 1.0], [1.0, 0.0]])
-    npY = np.array([[0.0, -1j], [1j, 0.0]])
-    npZ = np.array([[1.0, 0.0], [0.0, -1.0]])
-    terms = [
-        coeffs[radius_index][0] * np.kron(npI, npI),
-        coeffs[radius_index][1] * np.kron(npZ, npI),
-        coeffs[radius_index][2] * np.kron(npI, npZ),
-        coeffs[radius_index][3] * np.kron(npZ, npZ),
-        coeffs[radius_index][4] * np.kron(npX, npX),
-        coeffs[radius_index][5] * np.kron(npY, npY),
-    ]
-    hamiltonian = sum(terms)
-    rho = compute_density_matrix(ansatz, cirq.depolarize, (depo_noise_strength,))
-    return np.trace(rho @ hamiltonian).real
+    hamiltonian = hamiltonians[radius_index]
+    executor = mitiq.Executor(compute_density_matrix)
+    kwargs = {"noise_model":cirq.depolarize, "noise_level":(depo_noise_strength,)}
+    expec_val = executor.evaluate(ansatz, hamiltonian, **kwargs)[0]
+    return expec_val.real
 ```
 
 ## Evaluating the energy landscape for a fixed $R$
@@ -169,7 +174,8 @@ num_to_average = 1
 
 # To reproduce the results of the Mitiq paper use the following settings
 # scaling_function = zne.scaling.fold_gates_at_random
-# pfac = zne.inference.PolyFactory(order=3, scale_factors=[1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5, 5., 5.5, 6.])
+# pfac = zne.inference.PolyFactory(order=3, 
+#                           scale_factors=[1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5, 5., 5.5, 6.])
 # num_to_average = 5
 # pvals = (0.00, 0.02, 0.04, 0.06)
 # thetas = np.linspace(0.0, 2.0 * np.pi, 20)
@@ -275,7 +281,7 @@ for pval in pvals:
     for i in range(len(radii)):
         # Objective function to minimize
         def obj(theta):
-            return energy(ansatz(theta), radius_index=i, depo_noise_strength=pval)
+            return energy(ansatz(theta[0]), radius_index=i, depo_noise_strength=pval)
 
         res = brute(obj, ranges=[(0, 2 * np.pi)], Ns=10, finish=None, full_output=True)
         these_thetas.append(res[0])
@@ -304,7 +310,7 @@ for pval in pvals[1:]:
 
         def objective_function(theta):
             return zne.execute_with_zne(
-                ansatz(theta),
+                ansatz(theta[0]),
                 partial(energy, radius_index=i, depo_noise_strength=pval),
                 factory=fac,
                 scale_noise=scaling_function,


### PR DESCRIPTION
Description
-----------

1. Removed the hardcoded Hamiltonian. Replaced it with a `molecular_hamiltonian` method that uses `PennyLane` for generating the required two-qubit Hamiltonian by tapering the full Hamiltonian using symmetries given in the O'Malley's PRX paper. 
2. The above method return the Hamiltonian as a `metriq.Observable` object. Additionally, I have updated the energy wrapper function to use the `mitiq_cirq.compute_density_matrix` for the executor. This keeps the overall code necessary the same, with just a few tweaks to make it work with `scipy.optimize.brute`. 

Checklist
---------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [ ] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

License
-------

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
Fixes #1094 