### PR TITLE
Updates tests and docstrings for cirq utils

### DIFF
--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -30,7 +30,7 @@ def sample_bitstrings(
     shots: int = 8192,
 ) -> MeasurementResult:
     """Adds noise to the input circuit. The noise is added based on a particular
-    noise model and some value for the error rate. 
+    noise model and some value for the error rate.
 
     Args:
         circuit: The input Cirq circuit.

--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -59,7 +59,8 @@ def compute_density_matrix(
     noise_model: cirq.NOISE_MODEL_LIKE = cirq.amplitude_damp,  # type: ignore
     noise_level: Tuple[float] = (0.01,),
 ) -> np.ndarray:
-    """Finds the density matrix of a noisy version of the input circuit.
+    """Returns the density matrix of the quantum state after the
+    (noisy) execution of the input circuit.
 
     Args:
         circuit: The input Cirq circuit.

--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -29,6 +29,19 @@ def sample_bitstrings(
     sampler: cirq.Sampler = cirq.DensityMatrixSimulator(),
     shots: int = 8192,
 ) -> MeasurementResult:
+    """Adds noise to the input circuit. The noise is added based on a particular
+    noise model and some value for the error rate. 
+
+    Args:
+        circuit: The input Cirq circuit.
+        noise_model: Input Cirq noise model. Default is amplitude damping.
+        noise_level: Noise rate as a tuple of floats
+        sampler: Cirq simulator from which the result will be sampled from
+        shots: Number of measurements
+
+    Returns:
+        Sampled outcome from a measurement.
+    """
     if sum(noise_level) > 0:
         circuit = circuit.with_noise(noise_model(*noise_level))  # type: ignore
 
@@ -46,6 +59,16 @@ def compute_density_matrix(
     noise_model: cirq.NOISE_MODEL_LIKE = cirq.amplitude_damp,  # type: ignore
     noise_level: Tuple[float] = (0.01,),
 ) -> np.ndarray:
+    """Finds the density matrix of a noisy version of the input circuit.
+
+    Args:
+        circuit: The input Cirq circuit.
+        noise_model: Input Cirq noise model. Default is amplitude damping.
+        noise_level: Noise rate as a tuple of floats
+
+    Returns:
+        NumPy array for the final density matrix.
+    """
     if sum(noise_level) > 0:
         circuit = circuit.with_noise(noise_model(*noise_level))  # type: ignore
 

--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -29,8 +29,8 @@ def sample_bitstrings(
     sampler: cirq.Sampler = cirq.DensityMatrixSimulator(),
     shots: int = 8192,
 ) -> MeasurementResult:
-    """Adds noise to the input circuit. The noise is added based on a particular
-    noise model and some value for the error rate.
+    """Adds noise to the input circuit. The noise is added based on a
+    particular noise model and some value for the error rate.
 
     Args:
         circuit: The input Cirq circuit.

--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -68,7 +68,7 @@ def compute_density_matrix(
         noise_level: Noise rate as a tuple of floats.
 
     Returns:
-        NumPy array for the final density matrix.
+        The final density matrix as a NumPy array.
     """
     if sum(noise_level) > 0:
         circuit = circuit.with_noise(noise_model(*noise_level))  # type: ignore

