### PR TITLE
Restore the titles of the examples in the Mitiq docs

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -19,7 +19,7 @@ sphinx-autodoc-typehints~=1.12.0
 myst-nb~=0.12.3
 pydata-sphinx-theme~=0.8.1
 jupytext==1.11.1
-sphinx-gallery
+sphinx-gallery==0.10.1
 nbsphinx
 openfermion==1.5.1; sys_platform != 'win32'
 openfermionpyscf==0.5; sys_platform != 'win32'

--- a/docs/source/examples/examples.myst
+++ b/docs/source/examples/examples.myst
@@ -14,3 +14,4 @@ Defining a Mitiq executor with a hamiltonian <hamiltonians.md>
 Mitiq paper codeblocks <mitiq-paper/mitiq-paper-codeblocks>
 Estimating the potential energy surface of molecular Hydrogen with ZNE <molecular_hydrogen.myst>
 Estimating the potential energy surface of molecular Hydrogen with ZNE and PennyLane + Cirq <molecular_hydrogen_pennylane.myst>
+```


### PR DESCRIPTION


## Description

Restores the layout problems of the Mitiq gallery of examples.
Fixes #1450 

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
