### PR TITLE
Support python 3.10

### DIFF
--- a/.github/workflows/asv.yaml
+++ b/.github/workflows/asv.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Run benchmarks
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Install ASV
         run: pip install asv

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Install Python dependencies
         run: |
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Install Mitiq
         run: |
           python -m pip install --upgrade pip
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Install Mitiq
         run: |
           python -m pip install --upgrade pip
@@ -104,7 +104,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9]
+        python-version: ['3.8', '3.9', '3.10']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out mitiq
@@ -128,7 +128,7 @@ jobs:
         run: make test-all
       - name: Submit coverage report to Codecov
         # Only submit to Codecov once.
-        if: ${{ matrix.python-version == 3.9 }}
+        if: ${{ matrix.python-version == '3.10' }}
         uses: codecov/codecov-action@v3.1.1
         with:
           fail_ci_if_error: true
@@ -137,7 +137,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: [3.8, 3.9]
+        python-version: ['3.8', '3.9', '3.10']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out mitiq

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -13,6 +13,7 @@ black~=22.8
 mypy~=0.981
 
 # Documentation and examples.
+Sphinx==5.1.1
 sphinxcontrib-bibtex~=2.5.0
 sphinx-copybutton~=0.4.0
 sphinx-autodoc-typehints~=1.12.0
@@ -21,6 +22,7 @@ pydata-sphinx-theme~=0.8.1
 jupytext==1.11.1
 sphinx-gallery==0.10.1
 nbsphinx
+pyscf==2.1.0
 openfermion==1.5.1; sys_platform != 'win32'
 openfermionpyscf==0.5; sys_platform != 'win32'
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -22,7 +22,7 @@ pydata-sphinx-theme~=0.10.1
 jupytext==1.14.1
 sphinx-gallery==0.10.1
 nbsphinx
-pyscf==2.1.1
+pyscf==2.1.1; sys_platform != 'win32'
 openfermion==1.5.1; sys_platform != 'win32'
 openfermionpyscf==0.5; sys_platform != 'win32'
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -17,12 +17,12 @@ Sphinx==5.1.1
 sphinxcontrib-bibtex~=2.5.0
 sphinx-copybutton~=0.4.0
 sphinx-autodoc-typehints~=1.12.0
-myst-nb~=0.12.3
-pydata-sphinx-theme~=0.8.1
-jupytext==1.11.1
+myst-nb~=0.16.0
+pydata-sphinx-theme~=0.10.1
+jupytext==1.14.1
 sphinx-gallery==0.10.1
 nbsphinx
-pyscf==2.1.0
+pyscf==2.1.1
 openfermion==1.5.1; sys_platform != 'win32'
 openfermionpyscf==0.5; sys_platform != 'win32'
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -113,6 +113,8 @@ myst_enable_extensions = [
     "smartquotes",
 ]
 
+myst_heading_anchors = 3
+
 # Tells MyST to treat URIs beginning with these prefixes as external links.
 # Links that don't begin with these will be treated as internal cross-links.
 myst_url_schemes = ("http", "https", "mailto")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,39 +121,13 @@ myst_url_schemes = ("http", "https", "mailto")
 
 # -- Options for myst_nb -----------------------------------------------------
 
-# Needed to explicitly set render priority for the `doctest` mode.
-# https://myst-nb.readthedocs.io/en/latest/use/formatting_outputs.html#render-priority
-nb_render_priority = {
-    "html": (
-        "application/vnd.jupyter.widget-view+json",
-        "application/javascript",
-        "text/html",
-        "image/svg+xml",
-        "image/png",
-        "image/jpeg",
-        "text/markdown",
-        "text/latex",
-        "text/plain",
-    ),
-    "doctest": (
-        "application/vnd.jupyter.widget-view+json",
-        "application/javascript",
-        "text/html",
-        "image/svg+xml",
-        "image/png",
-        "image/jpeg",
-        "text/markdown",
-        "text/latex",
-        "text/plain",
-    ),
-}
 # How long should Sphinx wait while a notebook is being evaluated before
 # quitting.
-execution_timeout = 600
+nb_execution_timeout = 600
 
 # By default, if nothing has changed in the source, a notebook won't be
 # re-run for a subsequent docs build.
-jupyter_execute_notebooks = "cache"
+nb_execution_mode = "cache"
 
 # If SKIP_PYQUIL is True, do not re-run PyQuil notebooks.
 if os.environ.get("SKIP_PYQUIL"):