--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -35,9 +35,9 @@ def sample_bitstrings(
     Args:
         circuit: The input Cirq circuit.
         noise_model: Input Cirq noise model. Default is amplitude damping.
-        noise_level: Noise rate as a tuple of floats
-        sampler: Cirq simulator from which the result will be sampled from
-        shots: Number of measurements
+        noise_level: Noise rate as a tuple of floats.
+        sampler: Cirq simulator from which the result will be sampled from.
+        shots: Number of measurements.
 
     Returns:
         Sampled outcome from a measurement.

--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -65,7 +65,7 @@ def compute_density_matrix(
     Args:
         circuit: The input Cirq circuit.
         noise_model: Input Cirq noise model. Default is amplitude damping.
-        noise_level: Noise rate as a tuple of floats
+        noise_level: Noise rate as a tuple of floats.
 
     Returns:
         NumPy array for the final density matrix.

--- a/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
@@ -26,10 +26,11 @@ from mitiq.rem.measurement_result import MeasurementResult
 
 
 def test_sample_bitstrings():
-    """Tests if the outcome is as expected with different noise models and error rate."""
+    """Tests if the outcome is as expected with different noise models and
+    error rate."""
 
-    # testing default options i.e. noise model is amplitude damping with the default error rate
-    # shots is also the default number
+    # testing default options i.e. noise model is amplitude damping with
+    # the default error rate, shots is also the default number
     qc = cirq.Circuit(cirq.X(cirq.LineQubit(0))) + cirq.Circuit(
         cirq.measure(cirq.LineQubit(0))
     )

--- a/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
@@ -17,15 +17,22 @@
 import numpy as np
 import cirq
 
-from mitiq.interface.mitiq_cirq import sample_bitstrings, compute_density_matrix, execute_with_depolarizing_noise
+from mitiq.interface.mitiq_cirq import (
+    sample_bitstrings,
+    compute_density_matrix,
+    execute_with_depolarizing_noise,
+)
 from mitiq.rem.measurement_result import MeasurementResult
+
 
 def test_sample_bitstrings():
     """Tests if the outcome is as expected with different noise models and error rate."""
 
     # testing default options i.e. noise model is amplitude damping with the default error rate
     # shots is also the default number
-    qc = cirq.Circuit(cirq.X(cirq.LineQubit(0))) + cirq.Circuit(cirq.measure(cirq.LineQubit(0)))
+    qc = cirq.Circuit(cirq.X(cirq.LineQubit(0))) + cirq.Circuit(
+        cirq.measure(cirq.LineQubit(0))
+    )
     result_default = sample_bitstrings(qc)
     assert result_default.nqubits == 1
     assert result_default.qubit_indices == (0,)
@@ -33,11 +40,20 @@ def test_sample_bitstrings():
     assert isinstance(result_default, MeasurementResult)
 
     # test for sum(noise_level) = 0
-    result_no_noise = sample_bitstrings(qc, noise_level = (0.00,), shots = 10)
-    assert np.allclose(result_no_noise.asarray, np.array([[1], [1], [1], [1], [1], [1], [1], [1], [1], [1]]))
+    result_no_noise = sample_bitstrings(qc, noise_level=(0.00,), shots=10)
+    assert np.allclose(
+        result_no_noise.asarray,
+        np.array([[1], [1], [1], [1], [1], [1], [1], [1], [1], [1]]),
+    )
 
     # test result with inputs different from default
-    result_not_default = sample_bitstrings(qc, cirq.GeneralizedAmplitudeDampingChannel, (0.1, 0.1),cirq.DensityMatrixSimulator(), 8000)
+    result_not_default = sample_bitstrings(
+        qc,
+        cirq.GeneralizedAmplitudeDampingChannel,
+        (0.1, 0.1),
+        cirq.DensityMatrixSimulator(),
+        8000,
+    )
     assert result_not_default.nqubits == 1
     assert result_not_default.qubit_indices == (0,)
     assert result_not_default.shots == 8000
@@ -48,8 +64,14 @@ def test_compute_density_matrix():
 
     qc = cirq.Circuit(cirq.X(cirq.LineQubit(0)))
     assert np.isclose(np.trace(compute_density_matrix(qc)), 1)
-    assert np.isclose(np.trace(compute_density_matrix(qc, cirq.GeneralizedAmplitudeDampingChannel, (0.1, 0.1))), 1)
-
+    assert np.isclose(
+        np.trace(
+            compute_density_matrix(
+                qc, cirq.GeneralizedAmplitudeDampingChannel, (0.1, 0.1)
+            )
+        ),
+        1,
+    )
 
 
 def test_execute_with_depolarizing_noise():

--- a/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
@@ -17,7 +17,39 @@
 import numpy as np
 import cirq
 
-from mitiq.interface.mitiq_cirq import execute_with_depolarizing_noise
+from mitiq.interface.mitiq_cirq import sample_bitstrings, compute_density_matrix, execute_with_depolarizing_noise
+from mitiq.rem.measurement_result import MeasurementResult
+
+def test_sample_bitstrings():
+    """Tests if the outcome is as expected with different noise models and error rate."""
+
+    # testing default options i.e. noise model is amplitude damping with the default error rate
+    # shots is also the default number
+    qc = cirq.Circuit(cirq.X(cirq.LineQubit(0))) + cirq.Circuit(cirq.measure(cirq.LineQubit(0)))
+    result_default = sample_bitstrings(qc)
+    assert result_default.nqubits == 1
+    assert result_default.qubit_indices == (0,)
+    assert result_default.shots == 8192
+    assert isinstance(result_default, MeasurementResult)
+
+    # test for sum(noise_level) = 0
+    result_no_noise = sample_bitstrings(qc, noise_level = (0.00,), shots = 10)
+    assert np.allclose(result_no_noise.asarray, np.array([[1], [1], [1], [1], [1], [1], [1], [1], [1], [1]]))
+
+    # test result with inputs different from default
+    result_not_default = sample_bitstrings(qc, cirq.GeneralizedAmplitudeDampingChannel, (0.1, 0.1),cirq.DensityMatrixSimulator(), 8000)
+    assert result_not_default.nqubits == 1
+    assert result_not_default.qubit_indices == (0,)
+    assert result_not_default.shots == 8000
+
+
+def test_compute_density_matrix():
+    """Tests if the density matrix of a noisy circuit is output as expected."""
+
+    qc = cirq.Circuit(cirq.X(cirq.LineQubit(0)))
+    assert np.isclose(np.trace(compute_density_matrix(qc)), 1)
+    assert np.isclose(np.trace(compute_density_matrix(qc, cirq.GeneralizedAmplitudeDampingChannel, (0.1, 0.1))), 1)
+
 
 
 def test_execute_with_depolarizing_noise():


### PR DESCRIPTION
Description
-----------
Fixes #1124 

Checklist
---------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

License
-------

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.


Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).

- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
