### PR TITLE
remove comma from `.all-contributorsrc`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -330,7 +330,7 @@
         "test",
         "code"
       ]
-    },
+    }
   ],
   "contributorsPerLine": 7,
   "projectName": "mitiq",


### PR DESCRIPTION
the bot looks to have made a mistake in the previous commit https://github.com/unitaryfund/mitiq/commit/bc0248253f45f59189a8ba000236dea20d951095

fixes https://github.com/unitaryfund/mitiq/issues/1380