### PR TITLE
[temporary] ignore errors from first-interaction

### DIFF
--- a/.github/workflows/greeting.yml
+++ b/.github/workflows/greeting.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/first-interaction@v1
+      continue-on-error: true
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         pr-message:  'Hello @${{ github.actor }}, thank you for submitting a PR to Mitiq! We will respond as soon as possible, and if you have any questions in the meantime, you can ask us on the [Unitary Fund Discord](http://discord.unitary.fund).'


### PR DESCRIPTION
## Description

The greeting bot is causing all PR builds to "fail", even though most of the time it's just the greeting that's failing. I thought a fix might be out sooner (especially since a [PR](https://github.com/actions/first-interaction/pull/102) is open), but the project doesn't seem to see a whole lot of activity. A workaround was suggested in https://github.com/actions/first-interaction/issues/101#issuecomment-1262487501, so that's what's copied here.