### PR TITLE
Prevent idle qubits with qiskit barriers from being lost after conversions

### DIFF
--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -240,9 +240,14 @@ def noise_scaling_converter(
             from mitiq.interface.mitiq_qiskit.conversions import (
                 _add_identity_to_idle,
             )
+            from qiskit.transpiler.passes import RemoveBarriers
 
             # Avoid mutating the input circuit
             circuit = deepcopy(circuit)
+            # Removing barriers is necessary to correctly identify idle qubits
+            circuit = RemoveBarriers()(circuit)
+            # Apply identity gates to idle qubits otherwise they get lost
+            # when converting to Cirq. Eventually, identities will be removed.
             idle_indices = _add_identity_to_idle(circuit)
 
         scaled_circuit = atomic_converter(noise_scaling_function)(

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -16,6 +16,7 @@
 """Functions for converting to/from Mitiq's internal circuit representation."""
 from functools import wraps
 from typing import Any, Callable, cast, Iterable, Tuple
+from copy import deepcopy
 
 from cirq import Circuit
 
@@ -232,6 +233,7 @@ def noise_scaling_converter(
     def new_scaling_function(
         circuit: QPROGRAM, *args: Any, **kwargs: Any
     ) -> QPROGRAM:
+
         # Pre atomic conversion
         idle_indices = set()
         if "qiskit" in circuit.__module__:
@@ -239,6 +241,8 @@ def noise_scaling_converter(
                 _add_identity_to_idle,
             )
 
+            # Avoid mutating the input circuit
+            circuit = deepcopy(circuit)
             idle_indices = _add_identity_to_idle(circuit)
 
         scaled_circuit = atomic_converter(noise_scaling_function)(

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -16,7 +16,6 @@
 """Functions for converting to/from Mitiq's internal circuit representation."""
 from functools import wraps
 from typing import Any, Callable, cast, Iterable, Tuple
-from copy import deepcopy
 
 from cirq import Circuit
 
@@ -243,7 +242,7 @@ def noise_scaling_converter(
             from qiskit.transpiler.passes import RemoveBarriers
 
             # Avoid mutating the input circuit
-            circuit = deepcopy(circuit)
+            circuit = circuit.copy()
             # Removing barriers is necessary to correctly identify idle qubits
             circuit = RemoveBarriers()(circuit)
             # Apply identity gates to idle qubits otherwise they get lost

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -129,6 +129,9 @@ def _add_identity_to_idle(
 
     Returns:
         An unordered set of the indices that were altered
+
+    Note: An idle qubit is a qubit without any gates (including Qiskit
+        barriers) acting on it. 
     """
 
     data = copy.deepcopy(circuit._data)
@@ -136,8 +139,6 @@ def _add_identity_to_idle(
     idle_bit_indices = set()
     for op in data:
         gate, qubits, cbits = op
-        if gate.name == "barrier":  # Skip barriers
-            continue
         bit_indices.update(set(bit.index for bit in qubits))
     for index in range(circuit.num_qubits):
         if index not in bit_indices:

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -131,7 +131,7 @@ def _add_identity_to_idle(
         An unordered set of the indices that were altered
 
     Note: An idle qubit is a qubit without any gates (including Qiskit
-        barriers) acting on it. 
+        barriers) acting on it.
     """
 
     data = copy.deepcopy(circuit._data)

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -130,11 +130,14 @@ def _add_identity_to_idle(
     Returns:
         An unordered set of the indices that were altered
     """
+
     data = copy.deepcopy(circuit._data)
     bit_indices = set()
     idle_bit_indices = set()
     for op in data:
         gate, qubits, cbits = op
+        if gate.name == "barrier":  # Skip barriers
+            continue
         bit_indices.update(set(bit.index for bit in qubits))
     for index in range(circuit.num_qubits):
         if index not in bit_indices:

--- a/mitiq/tests/test_conversions.py
+++ b/mitiq/tests/test_conversions.py
@@ -203,9 +203,13 @@ def test_noise_scaling_converter_with_qiskit_idle_qubits_and_barriers():
     test_circuit_qiskit.x(0)
     test_circuit_qiskit.x(2)
     test_circuit_qiskit.barrier(0, 1, 2)
+    test_copy = test_circuit_qiskit.copy()
+
     scaled = scaling_function(test_circuit_qiskit)
-    # Mitiq expected to remove qiskit barriers
+    # Mitiq is expected to remove qiskit barriers
     expected = qiskit.QuantumCircuit(4)
     expected.x(0)
     expected.x(2)
     assert scaled == expected
+    # Mitiq should not mutate the input circuit
+    test_circuit_qiskit == test_copy

--- a/mitiq/tests/test_conversions.py
+++ b/mitiq/tests/test_conversions.py
@@ -176,3 +176,36 @@ def test_atomic_one_to_many_converter(to_type):
     circuits = returns_several_circuits(circuit, return_mitiq=True)
     for circuit in circuits:
         assert isinstance(circuit, cirq.Circuit)
+
+
+def test_noise_scaling_converter_with_qiskit_idle_qubits_and_barriers():
+    """Idle qubits must be preserved even if the input has barriers.
+    Test input:
+         ┌───┐ ░
+    q_0: ┤ X ├─░─
+         └───┘ ░
+    q_1: ──────░─
+         ┌───┐ ░
+    q_2: ┤ X ├─░─
+         └───┘ ░
+    q_3: ────────
+    Expected output:
+         ┌───┐
+    q_0: ┤ X ├
+         └───┘
+    q_1: ─────
+         ┌───┐
+    q_2: ┤ X ├
+         └───┘
+    q_3: ─────
+    """
+    test_circuit_qiskit = qiskit.QuantumCircuit(4)
+    test_circuit_qiskit.x(0)
+    test_circuit_qiskit.x(2)
+    test_circuit_qiskit.barrier(0, 1, 2)
+    scaled = scaling_function(test_circuit_qiskit)
+    # Mitiq expected to remove qiskit barriers
+    expected = qiskit.QuantumCircuit(4)
+    expected.x(0)
+    expected.x(2)
+    assert scaled == expected

--- a/mitiq/tests/test_conversions.py
+++ b/mitiq/tests/test_conversions.py
@@ -212,4 +212,4 @@ def test_noise_scaling_converter_with_qiskit_idle_qubits_and_barriers():
     expected.x(2)
     assert scaled == expected
     # Mitiq should not mutate the input circuit
-    test_circuit_qiskit == test_copy
+    assert test_circuit_qiskit == test_copy


### PR DESCRIPTION
Description
-----------

Fixes #1368 

Qiskit circuits with idle qubits and qiskit barriers have unexpected results when modified by folding functions.
This is related to a bug in the Mitiq `noise_scaling_converter` decorator.

The following code snippet:
```python
test_circuit_qiskit = QuantumCircuit(4)
test_circuit_qiskit.x(0)
test_circuit_qiskit.x(2)
test_circuit_qiskit.barrier(0,1,2)
test_folded = zne.scaling.fold_gates_at_random(test_circuit_qiskit, 1.0)
print(f"Input circuit:\n{test_circuit_qiskit}")
print(f"Folded circuit:\n{test_folded}")
```
before fixing the bug gives the unexpected result:
```
Input circuit:
     ┌───┐ ░ 
q_0: ┤ X ├─░─
     └───┘ ░ 
q_1: ──────░─
     ┌───┐ ░ 
q_2: ┤ X ├─░─
     ├───┤ ░ 
q_3: ┤ I ├───
     └───┘   
Folded circuit:
     ┌───┐
q_0: ┤ X ├
     ├───┤
q_1: ┤ X ├
     ├───┤
q_2: ┤ I ├
     └───┘
q_3: ─────
```
after fixing this bug, the correct expected result is recovered:

```
Input circuit:
     ┌───┐ ░ 
q_0: ┤ X ├─░─
     └───┘ ░ 
q_1: ──────░─
     ┌───┐ ░ 
q_2: ┤ X ├─░─
     └───┘ ░ 
q_3: ────────
             
Folded circuit:
     ┌───┐
q_0: ┤ X ├
     └───┘
q_1: ─────
     ┌───┐
q_2: ┤ X ├
     └───┘
q_3: ─────
```

License
-------

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
