### PR TITLE
remove `print` calls

### DIFF
--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -175,9 +175,7 @@ class Executor:
 
         elif self._executor_return_type in DensityMatrixLike:
             observable = cast(Observable, observable)
-            print("before:", all_results)
             all_results = cast(List[npt.NDArray[np.complex64]], all_results)
-            print("after: ", all_results)
             results = [
                 observable._expectation_from_density_matrix(density_matrix)
                 for density_matrix in all_results


### PR DESCRIPTION
removes print statements accidentally added in https://github.com/unitaryfund/mitiq/pull/1501.

Sorry for leaving these in!