--- a/docs/source/examples/cirq-ibmq-backends.myst
+++ b/docs/source/examples/cirq-ibmq-backends.myst
@@ -11,8 +11,7 @@ kernelspec:
   name: python3
 ---
 
-(label-cirq-zne-example)=
-# [Error mitigation with Cirq on IBMQ backends](#error-mitigation-cirq-on-ibmq-backends)
+# Error mitigation with Cirq on IBMQ backends
 
 
 This tutorial shows an example of how to mitigate noise on IBMQ backends with the [Cirq frontend](https://quantumai.google/cirq).
@@ -20,11 +19,11 @@ It isn't necessary to use Qiskit frontends (circuits) to run on IBM backends. We
 Mitiq to use supported frontends with supported backends. Below, we show how to run a Cirq circuit on an
 IBMQ backend, broken down in the following steps.
 
-- [Settings](#settings)
-- [Setup: Defining a circuit](#setup-defining-a-circuit)
-- [High-level usage](#high-level-usage)
-- [Options](#options)
-- [Lower-level usage](#lower-level-usage)
+- [](#settings)
+- [](#setup-defining-a-circuit-in-cirq)
+- [](#high-level-usage)
+- [](#options)
+- [](#lower-level-usage)
 
 +++
 

--- a/docs/source/examples/ibmq-backends.myst
+++ b/docs/source/examples/ibmq-backends.myst
@@ -11,18 +11,17 @@ kernelspec:
   name: python3
 ---
 
-(label-zne-example)=
-# [Error mitigation on IBMQ backends with Qiskit](#error-mitigation-on-ibmq-backends)
+# Error mitigation on IBMQ backends with Qiskit
 
 
 This tutorial shows an example of how to mitigate noise on IBMQ
 backends, broken down in the following steps.
 
-- [Settings](#settings)
-- [Setup: Defining a circuit](#setup-defining-a-circuit)
-- [High-level usage](#high-level-usage)
-- [Options](#options)
-- [Lower-level usage](#lower-level-usage)
+- [](#settings)
+- [](#setup-defining-a-circuit)
+- [](#high-level-usage)
+- [](#options)
+- [](#lower-level-usage)
 
 +++
 

--- a/docs/source/examples/maxcut-demo.myst
+++ b/docs/source/examples/maxcut-demo.myst
@@ -16,7 +16,7 @@ kernelspec:
 +++
 
 In this notebook we solve a simple [_MaxCut_ problem](https://en.wikipedia.org/wiki/Maximum_cut) with the
-_Quantum Approximate Optimization Algorithm_ (QAOA) [[1-5]](#References) executed on a simulated noisy backend.
+_Quantum Approximate Optimization Algorithm_ (QAOA) [[1-5]](#references) executed on a simulated noisy backend.
 In particular we are interested in investigating how Mitiq can help reduce errors and improve the results.
 
 +++

--- a/docs/source/examples/pennylane-ibmq-backends.myst
+++ b/docs/source/examples/pennylane-ibmq-backends.myst
@@ -16,13 +16,14 @@ kernelspec:
 
 In this tutorial we will cover how to use Mitiq in conjunction with [PennyLane](https://pennylane.ai/), and further how to run error-mitigated circuits on IBMQ backends.
 
-- [Setup: Defining a circuit](#setup-defining-a-circuit)
-- [High-level usage](#high-level-usage)
-- [Options](#options)
-- [Decorator usage](#decorator-usage)
+- [](#setup-defining-a-circuit)
+- [](#high-level-usage)
+- [](#options)
+- [](#decorator-usage)
 
 +++
 
+(examples/ibmq-backends-pennylane/setup-defining-a-circuit)=
 ## Setup: Defining a circuit
 
 +++

--- a/docs/source/examples/vqe-pyquil-demo.ipynb
+++ b/docs/source/examples/vqe-pyquil-demo.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "\n",
     "The VQE example shown here is adapted from the `VQE` function in Grove \n",
-    "[[1]](#References) and the pyQuil / Grove VQE tutorial [[2]](#References). \n",
+    "[[1]](#references) and the pyQuil / Grove VQE tutorial [[2]](#references). \n",
     "\n",
     "\n",
     "## Defining the quantum system using pyQuil"
@@ -207,7 +207,7 @@
    "source": [
     "Compute expectation value of the Hamiltonian over the over the distribution \n",
     "generated from the quantum program. The following function is a modified version \n",
-    "of `expectation` from the `VQE` function in Grove [[1]](#References). Here the noisy \n",
+    "of `expectation` from the `VQE` function in Grove [[1]](#references). Here the noisy \n",
     "gates are defined inside the executor function via `add_noise_to_circuit`, since \n",
     "pyQuil custom gates cannot be folded in Mitiq."
    ]
@@ -255,7 +255,7 @@
    "metadata": {},
    "source": [
     "The following function is a modified version of `expectation_from_sampling` \n",
-    "from the `VQE` function in Grove [[1]](#References). It is modified to follow pyQuil \n",
+    "from the `VQE` function in Grove [[1]](#references). It is modified to follow pyQuil \n",
     "conventions for defining custom gates."
    ]
   },
@@ -296,7 +296,7 @@
    "metadata": {},
    "source": [
     "Calculate the parity of elements at indexes in marked_qubits. The function is a \n",
-    "modified version of `parity_even_p` from the `VQE` function in Grove [[1]](#References)."
+    "modified version of `parity_even_p` from the `VQE` function in Grove [[1]](#references)."
    ]
   },
   {
@@ -555,7 +555,7 @@
     "## Conclusion\n",
     "\n",
     "While the VQE algorithm is generally considered to be robust to noise \n",
-    "[[2]](#References), at the noise level modeled in this example, the \n",
+    "[[2]](#references), at the noise level modeled in this example, the \n",
     "accumulation of errors results in loss of accuracy and additional iterations \n",
     "required to reach convergence. Adding ZNE then improves the convergence of the \n",
     "algorithm to the minimum energy. The result is also demonstrated in the energy \n",

--- a/docs/source/examples/zne-braket-ionq.myst
+++ b/docs/source/examples/zne-braket-ionq.myst
@@ -22,11 +22,11 @@ More details on the Mitiq notions of frontends and backends are given [here](../
 
 Below, we show how to run a simple Braket circuit on an IonQ device, broken down in the following steps.
 
-- [Settings](#settings)
-- [Setup: Defining a circuit](#setup-defining-a-circuit)
-- [High-level usage](#high-level-usage)
-- [Options](#options)
-- [Lower-level usage](#lower-level-usage)
+- [](#settings)
+- [](#setup-defining-a-circuit-in-braket)
+- [](#high-level-usage)
+- [](#options)
+- [](#lower-level-usage)
 
 +++
 

--- a/docs/source/guide/error-mitigation.myst
+++ b/docs/source/guide/error-mitigation.myst
@@ -6,10 +6,10 @@ as other external links framing this topic in the open-source software
 ecosystem. This recent review article {cite}`Endo_2021_JPSJ` summarizes the theory behind many error-mitigating
 techniques.
 
-- [What is quantum error mitigation?](#what-is-quantum-error-mitigation)
-- [Why is quantum error mitigation important?](#why-is-quantum-error-mitigation-important)
-- [Related fields](#related-fields)
-- [External References](#external-references)
+- [](#what-is-quantum-error-mitigation)
+- [](#why-is-quantum-error-mitigation-important)
+- [](#related-fields)
+- [](#external-references)
 
 ## What is quantum error mitigation?
 

--- a/docs/source/guide/frontends-backends.myst
+++ b/docs/source/guide/frontends-backends.myst
@@ -52,6 +52,7 @@ Examples for using each of the frameworks to represent the input to a mitigation
 - {ref}`Cirq <examples/cirq-ibmq-backends/setup-defining-a-circuit>`
 - {ref}`Qiskit <examples/ibmq-backends/setup-defining-a-circuit>`
 - {ref}`PyQuil <examples/pyquil_demo>`
+- {ref}`PennyLane <examples/ibmq-backends-pennylane/setup-defining-a-circuit>`
 - {ref}`Braket <examples/braket_mirror_circuit/define-the-circuit>`
 
 ## Backends

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,3 @@
 [tool.black]
 line-length = 79
 target-version = ['py310']
-include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs         # black-default
-    | \.git
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-  )/
-)
-'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 79
-target-version = ['py39']
+target-version = ['py310']
 include = '\.pyi?$'
 exclude = '''
 (


### PR DESCRIPTION
## Description

This PR adds support for the latest released version of python (3.10). What's new in this version of python can be found [here](https://docs.python.org/3/whatsnew/3.10.html), but I've avoided using the new features as we want to continue support for python 3.8 and 3.9.

The main changes are some dependency upgrades that were previously not compatible with python 3.10, and as a result some changes to documentation as it seems myst has gotten stricter with the updates when it comes to references.

---

fixes https://github.com/unitaryfund/mitiq/issues/1292
fixes https://github.com/unitaryfund/mitiq/issues/1493

FYI: Python EOL schedule: https://endoflife.date/python