### PR TITLE
Unmitigated version of learning-based PEC

### DIFF
--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -150,16 +150,7 @@ class Executor:
                 for circuit_with_measurements in observable.measure_in(circuit)
             ]
             result_step = observable.ngroups
-        elif (
-            observable is not None
-            and self._executor_return_type not in MeasurementResultLike
-            and self._executor_return_type not in DensityMatrixLike
-        ):
-            raise ValueError(
-                """Executor and observable are not compatible. Executors
-                returning expectation values as float must be used with
-                observable=None"""
-            )
+
         else:
             all_circuits = circuits
             result_step = 1

--- a/mitiq/executor/tests/test_executor.py
+++ b/mitiq/executor/tests/test_executor.py
@@ -205,34 +205,6 @@ def test_executor_evaluate_float(execute):
     assert executor.quantum_results == [1, 2]
 
 
-@pytest.mark.parametrize(
-    "execute",
-    [
-        executor_batched,
-        executor_batched_unique,
-        executor_serial_unique,
-        executor_serial_typed,
-        executor_serial,
-        executor_pyquil_batched,
-    ],
-)
-@pytest.mark.parametrize(
-    "obs",
-    [
-        PauliString("X"),
-        PauliString("XZ"),
-        PauliString("Z"),
-    ],
-)
-def test_executor_observable_compatibility_check(execute, obs):
-    q = cirq.LineQubit(0)
-    circuits = [cirq.Circuit(cirq.X(q)), cirq.Circuit(cirq.H(q), cirq.Z(q))]
-
-    executor = Executor(execute)
-
-    with pytest.raises(ValueError, match="are not compatible"):
-        executor.evaluate(circuits, obs)
-
 
 @pytest.mark.parametrize(
     "execute", [executor_measurements, executor_measurements_batched]

--- a/mitiq/pec/representations/__init__.py
+++ b/mitiq/pec/representations/__init__.py
@@ -39,5 +39,6 @@ from mitiq.pec.representations.biased_noise import (
 
 from mitiq.pec.representations.learning import (
     biased_noise_loss_function,
+    _unmitigated_loss_function,
     learn_noise_parameters_from_unmitigated_data,
 )

--- a/mitiq/pec/representations/__init__.py
+++ b/mitiq/pec/representations/__init__.py
@@ -38,5 +38,6 @@ from mitiq.pec.representations.biased_noise import (
 )
 
 from mitiq.pec.representations.learning import (
-    _biased_noise_loss_function,
+    biased_noise_loss_function,
+    learn_noise_parameters_from_unmitigated_data,
 )

--- a/mitiq/pec/representations/learning.py
+++ b/mitiq/pec/representations/learning.py
@@ -17,14 +17,28 @@ learning-based technique."""
 
 from typing import Optional, Dict, Any, List
 import numpy as np
+from scipy.optimize import minimize
+from cirq import (
+    MixedUnitaryChannel,
+    I,
+    X,
+    Y,
+    Z,
+    Circuit,
+    ops,
+    unitary,
+)
 from mitiq import QPROGRAM, Executor, Observable
+from mitiq.interface import convert_to_mitiq
+from mitiq.interface.mitiq_cirq import compute_density_matrix
+from mitiq.cdr import generate_training_circuits
 from mitiq.pec import execute_with_pec
 from mitiq.pec.representations.biased_noise import (
     represent_operation_with_local_biased_noise,
 )
 
 
-def _biased_noise_loss_function(
+def biased_noise_loss_function(
     params: np.ndarray,
     operations_to_mitigate: List[QPROGRAM],
     training_circuits: List[QPROGRAM],
@@ -84,3 +98,72 @@ def _biased_noise_loss_function(
     return np.sum((mitigated_values - ideal_values) ** 2) / len(
         training_circuits
     )
+
+
+def unmitigated_loss_function(
+    epsilon_guess, noisy_executor, training_circuits, observable=None
+):
+    def noise_model_execute(circ: Circuit) -> np.ndarray:
+        circuit = convert_to_mitiq(circ)[0]
+        noisy_circ = circuit.with_noise(
+            biased_noise_channel(epsilon=epsilon_guess[0], eta=0)
+        )
+        return compute_density_matrix(noisy_circ, noise_level=(0.0,))
+
+    noise_model_executor = Executor(noise_model_execute)
+    noise_model_values = np.array(
+        [
+            noise_model_executor.evaluate(training_circuit, observable)
+            for training_circuit in training_circuits
+        ]
+    )
+
+    noisy_values = np.array(
+        [
+            noisy_executor.evaluate(training_circuit, observable)
+            for training_circuit in training_circuits
+        ]
+    )
+
+    return np.sum(
+        abs(noise_model_values.reshape(-1, 1) - noisy_values.reshape(-1, 1))
+        ** 2
+    ) / len(training_circuits)
+
+
+def biased_noise_channel(epsilon: float, eta: float) -> MixedUnitaryChannel:
+    a = 1 - epsilon
+    b = epsilon * (3 * eta + 1) / (3 * (eta + 1))
+    c = epsilon / (3 * (eta + 1))
+
+    mix = [
+        (a, unitary(I)),
+        (b, unitary(Z)),
+        (c, unitary(X)),
+        (c, unitary(Y)),
+    ]
+    return ops.MixedUnitaryChannel(mix)
+
+
+def learn_noise_parameters_from_unmitigated_data(
+    circuit,
+    epsilon0,
+    noisy_executor,
+    num_training_circuits,
+    fraction_non_clifford,
+    training_random_state=None,
+    observable=None,
+):
+    training_circuits = generate_training_circuits(
+        circuit,
+        num_training_circuits=num_training_circuits,
+        fraction_non_clifford=fraction_non_clifford,
+        random_state=training_random_state,
+    )
+    result = minimize(
+        fun=unmitigated_loss_function,
+        x0=epsilon0,
+        args=(noisy_executor, training_circuits, observable),
+        method="Nelder-Mead",
+    )
+    return result.success, result.x[0]

--- a/mitiq/pec/representations/tests/test_learning.py
+++ b/mitiq/pec/representations/tests/test_learning.py
@@ -29,11 +29,17 @@ from cirq import (
     ops,
     unitary,
 )
+import qiskit
 from mitiq import Executor, Observable, PauliString
+from mitiq.interface.mitiq_qiskit import qiskit_utils
+from mitiq.interface.mitiq_qiskit.conversions import to_qiskit
 from mitiq.interface.mitiq_cirq import compute_density_matrix
 from mitiq.cdr import generate_training_circuits
 from mitiq.cdr._testing import random_x_z_cnot_circuit
-from mitiq.pec.representations.learning import _biased_noise_loss_function
+from mitiq.pec.representations.learning import (
+    biased_noise_loss_function,
+    learn_noise_parameters_from_unmitigated_data,
+)
 
 circuit = random_x_z_cnot_circuit(
     LineQubit.range(2), n_moments=5, random_state=1
@@ -99,7 +105,7 @@ def test_biased_noise_loss_function(epsilon, eta, operations):
     noisy_values = np.array(
         [noisy_executor.evaluate(t, observable) for t in training_circuits]
     )
-    loss = _biased_noise_loss_function(
+    loss = biased_noise_loss_function(
         params=[epsilon, eta],
         operations_to_mitigate=operations,
         training_circuits=training_circuits,
@@ -125,7 +131,7 @@ def test_biased_noise_loss_compare_ideal(operations):
         return ideal_execute(noisy_circ)
 
     noisy_executor = Executor(noisy_execute)
-    loss = _biased_noise_loss_function(
+    loss = biased_noise_loss_function(
         params=[0, 0],
         operations_to_mitigate=operations,
         training_circuits=training_circuits,
@@ -135,3 +141,64 @@ def test_biased_noise_loss_compare_ideal(operations):
         observable=observable,
     )
     assert np.isclose(loss, 0)
+
+
+offset = 0.01
+
+
+@pytest.mark.parametrize("epsilon", [0, 0.05, 0.1])
+def test_learn_noise_parameters_from_unmitigated_data(epsilon):
+    """Test the learning function with initial noise strength with a small
+    offset from the simulated noise model values"""
+
+    def noisy_execute(circ: Circuit) -> np.ndarray:
+        noisy_circ = circ.with_noise(
+            biased_noise_channel(epsilon=epsilon, eta=0)
+        )
+        return ideal_execute(noisy_circ)
+
+    noisy_executor = Executor(noisy_execute)
+
+    if epsilon == 0:
+        epsilon0 = offset
+    else:
+        epsilon0 = (1 + offset) * epsilon
+
+    [success, epsilon_opt] = learn_noise_parameters_from_unmitigated_data(
+        circuit=circuit,
+        epsilon0=epsilon0,
+        noisy_executor=noisy_executor,
+        num_training_circuits=5,
+        fraction_non_clifford=0.2,
+        training_random_state=np.random.RandomState(1),
+        observable=observable,
+    )
+    assert success
+    assert abs(epsilon_opt - epsilon) < abs(epsilon0 - epsilon)
+
+
+def test_learn_noise_parameters_unmitigated_qiskit():
+    """Test the learning function with initial noise strength
+    with a small offset from the simulated noise model values"""
+    epsilon = 0.05
+
+    def noisy_execute_qiskit(circ: qiskit.QuantumCircuit) -> float:
+        noise_model = qiskit_utils.initialized_depolarizing_noise(epsilon)
+        return qiskit_utils.execute_with_noise(
+            circ, observable.matrix(), noise_model
+        )
+
+    noisy_executor_qiskit = Executor(noisy_execute_qiskit)
+    epsilon0 = (1 + offset) * epsilon
+
+    qiskit_circuit = to_qiskit(circuit)
+    [success, _] = learn_noise_parameters_from_unmitigated_data(
+        circuit=qiskit_circuit,
+        epsilon0=epsilon0,
+        noisy_executor=noisy_executor_qiskit,
+        num_training_circuits=5,
+        fraction_non_clifford=0.2,
+        training_random_state=np.random.RandomState(1),
+        observable=observable,
+    )
+    assert success


### PR DESCRIPTION
Alternate implementation of learning-based PEC: uses noisy (unmitigated) data to learn noise model

<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.

  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.

  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file