### PR TITLE
Add executor with a backend argument in mitiq_qiskit utils

### DIFF
--- a/mitiq/interface/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/qiskit_utils.py
@@ -263,7 +263,7 @@ def compute_expectation_value_on_noisy_backend(
     shots: int = 10000,
     measure_all: bool = False,
     qubit_indices: Optional[Tuple[int]] = None,
-) -> MeasurementResult:
+) -> complex:
     """Returns the noisy expectation value of the input Mitiq observable
     obtained from executing the input circuit on a Qiskit backend.
 
@@ -292,4 +292,4 @@ def compute_expectation_value_on_noisy_backend(
     )
     executor = Executor(execute)
 
-    return executor.evaluate(circuit, obs)
+    return executor.evaluate(circuit, obs)[0]

--- a/mitiq/interface/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/qiskit_utils.py
@@ -200,21 +200,22 @@ def sample_bitstrings(
     """Returns measurement bitstrings obtained from executing the input circuit on
     a Qiskit backend (passed as an argument).
     Note that the input circuit must contain measurement gates
-    (unless `measure_all` is `True`).
+    (unless ``measure_all`` is ``True``).
 
     Args:
         circuit: The input Qiskit circuit.
         backend: A real or fake Qiskit backend. The input circuit
             should be transpiled into a compatible gate set.
-            It may be necessary to set optimization_level=0 when transpiling.
-        noise_model: A valid Qiskit `NoiseModel` object. This option is used
-            if and only if `backend` is `None`. In this case a default density
-            matrix simulator is used with `optimization_level=0`.
+            It may be necessary to set ``optimization_level=0`` when
+            transpiling.
+        noise_model: A valid Qiskit ``NoiseModel`` object. This option is used
+            if and only if ``backend`` is ``None``. In this case a default
+            density matrix simulator is used with ``optimization_level=0``.
         shots: The number of measurements.
         qubit_indices: Optional qubit indices associated to bitstrings.
 
     Returns:
-        The measured bitstrings casted as a Mitiq {class}`.MeasurementResult`
+        The measured bitstrings casted as a Mitiq :class:`.MeasurementResult`
         object.
     """
     circuit_to_execute = circuit.copy()

--- a/mitiq/interface/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/qiskit_utils.py
@@ -198,8 +198,8 @@ def sample_bitstrings(
     measure_all: bool = False,
     qubit_indices: Optional[Tuple[int]] = None,
 ) -> MeasurementResult:
-    """Returns measurement bitstrings obtained from executing the input circuit on
-    a Qiskit backend (passed as an argument).
+    """Returns measurement bitstrings obtained from executing the input circuit
+    on a Qiskit backend (passed as an argument).
     Note that the input circuit must contain measurement gates
     (unless ``measure_all`` is ``True``).
 

--- a/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
@@ -253,7 +253,7 @@ def test_compute_expectation_value_on_noisy_backend_with_noise_model():
         qiskit_circuit,
         obs,
         noise_model=initialized_depolarizing_noise(0),
-    )[0]
+    )
 
     assert isinstance(noiseless_expval, complex)
     assert np.isclose(np.imag(noiseless_expval), 0.0)
@@ -264,7 +264,7 @@ def test_compute_expectation_value_on_noisy_backend_with_noise_model():
         qiskit_circuit,
         obs,
         noise_model=initialized_depolarizing_noise(0.01),
-    )[0]
+    )
 
     assert isinstance(expval, complex)
     assert np.isclose(np.imag(expval), 0.0)
@@ -282,7 +282,7 @@ def test_compute_expectation_value_on_noisy_backend_with_qiskit_backend():
         qiskit_circuit,
         obs,
         backend=FakeLima(),
-    )[0]
+    )
 
     assert isinstance(expval, complex)
     assert np.isclose(np.imag(expval), 0.0)
@@ -304,12 +304,12 @@ def test_compute_expectation_value_on_noisy_backend_with_measurements():
         qiskit_circuit,
         obs,
         noise_model=initialized_depolarizing_noise(0.01),
-    )[0]
+    )
     assert 0.9 < np.real(expval) < 1.0
 
     expval = compute_expectation_value_on_noisy_backend(
         qiskit_circuit,
         obs,
         backend=FakeLima(),
-    )[0]
+    )
     assert 0.9 < np.real(expval) < 1.0

--- a/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
@@ -200,6 +200,11 @@ def test_sample_bitstrings():
     assert measurement_result.result == [[0], [0], [0], [0], [0]]
     assert measurement_result.qubit_indices == (0,)
 
+
+def test_sample_bitstrings_with_measure_all():
+    """Tests that the function sample_bitstrings returns a valid
+    mitiq.MeasurementResult when "measure_all" is True.
+    """
     two_qubit_circ = QuantumCircuit(2)
     two_qubit_circ.cx(0, 1)
     measurement_result = sample_bitstrings(


### PR DESCRIPTION
Description
-----------

Adds a `sample_bitstrings` executor function in mitiq_qiskit. This function has a backend argument which makes it easier to run circuits on real devices or mock simulated devices in Qiskit.

Fixes #1163 

Fixes #1360 (stale unitary hack PR).  


License
-------

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
