### PR TITLE
Support for Qiskit 0.37

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 # Third-party integration.
-qiskit~=0.36.2
+qiskit~=0.37.1
 pyquil~=3.0.0
 pennylane-qiskit~=0.24.0
 pennylane~=0.24.0

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -255,13 +255,10 @@ def _transform_registers(
     circuit.add_register(*new_qregs)
 
     # Map the qubits in operations to the new qubits.
-    new_ops = []
     for op in data:
         gate, qubits, cbits = op
         new_qubits = _map_qubits(qubits, qreg_sizes, new_qregs)
-        new_ops.append((gate, new_qubits, cbits))
-
-    circuit._data = new_ops
+        circuit.append(gate, new_qubits, cbits)
 
 
 def to_qasm(circuit: cirq.Circuit) -> QASMType:


### PR DESCRIPTION
Description
-----------

The function `mitiq.interface.mitiq_qiskit.conversions._transform_registers` touches
a lot of Qiskit internals. This makes the code very flimsy when Qiskit updates.
This change allows for Qiskit 0.37.

Make circuit transformation as transpilation passes would be probably better. But that's for another time.

Checklist
---------

Check off the following once complete (or if not applicable) after opening the PR. The PR will be reviewed once this checklist is complete and all tests are passing.

- [X] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

License
-------

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

This PR is on top of https://github.com/unitaryfund/mitiq/pull/1414
