### PR TITLE
Write user guide section for learning-based PEC

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 # Third-party integration.
-qiskit~=0.39.1
+qiskit~=0.39.2
 pyquil~=3.3.2
 pennylane-qiskit~=0.24.0
 pennylane~=0.26.0

--- a/docs/source/guide/observables.myst
+++ b/docs/source/guide/observables.myst
@@ -11,6 +11,7 @@ kernelspec:
   name: python3
 ---
 
+(guide/observables/observables)=
 # Observables
 
 +++

--- a/docs/source/guide/pec-3-options.myst
+++ b/docs/source/guide/pec-3-options.myst
@@ -432,136 +432,222 @@ The learning-based PEC workflow was inspired by the procedure described in *Stri
 #### Learning quasiprobability representations with a depolarizing noise model
 
 In cases where the noise of the backend can be approximated by a depolarizing noise model,
-`pec.representations.learning.learn_depolarizing_noise_parameter` can be used to learn the noise strength `\epsilon` associated to a set of
-input operations. 
+{func}`.pec.representations.learning.learn_depolarizing_noise_parameter` can be used to learn the noise strength `epsilon` associated to a set
+of input operations. 
 
 
-The learning process is based on the execution of a set of training circuits on a noisy backend (via a noisy executor) 
-and on a classical simulator (via an ideal executor). 
+The learning process is based on the execution of a set of training circuits on a noisy backend via a noisy
+{ref}`executor <guide/executors/executors>` 
+and on a classical simulator via an ideal {ref}`executor <guide/executors/executors>`. 
 The training circuits are near-Clifford approximations of the input circuit. 
 During training, the noise strength parameter is used to calculate quasiprobability representations of the ideal gate with
 a depolarizing noise model.
-The representations are then input into {func}`.pec.execute_w_pec()` to obtain an error-mitigated expecation value from execution of the training
+The representations are then input into {func}`.pec.execute_w_pec` to obtain an error-mitigated expecation value from execution of the training
 circuit, for comparison with the ideal expecation value obtained from classical simulation of the training circuit.
-The optimizer used in the learning function is from `scipy.optimze.minimize`.
+The optimizer used in the learning function is from {py:func}`scipy.optimize.minimize`.
 The default optimization method in the learning function is `Nelder-Mead`, as that appears to work best for this particular problem setup.
 
 
 In addition to specifying the input operation, the circuit of interest, and the ideal and noisy executors, the user should specify the number
 of training circuits, the fraction of non-Clifford gates in the training circuits, and an initial guess for noise strength. 
 The user can also set options for the intermediate executions of {func}`.pec.execute_w_pec()` during the training process as a dictionary in
-`pec_kwargs`, specify the observable of which the expecation value is to be computed, and enter a dictionary of additional data and options including
-optimization method (supported by {py:func}`scipy.optimize.minimize`) and settings for the chosen optimization method.
+`pec_kwargs`, specify the observable{ref}`observable <guide/observables/observables>` of which the expecation value is to be computed, and
+enter a dictionary of additional data and options including optimization method (supported by {py:func}`scipy.optimize.minimize`) and settings
+for the chosen optimization method.
 
 ```{code-cell} ipython3
 ---
 mystnb:
   skip-execution: true
 ---
-representations = represent_operation_with_local_depolarizing_noise(operation, epsilon_opt)
+from qiskit.providers.aer.noise import NoiseModel
+from qiskit.providers.aer.noise.errors.standard_errors import (
+    depolarizing_error,
+)
+from mitiq import Observable, PauliString
+from mitiq.pec.representations.learning import (
+    learn_depolarizing_noise_parameter,
+)
 
+circuit = qiskit.QuantumCircuit(2)
+circuit.rx(1.14 * np.pi, 0)
+circuit.rz(0, 0)
+circuit.cx(1, 0)
+circuit.rx(1.71 * np.pi, 0)
+circuit.rx(1.14 * np.pi, 1)
+
+observable = Observable(PauliString("XZ"), PauliString("YY")).matrix()
+
+# set up ideal simulator
+def ideal_execute(circuit):
+    """Simulate (training) circuits without noise"""
+    circuit_copy = circuit.copy()
+    noise_model = initialized_depolarizing_noise(0.0)
+    return execute_with_noise(circuit_copy, observable, noise_model)
+
+
+epsilon = 0.05  # noise level for simulation in noisy executor
+
+
+def noisy_execute(circuit):
+    """Simulate circuit with a depolarizing noise model"""
+    circuit_copy = circuit.copy()
+    noise_model = NoiseModel()
+    noise_model.add_all_qubit_quantum_error(depolarizing_error(epsilon, 2), ["cx"])
+    return execute_with_noise(circuit_copy, observable, noise_model)
+
+
+operations_to_learn = qiskit.QuantumCircuit(2)
+operations_to_learn.cx(1, 0)
+
+import timeit
+
+[success, epsilon_opt] = learn_depolarizing_noise_parameter(
+    operations_to_learn=[operations_to_learn],  # learn rep of Hadamard
+    circuit=circuit,
+    ideal_executor=Executor(ideal_execute),
+    noisy_executor=Executor(noisy_execute),
+    pec_kwargs={"num_samples": 500},
+    num_training_circuits=5,
+    fraction_non_clifford=0.2,
+    
+    epsilon0=0.9 * epsilon,  # initial guess for epsilon
+)
+end = timeit.default_timer()
+print(end - start)
+print(success)
+print(epsilon_opt)
 ```
