### PR TITLE
Implement conversions of IonQ native gates for Braket

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,3 +43,4 @@ Luciano Bello
 dependabot[bot]
 allcontributors[bot]
 Isaac Griswold-Steiner
+Tim (Yi-Ting) Chen

--- a/mitiq/interface/mitiq_braket/conversions.py
+++ b/mitiq/interface/mitiq_braket/conversions.py
@@ -22,6 +22,7 @@ from cirq.linalg.decompositions import (
     deconstruct_single_qubit_matrix_into_angles,
     kak_decomposition,
 )
+import cirq_ionq.ionq_native_gates as cirq_ionq_ops
 from braket.circuits import (
     gates as braket_gates,
     Circuit as BKCircuit,
@@ -192,6 +193,14 @@ def _translate_one_qubit_braket_instruction_to_cirq_operation(
         return [cirq_ops.rz(gate.angle).on(*qubits)]
     elif isinstance(gate, braket_gates.PhaseShift):
         return [cirq_ops.Z.on(*qubits) ** (gate.angle / np.pi)]
+    elif isinstance(gate, braket_gates.GPi):
+        return [
+            cirq_ionq_ops.GPIGate(phi=gate.angle / (2 * np.pi)).on(*qubits)
+        ]
+    elif isinstance(gate, braket_gates.GPi2):
+        return [
+            cirq_ionq_ops.GPI2Gate(phi=gate.angle / (2 * np.pi)).on(*qubits)
+        ]
 
     else:
         _raise_braket_to_cirq_error(instr)
@@ -278,6 +287,15 @@ def _translate_two_qubit_braket_instruction_to_cirq_operation(
         ]
     elif isinstance(gate, braket_gates.XY):
         return [cirq_ops.ISwapPowGate(exponent=gate.angle / np.pi).on(*qubits)]
+
+    # Two-qubit two-parameters parameterized gates.
+    elif isinstance(gate, braket_gates.MS):
+        return [
+            cirq_ionq_ops.MSGate(
+                phi0=gate.angle_1 / (2 * np.pi),
+                phi1=gate.angle_2 / (2 * np.pi),
+            ).on(*qubits)
+        ]
 
     else:
         _raise_braket_to_cirq_error(instr)

--- a/mitiq/interface/mitiq_braket/conversions.py
+++ b/mitiq/interface/mitiq_braket/conversions.py
@@ -375,6 +375,14 @@ def _translate_one_qubit_cirq_operation_to_braket_instruction(
         elif isinstance(op.gate, cirq_ops.IdentityGate):
             return [Instruction(braket_gates.I(), target)]
 
+        # IonQ native gates
+        elif isinstance(op.gate, cirq_ionq_ops.GPIGate):
+            angle = op.gate.phi * 2 * np.pi
+            return [Instruction(braket_gates.GPi(angle), target)]
+        elif isinstance(op.gate, cirq_ionq_ops.GPI2Gate):
+            angle = op.gate.phi * 2 * np.pi
+            return [Instruction(braket_gates.GPi2(angle), target)]
+
     # Arbitrary single-qubit unitary decomposition.
     # TODO: This does not account for global phase.
     if isinstance(op, cirq_ops.Operation):
@@ -450,6 +458,16 @@ def _translate_two_qubit_cirq_operation_to_braket_instruction(
         return [
             Instruction(
                 braket_gates.ZZ(cast(float, op.gate.exponent) * np.pi),
+                [q1, q2],
+            )
+        ]
+
+    # IonQ native gates
+    elif isinstance(op.gate, cirq_ionq_ops.MSGate):
+        a0, a1 = op.gate.phi0, op.gate.phi1
+        return [
+            Instruction(
+                braket_gates.MS(a0 * 2 * np.pi, a1 * 2 * np.pi),
                 [q1, q2],
             )
         ]

--- a/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
+++ b/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
@@ -268,7 +268,14 @@ def test_to_from_braket_common_one_qubit_gates():
     assert _equal(test_circuit, cirq_circuit, require_qubit_equality=True)
 
 
-@pytest.mark.parametrize("uncommon_gate", [ops.HPowGate(exponent=-1 / 14)])
+@pytest.mark.parametrize(
+    "uncommon_gate",
+    [
+        ops.HPowGate(exponent=-1 / 14),
+        cirq_ionq_ops.GPIGate(phi=1 / 14),
+        cirq_ionq_ops.GPI2Gate(phi=1 / 14),
+    ],
+)
 def test_to_from_braket_uncommon_one_qubit_gates(uncommon_gate):
     """These gates get decomposed when converting Cirq -> Braket -> Cirq, but
     the unitaries should be equal up to global phase.
@@ -315,7 +322,11 @@ def test_to_from_braket_common_two_qubit_gates(common_gate):
 
 @pytest.mark.parametrize(
     "uncommon_gate",
-    [ops.CNotPowGate(exponent=-1 / 17), ops.CZPowGate(exponent=2 / 7)],
+    [
+        ops.CNotPowGate(exponent=-1 / 17),
+        ops.CZPowGate(exponent=2 / 7),
+        cirq_ionq_ops.MSGate(phi0=1 / 7, phi1=2 / 7),
+    ],
 )
 def test_to_from_braket_uncommon_two_qubit_gates(uncommon_gate):
     """These gates get decomposed when converting Cirq -> Braket -> Cirq, but

--- a/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
+++ b/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
@@ -22,6 +22,7 @@ from braket.circuits import (
     gates as braket_gates,
 )
 from cirq import Circuit, LineQubit, ops, protocols, testing
+import cirq_ionq.ionq_native_gates as cirq_ionq_ops
 
 from mitiq.interface.mitiq_braket.conversions import from_braket, to_braket
 from mitiq.utils import _equal
@@ -85,6 +86,8 @@ def test_from_braket_parameterized_single_qubit_gates(qubit_index):
         braket_gates.Ry,
         braket_gates.Rz,
         braket_gates.PhaseShift,
+        braket_gates.GPi,
+        braket_gates.GPi2,
     ]
     angles = np.random.RandomState(11).random(len(pgates))
     instructions = [
@@ -106,6 +109,8 @@ def test_from_braket_parameterized_single_qubit_gates(qubit_index):
         ops.ry(angles[1]).on(qubit),
         ops.rz(angles[2]).on(qubit),
         ops.Z.on(qubit) ** (angles[3] / np.pi),
+        cirq_ionq_ops.GPIGate(phi=angles[4] / (2 * np.pi)).on(qubit),
+        cirq_ionq_ops.GPI2Gate(phi=angles[5] / (2 * np.pi)).on(qubit),
     )
     assert _equal(
         cirq_circuit, expected_cirq_circuit, require_qubit_equality=True
@@ -154,6 +159,26 @@ def test_from_braket_parameterized_two_qubit_gates():
     angles = np.random.RandomState(2).random(len(pgates))
     instructions = [
         Instruction(rot(a), target=[0, 1]) for rot, a in zip(pgates, angles)
+    ]
+
+    cirq_circuits = list()
+    for instr in instructions:
+        braket_circuit = BKCircuit()
+        braket_circuit.add_instruction(instr)
+        cirq_circuits.append(from_braket(braket_circuit))
+
+    for instr, cirq_circuit in zip(instructions, cirq_circuits):
+        assert np.allclose(instr.operator.to_matrix(), cirq_circuit.unitary())
+
+
+def test_from_braket_parameterized_two_qubit_two_parameters_gates():
+    pgates = [
+        braket_gates.MS,
+    ]
+    angles = np.random.RandomState(2).random((len(pgates), 2))
+    instructions = [
+        Instruction(rot(a[0], a[1]), target=[0, 1])
+        for rot, a in zip(pgates, angles)
     ]
 
     cirq_circuits = list()


### PR DESCRIPTION
## Description

Implement conversions of IonQ native gates for Braket so that Mitiq can understand circuits with IonQ native gates. 

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file