### PR TITLE
add myself to authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ dependabot[bot]
 Purva Thakre
 Will Zeng
 Misty-W
+Nate Stemen
 Peter Karalekas
 allcontributors[bot]
 max gordon


### PR DESCRIPTION
Somehow never got around to this.

I'm not entirely sure if I also need to add myself to something related to the allcontributors bot, but there are no docs so it's hard to tell.