-
 
 ```{note}
 Using this function may require some tuning.
-One of the main challenges is setting a good value of ``num_samples`` in the PEC options ``pec_kwargs``.
-Setting a small value of ``num_samples`` is typically necessary to obtain a reasonable execution time.
+One of the main challenges is setting a good value of `num_samples` in the PEC options `pec_kwargs`.
+Setting a small value of `num_samples` is typically necessary to obtain a reasonable execution time.
 On the other hand, using a number of PEC samples that is too small can result in a large statistical error, ultimately causing the optimization
 process to fail.
 ```
 
 
-Upon completing the optimization loop, `learn_depolarizing_noise_parameter` returns a flag indicating whether or not the optimizer exited
-successfully, in addition to the optimized noise strength, which can then be input into 
-`represent_operation_with_local_depolarizing_noise` to calculate quasiprobability representations of the ideal gate in terms of noisy gates.
+Upon completing the optimization loop, {func}`.representations.learning.learn_depolarizing_noise_parameter` returns a flag indicating
+whether the optimizer exited successfully, in addition to the optimized noise strength, which can then be input into 
+{func}`.representations.depolarizing.represent_operation_with_local_depolarizing_noise` to calculate quasiprobability representations of the
+ideal gate in terms of noisy gates.
 
 ```{code-cell} ipython3
 ---
 mystnb:
   skip-execution: true
 ---
-representations = represent_operation_with_local_depolarizing_noise(operation, epsilon_opt)
+representations = represent_operation_with_local_depolarizing_noise(
+    operations_to_learn, epsilon_opt
+)
 ```
-
 
 #### Learning quasiprobability representations with a biased noise model
 
 In cases where the noise of the backend can be approximated by a combined depolarizing and dephasing noise model with a bias factor, also
 referred to as a biased noise model, `pec.representations.learning.learn_biased_noise_parameters` can be used to learn the noise strength
-`\epsilon` and noise bias `\eta`  associated to a set of input operations. 
+`epsilon` and noise bias `eta`  associated to a set of input operations. 
 
 
 The single-qubit biased noise channel is given by:
 
-```math
+$$
 \mathcal{D}(\epsilon) = (1 - \epsilon)[\mathbb{1}] 
 + \epsilon(\frac{\eta}{\eta + 1} \mathcal{Z}
 + \frac{1}{3}\frac{1}{\eta + 1}(\mathcal{X} + \mathcal{Y}
 + \mathcal{Z}))
- ``` 
+$$ 
 
 
 For multi-qubit operations, the noise channel used is the tensor product of the local single-qubit channels.
 
 
-The learning process is based on the execution of a set of training circuits on a noisy backend (via a noisy executor) 
-and on a classical simulator (via an ideal executor). 
+The learning process is based on the execution of a set of training circuits on a noisy backend via a noisy
+{ref}`executor <guide/executors/executors>` and on a classical simulator via an ideal {ref}`executor <guide/executors/executors>`. 
 The training circuits are near-Clifford approximations of the input circuit. 
 During training, the noise strength and noise bias parameters are used to calculate quasiprobability representations of the ideal gate with
 a biased noise model.
-The representations are then input into {func}`.pec.execute_w_pec()` to obtain an error-mitigated expecation value from execution of the training
+The representations are then input into {func}`.pec.execute_w_pec` to obtain an error-mitigated expecation value from execution of the training
 circuit, for comparison with the ideal expecation value obtained from classical simulation of the training circuit.
-The optimizer used in the learning function is from `scipy.optimze.minimize`.
+The optimizer used in the learning function is from {py:func}`scipy.optimize.minimize`.
 The default optimization method in the learning function is `Nelder-Mead`, as that appears to work best for this particular problem setup.
 
 
-In addition to specifying the input operation, the circuit of interest, and the ideal and noisy executors, the user should specify the number
-of training circuits, the fraction of non-Clifford gates in the training circuits, and initial guesses for noise strength and noise bias. 
-The user can also set options for the intermediate executions of ``execute_w_pec`` during the training process as a dictionary in
-`pec_kwargs`, specify the observable of which the expecation value is to be computed, and enter a dictionary of additional data and options including
-optimization method (supported by``scipy.optimize.minimize``) and settings for the chosen optimization method.
-
+In addition to specifying the input operation, the circuit of interest, and the ideal and noisy executors,
+the user should specify the number of training circuits, the fraction of non-Clifford gates in the training circuits, and initial guesses for
+noise strength and noise bias. 
+The user can also set options for the intermediate executions of {func}`.pec.execute_w_pec during the training process as a dictionary in
+`pec_kwargs`, specify the observable{ref}`observable <guide/observables/observables>` of which the expecation value is to be computed, and
+enter a dictionary of additional data and options including optimization method (supported by {py:func}`scipy.optimize.minimize`) and settings
+for the chosen optimization method.
 
 ```{code-cell} ipython3
 ---
 mystnb:
   skip-execution: true
 ---
-[success, epsilon_opt, eta_opt] = learn_biased_noise_parameters(
-    operation,
-    circuit,
-    ideal_executor,
-    noisy_executor,
-    pec_kwargs,
-    num_training_circuits,
-    fraction_non_clifford,
-    epsilon0=epsilon0,
-    observable=observable,
+from mitiq.pec.representations.learning import (
+    learn_biased_noise_parameters,
 )
-```
 
+epsilon = 0.05
+eta = 0
+
+# simulate biased noise occurs on the CNOT gates
+def noisy_execute(circuit):
+    circuit_copy = circuit.copy()
+    noise_model = NoiseModel()
+    noise_model.add_all_qubit_quantum_error(depolarizing_error(epsilon, 2), ["cx"])
+    return execute_with_noise(circuit_copy, observable, noise_model)
+
+
+operations_to_learn = qiskit.QuantumCircuit(2)
+operations_to_learn.cx(1, 0)
+
+start = timeit.default_timer()
+[success, epsilon_opt, eta_opt] = learn_biased_noise_parameters(
+    operations_to_learn=[operations_to_learn],  # learn rep of CNOT
+    circuit=circuit,
+    ideal_executor=Executor(ideal_execute),
+    noisy_executor=Executor(noisy_execute),
+    pec_kwargs={"num_samples": 500, "random_state": 1},
+    num_training_circuits=5,
+    fraction_non_clifford=0.2,
+    training_random_state=np.random.RandomState(1),
+    epsilon0=1.01 * 0.05,  # initial guess for noise strength
+    eta0= eta + 0.01,  # initial guess for noise bias
+)
+end = timeit.default_timer()
+print(end - start)
+print(success)
+print(epsilon_opt)
+print(eta_opt)
+```
 
 ```{note}
 Using this function may require some tuning.
-One of the main challenges is setting a good value of ``num_samples`` in the PEC options ``pec_kwargs``.
-Setting a small value of ``num_samples`` is typically necessary to obtain a reasonable execution time.
+One of the main challenges is setting a good value of `num_samples` in the PEC options `pec_kwargs`.
+Setting a small value of `num_samples` is typically necessary to obtain a reasonable execution time.
 On the other hand, using a number of PEC samples that is too small can result in a large statistical error, ultimately causing the optimization
 process to fail.
 ```
 
 
-Upon completing the optimization loop, `learn_biased_noise_parameters` returns a flag indicating whether or not the optimizer exited
-successfully, in addition to the optimized noise strength and noise bias, which can then be input into 
-`represent_operation_with_local_biased_noise` to calculate quasiprobability representations of the ideal gate in terms of noisy gates.
-
+Upon completing the optimization loop, {func}`.representations.learning.learn_biased_noise_parameters` returns a flag indicating whether the
+optimizer exited successfully, in addition to the optimized noise strength and noise bias, which can then be input into 
+{func}`.represent_operation_with_local_biased_noise` to calculate quasiprobability representations of the ideal gate in terms of noisy gates.
 
 ```{code-cell} ipython3
 ---
 mystnb:
   skip-execution: true
 ---
+from pec.representations import (
+    represent_operation_with_local_biased_noise,
+)
+
 representations = represent_operation_with_local_biased_noise(
-    operation, epsilon_opt, eta_opt
-    )
+    operations_to_learn, epsilon_opt, eta_opt
+)
 ```

--- a/docs/source/guide/pec-3-options.myst
+++ b/docs/source/guide/pec-3-options.myst
@@ -458,17 +458,8 @@ optimization method (supported by {py:func}`scipy.optimize.minimize`) and settin
 mystnb:
   skip-execution: true
 ---
-[success, epsilon_opt] = learn_depolarizing_noise_parameter(
-    operation,
-    circuit,
-    ideal_executor,
-    noisy_executor,
-    pec_kwargs,
-    num_training_circuits,
-    fraction_non_clifford,
-    epsilon0=epsilon0,
-    observable=observable,
-)
+representations = represent_operation_with_local_depolarizing_noise(operation, epsilon_opt)
+
 ```
 
 

--- a/docs/source/guide/pec-3-options.myst
+++ b/docs/source/guide/pec-3-options.myst
@@ -417,7 +417,7 @@ a simpler but computationally more expensive approach is to perform multiple PEC
 value and compute the standard deviation of the results.
 
 
-### Applying learning-based PEC
+## Applying learning-based PEC
 
 +++
 
@@ -429,7 +429,7 @@ The learning-based PEC workflow was inspired by the procedure described in *Stri
 
 +++
 
-#### Learning quasiprobability representations with a depolarizing noise model
+### Learning quasiprobability representations with a depolarizing noise model
 
 In cases where the noise of the backend can be approximated by a depolarizing noise model,
 {func}`.pec.representations.learning.learn_depolarizing_noise_parameter` can be used to learn the noise strength `epsilon` associated to a set
@@ -532,7 +532,7 @@ representations = represent_operation_with_local_depolarizing_noise(
 )
 ```
 
-#### Learning quasiprobability representations with a biased noise model
+### Learning quasiprobability representations with a biased noise model
 
 In cases where the noise of the backend can be approximated by a combined depolarizing and dephasing noise model with a bias factor, also
 referred to as a biased noise model, `pec.representations.learning.learn_biased_noise_parameters` can be used to learn the noise strength

--- a/docs/source/guide/pec-3-options.myst
+++ b/docs/source/guide/pec-3-options.myst
@@ -4,7 +4,7 @@ jupytext:
     extension: .myst
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.11.1
+    jupytext_version: 1.14.1
 kernelspec:
   display_name: Python 3
   language: python
@@ -420,6 +420,7 @@ value and compute the standard deviation of the results.
 ### Applying learning-based PEC
 
 +++
+
 Mitiq also contains functions for the learning quasiprobability representations of an ideal gate from Clifford circuit simulations,
 with biased noise or depolarizing noise models.
 The resulting quasiprobability representations can be used to obtain an error-mitigated expectation value in the `representations` argument of
@@ -430,6 +431,146 @@ The learning-based PEC workflow was inspired by the procedure described in *Stri
 
 #### Learning quasiprobability representations with a depolarizing noise model
 
+In cases where the noise of the backend can be approximated by a depolarizing noise model,
+`pec.representations.learning.learn_depolarizing_noise_parameter` can be used to learn the noise strength `\epsilon` associated to a set of
+input operations. 
+
+
+The learning process is based on the execution of a set of training circuits on a noisy backend (via a noisy executor) 
+and on a classical simulator (via an ideal executor). 
+The training circuits are near-Clifford approximations of the input circuit. 
+During training, the noise strength parameter is used to calculate quasiprobability representations of the ideal gate with
+a depolarizing noise model.
+The representations are then input into {func}`.pec.execute_w_pec()` to obtain an error-mitigated expecation value from execution of the training
+circuit, for comparison with the ideal expecation value obtained from classical simulation of the training circuit.
+The optimizer used in the learning function is from `scipy.optimze.minimize`.
+The default optimization method in the learning function is `Nelder-Mead`, as that appears to work best for this particular problem setup.
+
+
+In addition to specifying the input operation, the circuit of interest, and the ideal and noisy executors, the user should specify the number
+of training circuits, the fraction of non-Clifford gates in the training circuits, and an initial guess for noise strength. 
+The user can also set options for the intermediate executions of {func}`.pec.execute_w_pec()` during the training process as a dictionary in
+`pec_kwargs`, specify the observable of which the expecation value is to be computed, and enter a dictionary of additional data and options including
+optimization method (supported by {py:func}`scipy.optimize.minimize`) and settings for the chosen optimization method.
+
+```{code-cell} ipython3
+---
+mystnb:
+  skip-execution: true
+---
+[success, epsilon_opt] = learn_depolarizing_noise_parameter(
+    operation,
+    circuit,
+    ideal_executor,
+    noisy_executor,
+    pec_kwargs,
+    num_training_circuits,
+    fraction_non_clifford,
+    epsilon0=epsilon0,
+    observable=observable,
+)
+```
+
+
+```{note}
+Using this function may require some tuning.
+One of the main challenges is setting a good value of ``num_samples`` in the PEC options ``pec_kwargs``.
+Setting a small value of ``num_samples`` is typically necessary to obtain a reasonable execution time.
+On the other hand, using a number of PEC samples that is too small can result in a large statistical error, ultimately causing the optimization
+process to fail.
+```
+
+
+Upon completing the optimization loop, `learn_depolarizing_noise_parameter` returns a flag indicating whether or not the optimizer exited
+successfully, in addition to the optimized noise strength, which can then be input into 
+`represent_operation_with_local_depolarizing_noise` to calculate quasiprobability representations of the ideal gate in terms of noisy gates.
+
+```{code-cell} ipython3
+---
+mystnb:
+  skip-execution: true
+---
+representations = represent_operation_with_local_depolarizing_noise(operation, epsilon_opt)
+```
 
 
 #### Learning quasiprobability representations with a biased noise model
+
+In cases where the noise of the backend can be approximated by a combined depolarizing and dephasing noise model with a bias factor, also
+referred to as a biased noise model, `pec.representations.learning.learn_biased_noise_parameters` can be used to learn the noise strength
+`\epsilon` and noise bias `\eta`  associated to a set of input operations. 
+
+
+The single-qubit biased noise channel is given by:
+
+```math
+\mathcal{D}(\epsilon) = (1 - \epsilon)[\mathbb{1}] 
++ \epsilon(\frac{\eta}{\eta + 1} \mathcal{Z}
++ \frac{1}{3}\frac{1}{\eta + 1}(\mathcal{X} + \mathcal{Y}
++ \mathcal{Z}))
+ ``` 
+
+
+For multi-qubit operations, the noise channel used is the tensor product of the local single-qubit channels.
+
+
+The learning process is based on the execution of a set of training circuits on a noisy backend (via a noisy executor) 
+and on a classical simulator (via an ideal executor). 
+The training circuits are near-Clifford approximations of the input circuit. 
+During training, the noise strength and noise bias parameters are used to calculate quasiprobability representations of the ideal gate with
+a biased noise model.
+The representations are then input into {func}`.pec.execute_w_pec()` to obtain an error-mitigated expecation value from execution of the training
+circuit, for comparison with the ideal expecation value obtained from classical simulation of the training circuit.
+The optimizer used in the learning function is from `scipy.optimze.minimize`.
+The default optimization method in the learning function is `Nelder-Mead`, as that appears to work best for this particular problem setup.
+
+
+In addition to specifying the input operation, the circuit of interest, and the ideal and noisy executors, the user should specify the number
+of training circuits, the fraction of non-Clifford gates in the training circuits, and initial guesses for noise strength and noise bias. 
+The user can also set options for the intermediate executions of ``execute_w_pec`` during the training process as a dictionary in
+`pec_kwargs`, specify the observable of which the expecation value is to be computed, and enter a dictionary of additional data and options including
+optimization method (supported by``scipy.optimize.minimize``) and settings for the chosen optimization method.
+
+
+```{code-cell} ipython3
+---
+mystnb:
+  skip-execution: true
+---
+[success, epsilon_opt, eta_opt] = learn_biased_noise_parameters(
+    operation,
+    circuit,
+    ideal_executor,
+    noisy_executor,
+    pec_kwargs,
+    num_training_circuits,
+    fraction_non_clifford,
+    epsilon0=epsilon0,
+    observable=observable,
+)
+```
+
+
+```{note}
+Using this function may require some tuning.
+One of the main challenges is setting a good value of ``num_samples`` in the PEC options ``pec_kwargs``.
+Setting a small value of ``num_samples`` is typically necessary to obtain a reasonable execution time.
+On the other hand, using a number of PEC samples that is too small can result in a large statistical error, ultimately causing the optimization
+process to fail.
+```
+
+
+Upon completing the optimization loop, `learn_biased_noise_parameters` returns a flag indicating whether or not the optimizer exited
+successfully, in addition to the optimized noise strength and noise bias, which can then be input into 
+`represent_operation_with_local_biased_noise` to calculate quasiprobability representations of the ideal gate in terms of noisy gates.
+
+
+```{code-cell} ipython3
+---
+mystnb:
+  skip-execution: true
+---
+representations = represent_operation_with_local_biased_noise(
+    operation, epsilon_opt, eta_opt
+    )
+```

--- a/docs/source/guide/pec-3-options.myst
+++ b/docs/source/guide/pec-3-options.myst
@@ -442,24 +442,21 @@ and on a classical simulator via an ideal {ref}`executor <guide/executors/execut
 The training circuits are near-Clifford approximations of the input circuit. 
 During training, the noise strength parameter is used to calculate quasiprobability representations of the ideal gate with
 a depolarizing noise model.
-The representations are then input into {func}`.pec.execute_w_pec` to obtain an error-mitigated expecation value from execution of the training
-circuit, for comparison with the ideal expecation value obtained from classical simulation of the training circuit.
+The representations are then input into {func}`.pec.execute_with_pec` to obtain an error-mitigated expecation value from execution of the
+training circuit, for comparison with the ideal expecation value obtained from classical simulation of the training circuit.
 The optimizer used in the learning function is from {py:func}`scipy.optimize.minimize`.
 The default optimization method in the learning function is `Nelder-Mead`, as that appears to work best for this particular problem setup.
 
 
 In addition to specifying the input operation, the circuit of interest, and the ideal and noisy executors, the user should specify the number
 of training circuits, the fraction of non-Clifford gates in the training circuits, and an initial guess for noise strength. 
-The user can also set options for the intermediate executions of {func}`.pec.execute_w_pec()` during the training process as a dictionary in
-`pec_kwargs`, specify the observable{ref}`observable <guide/observables/observables>` of which the expecation value is to be computed, and
+The user can also set options for the intermediate executions of {func}`.pec.execute_with_pec()` during the training process as a dictionary in
+`pec_kwargs`, specify the {ref}`observable <guide/observables/observables>` of which the expecation value is to be computed, and
 enter a dictionary of additional data and options including optimization method (supported by {py:func}`scipy.optimize.minimize`) and settings
 for the chosen optimization method.
 
 ```{code-cell} ipython3
----
-mystnb:
-  skip-execution: true
----
+:tags: ["skip-execution": true]
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors.standard_errors import (
     depolarizing_error,
@@ -500,7 +497,6 @@ def noisy_execute(circuit):
 operations_to_learn = qiskit.QuantumCircuit(2)
 operations_to_learn.cx(1, 0)
 
-import timeit
 
 [success, epsilon_opt] = learn_depolarizing_noise_parameter(
     operations_to_learn=[operations_to_learn],  # learn rep of Hadamard
@@ -513,10 +509,6 @@ import timeit
     
     epsilon0=0.9 * epsilon,  # initial guess for epsilon
 )
-end = timeit.default_timer()
-print(end - start)
-print(success)
-print(epsilon_opt)
 ```
 
 ```{note}
@@ -534,10 +526,7 @@ whether the optimizer exited successfully, in addition to the optimized noise st
 ideal gate in terms of noisy gates.
 
 ```{code-cell} ipython3
----
-mystnb:
-  skip-execution: true
----
+:tags: ["skip-execution": true]
 representations = represent_operation_with_local_depolarizing_noise(
     operations_to_learn, epsilon_opt
 )
@@ -568,8 +557,8 @@ The learning process is based on the execution of a set of training circuits on 
 The training circuits are near-Clifford approximations of the input circuit. 
 During training, the noise strength and noise bias parameters are used to calculate quasiprobability representations of the ideal gate with
 a biased noise model.
-The representations are then input into {func}`.pec.execute_w_pec` to obtain an error-mitigated expecation value from execution of the training
-circuit, for comparison with the ideal expecation value obtained from classical simulation of the training circuit.
+The representations are then input into {func}`.pec.execute_with_pec` to obtain an error-mitigated expecation value from execution of the
+training circuit, for comparison with the ideal expecation value obtained from classical simulation of the training circuit.
 The optimizer used in the learning function is from {py:func}`scipy.optimize.minimize`.
 The default optimization method in the learning function is `Nelder-Mead`, as that appears to work best for this particular problem setup.
 
@@ -577,16 +566,13 @@ The default optimization method in the learning function is `Nelder-Mead`, as th
 In addition to specifying the input operation, the circuit of interest, and the ideal and noisy executors,
 the user should specify the number of training circuits, the fraction of non-Clifford gates in the training circuits, and initial guesses for
 noise strength and noise bias. 
-The user can also set options for the intermediate executions of {func}`.pec.execute_w_pec during the training process as a dictionary in
-`pec_kwargs`, specify the observable{ref}`observable <guide/observables/observables>` of which the expecation value is to be computed, and
+The user can also set options for the intermediate executions of {func}`.pec.execute_with_pec` during the training process as a dictionary in
+`pec_kwargs`, specify {ref}`observable <guide/observables/observables>` of which the expecation value is to be computed, and
 enter a dictionary of additional data and options including optimization method (supported by {py:func}`scipy.optimize.minimize`) and settings
 for the chosen optimization method.
 
 ```{code-cell} ipython3
----
-mystnb:
-  skip-execution: true
----
+:tags: ["skip-execution": true]
 from mitiq.pec.representations.learning import (
     learn_biased_noise_parameters,
 )
@@ -605,7 +591,6 @@ def noisy_execute(circuit):
 operations_to_learn = qiskit.QuantumCircuit(2)
 operations_to_learn.cx(1, 0)
 
-start = timeit.default_timer()
 [success, epsilon_opt, eta_opt] = learn_biased_noise_parameters(
     operations_to_learn=[operations_to_learn],  # learn rep of CNOT
     circuit=circuit,
@@ -618,11 +603,6 @@ start = timeit.default_timer()
     epsilon0=1.01 * 0.05,  # initial guess for noise strength
     eta0= eta + 0.01,  # initial guess for noise bias
 )
-end = timeit.default_timer()
-print(end - start)
-print(success)
-print(epsilon_opt)
-print(eta_opt)
 ```
 
 ```{note}
@@ -639,10 +619,7 @@ optimizer exited successfully, in addition to the optimized noise strength and n
 {func}`.represent_operation_with_local_biased_noise` to calculate quasiprobability representations of the ideal gate in terms of noisy gates.
 
 ```{code-cell} ipython3
----
-mystnb:
-  skip-execution: true
----
+:tags: ["skip-execution": true]
 from pec.representations import (
     represent_operation_with_local_biased_noise,
 )

--- a/docs/source/guide/pec-3-options.myst
+++ b/docs/source/guide/pec-3-options.myst
@@ -415,3 +415,21 @@ uncertainty of the PEC result. For example, given the raw samples contained in  
 one can apply a [bootstrapping](https://en.wikipedia.org/wiki/Bootstrapping_(statistics)) approach. Alternatively, 
 a simpler but computationally more expensive approach is to perform multiple PEC estimations of the same expectation
 value and compute the standard deviation of the results.
+
+
+### Applying learning-based PEC
+
++++
+Mitiq also contains functions for the learning quasiprobability representations of an ideal gate from Clifford circuit simulations,
+with biased noise or depolarizing noise models.
+The resulting quasiprobability representations can be used to obtain an error-mitigated expectation value in the `representations` argument of
+{func}`.pec.execute_with_pec`.
+The learning-based PEC workflow was inspired by the procedure described in *Strikis et al. PRX Quantum (2021)* {cite}`Strikis_2021_PRXQuantum`.
+
++++
+
+#### Learning quasiprobability representations with a depolarizing noise model
+
+
+
+#### Learning quasiprobability representations with a biased noise model

--- a/docs/source/guide/pec-3-options.myst
+++ b/docs/source/guide/pec-3-options.myst
@@ -421,9 +421,9 @@ value and compute the standard deviation of the results.
 
 +++
 
-Mitiq also contains functions for the learning quasiprobability representations of an ideal gate from Clifford circuit simulations,
+Mitiq also contains functions for learning the quasiprobability representations of an ideal gate from Clifford circuit simulations,
 with biased noise or depolarizing noise models.
-The resulting quasiprobability representations can be used to obtain an error-mitigated expectation value in the `representations` argument of
+The resulting quasiprobability representations can be used to obtain an error-mitigated expectation value via the `representations` argument of
 {func}`.pec.execute_with_pec`.
 The learning-based PEC workflow was inspired by the procedure described in *Strikis et al. PRX Quantum (2021)* {cite}`Strikis_2021_PRXQuantum`.
 

--- a/docs/source/guide/pec-3-options.myst
+++ b/docs/source/guide/pec-3-options.myst
@@ -429,13 +429,6 @@ The learning-based PEC workflow was inspired by the procedure described in *Stri
 
 +++
 
-### Learning quasiprobability representations with a depolarizing noise model
-
-In cases where the noise of the backend can be approximated by a depolarizing noise model,
-{func}`.pec.representations.learning.learn_depolarizing_noise_parameter` can be used to learn the noise strength `epsilon` associated to a set
-of input operations. 
-
-
 The learning process is based on the execution of a set of training circuits on a noisy backend via a noisy
 {ref}`executor <guide/executors/executors>` 
 and on a classical simulator via an ideal {ref}`executor <guide/executors/executors>`. 
@@ -449,14 +442,31 @@ The default optimization method in the learning function is `Nelder-Mead`, as th
 
 
 In addition to specifying the input operation, the circuit of interest, and the ideal and noisy executors, the user should specify the number
-of training circuits, the fraction of non-Clifford gates in the training circuits, and an initial guess for noise strength. 
+of training circuits, the fraction of non-Clifford gates in the training circuits, an initial guess for noise strength, and in the case of
+biased noise, an initial guess for a noise bias. 
 The user can also set options for the intermediate executions of {func}`.pec.execute_with_pec()` during the training process as a dictionary in
 `pec_kwargs`, specify the {ref}`observable <guide/observables/observables>` of which the expecation value is to be computed, and
 enter a dictionary of additional data and options including optimization method (supported by {py:func}`scipy.optimize.minimize`) and settings
 for the chosen optimization method.
 
+
+```{note}
+Using `learn_depolarizing_noise_parameter` and `learn_biased_noise_parameters` may require some tuning.
+One of the main challenges is setting a good value of `num_samples` in the PEC options `pec_kwargs`.
+Setting a small value of `num_samples` is typically necessary to obtain a reasonable execution time.
+On the other hand, using a number of PEC samples that is too small can result in a large statistical error, ultimately causing the optimization
+process to fail.
+```
+
+### Learning quasiprobability representations with a depolarizing noise model
+
+In cases where the noise of the backend can be approximated by a depolarizing noise model,
+{func}`.pec.representations.learning.learn_depolarizing_noise_parameter` can be used to learn the noise strength `epsilon` associated to a set
+of input operations.
+
 ```{code-cell} ipython3
 :tags: ["skip-execution"]
+
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors.standard_errors import (
     depolarizing_error,
@@ -511,15 +521,6 @@ operations_to_learn.cx(1, 0)
 )
 ```
 
-```{note}
-Using this function may require some tuning.
-One of the main challenges is setting a good value of `num_samples` in the PEC options `pec_kwargs`.
-Setting a small value of `num_samples` is typically necessary to obtain a reasonable execution time.
-On the other hand, using a number of PEC samples that is too small can result in a large statistical error, ultimately causing the optimization
-process to fail.
-```
-
-
 Upon completing the optimization loop, {func}`.representations.learning.learn_depolarizing_noise_parameter` returns a flag indicating
 whether the optimizer exited successfully, in addition to the optimized noise strength, which can then be input into 
 {func}`.representations.depolarizing.represent_operation_with_local_depolarizing_noise` to calculate quasiprobability representations of the
@@ -527,6 +528,7 @@ ideal gate in terms of noisy gates.
 
 ```{code-cell} ipython3
 :tags: ["skip-execution"]
+
 representations = represent_operation_with_local_depolarizing_noise(
     operations_to_learn, epsilon_opt
 )
@@ -551,28 +553,9 @@ $$
 
 For multi-qubit operations, the noise channel used is the tensor product of the local single-qubit channels.
 
-
-The learning process is based on the execution of a set of training circuits on a noisy backend via a noisy
-{ref}`executor <guide/executors/executors>` and on a classical simulator via an ideal {ref}`executor <guide/executors/executors>`. 
-The training circuits are near-Clifford approximations of the input circuit. 
-During training, the noise strength and noise bias parameters are used to calculate quasiprobability representations of the ideal gate with
-a biased noise model.
-The representations are then input into {func}`.pec.execute_with_pec` to obtain an error-mitigated expecation value from execution of the
-training circuit, for comparison with the ideal expecation value obtained from classical simulation of the training circuit.
-The optimizer used in the learning function is from {py:func}`scipy.optimize.minimize`.
-The default optimization method in the learning function is `Nelder-Mead`, as that appears to work best for this particular problem setup.
-
-
-In addition to specifying the input operation, the circuit of interest, and the ideal and noisy executors,
-the user should specify the number of training circuits, the fraction of non-Clifford gates in the training circuits, and initial guesses for
-noise strength and noise bias. 
-The user can also set options for the intermediate executions of {func}`.pec.execute_with_pec` during the training process as a dictionary in
-`pec_kwargs`, specify {ref}`observable <guide/observables/observables>` of which the expecation value is to be computed, and
-enter a dictionary of additional data and options including optimization method (supported by {py:func}`scipy.optimize.minimize`) and settings
-for the chosen optimization method.
-
 ```{code-cell} ipython3
 :tags: ["skip-execution"]
+
 from mitiq.pec.representations.learning import (
     learn_biased_noise_parameters,
 )
@@ -605,21 +588,13 @@ operations_to_learn.cx(1, 0)
 )
 ```
 
-```{note}
-Using this function may require some tuning.
-One of the main challenges is setting a good value of `num_samples` in the PEC options `pec_kwargs`.
-Setting a small value of `num_samples` is typically necessary to obtain a reasonable execution time.
-On the other hand, using a number of PEC samples that is too small can result in a large statistical error, ultimately causing the optimization
-process to fail.
-```
-
-
 Upon completing the optimization loop, {func}`.representations.learning.learn_biased_noise_parameters` returns a flag indicating whether the
 optimizer exited successfully, in addition to the optimized noise strength and noise bias, which can then be input into 
 {func}`.represent_operation_with_local_biased_noise` to calculate quasiprobability representations of the ideal gate in terms of noisy gates.
 
 ```{code-cell} ipython3
 :tags: ["skip-execution"]
+
 from pec.representations import (
     represent_operation_with_local_biased_noise,
 )

--- a/docs/source/guide/pec-3-options.myst
+++ b/docs/source/guide/pec-3-options.myst
@@ -456,7 +456,7 @@ enter a dictionary of additional data and options including optimization method 
 for the chosen optimization method.
 
 ```{code-cell} ipython3
-:tags: ["skip-execution": true]
+:tags: ["skip-execution"]
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors.standard_errors import (
     depolarizing_error,
@@ -526,7 +526,7 @@ whether the optimizer exited successfully, in addition to the optimized noise st
 ideal gate in terms of noisy gates.
 
 ```{code-cell} ipython3
-:tags: ["skip-execution": true]
+:tags: ["skip-execution"]
 representations = represent_operation_with_local_depolarizing_noise(
     operations_to_learn, epsilon_opt
 )
@@ -572,7 +572,7 @@ enter a dictionary of additional data and options including optimization method 
 for the chosen optimization method.
 
 ```{code-cell} ipython3
-:tags: ["skip-execution": true]
+:tags: ["skip-execution"]
 from mitiq.pec.representations.learning import (
     learn_biased_noise_parameters,
 )
@@ -619,7 +619,7 @@ optimizer exited successfully, in addition to the optimized noise strength and n
 {func}`.represent_operation_with_local_biased_noise` to calculate quasiprobability representations of the ideal gate in terms of noisy gates.
 
 ```{code-cell} ipython3
-:tags: ["skip-execution": true]
+:tags: ["skip-execution"]
 from pec.representations import (
     represent_operation_with_local_biased_noise,
 )


### PR DESCRIPTION
Description
-----------
Add learning-based PEC sub-section to `pec-3-options.myst`.

Fixes #1365 .


Checklist
---------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [X] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [X] Added myself / the copyright holder to the AUTHORS file

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

License
-------

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.


Tips
----

- If the validation check fails:

    1. Run `make check-types` (from the root directory of the repository) and fix any [mypy](https://mypy.readthedocs.io/en/stable/) errors.

    2. Run `make check-style` and fix any [flake8](http://flake8.pycqa.org) errors.

    3. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html) autoformatter.

  For more information, check the [Mitiq style guidelines](https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).

- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.
