### PR TITLE
Warn when unsupported gate fidelity is passed

### DIFF
--- a/mitiq/zne/scaling/folding.py
+++ b/mitiq/zne/scaling/folding.py
@@ -40,13 +40,21 @@ _cirq_gates_to_string_keys = {
     ops.Z: "Z",
     ops.T: "T",
     ops.I: "I",
+    ops.S: "S",
+    ops.T: "T",
+    ops.rx: "RX",
+    ops.ry: "RY",
+    ops.rz: "RZ",
     ops.CNOT: "CNOT",
     ops.CZ: "CZ",
+    ops.SWAP: "SWAP",
+    ops.ISWAP: "ISWAP",
+    ops.CSWAP: "CSWAP",
     ops.TOFFOLI: "TOFFOLI",
 }
-_string_keys_to_cirq_gates = dict(
-    zip(_cirq_gates_to_string_keys.values(), _cirq_gates_to_string_keys.keys())
-)
+_string_keys_to_cirq_gates = {
+    opstring: op for op, opstring in _cirq_gates_to_string_keys.items()
+}
 
 _valid_gate_names = list(
     map(
@@ -237,8 +245,16 @@ def fold_all(
                 "Y"         | Pauli Y
                 "Z"         | Pauli Z
                 "I"         | Identity
+                "S"         | Phase
+                "T"         | Pi/8 gate
+                "rx"        | X-rotation
+                "ry"        | Y-rotation
+                "rz"        | Z-rotation
                 "CNOT"      | CNOT
                 "CZ"        | CZ gate
+                "SWAP"      | Swap
+                "ISWAP"     | Imaginary swap
+                "CSWAP"     | CSWAP
                 "TOFFOLI"   | Toffoli gate
                 "single"    | All single qubit gates
                 "double"    | All two-qubit gates
@@ -326,7 +342,7 @@ def _create_weight_mask(
     circuit: Circuit,
     fidelities: Dict[str, float],
 ) -> List[float]:
-    """Returns a list of weights associated to each gate if the input
+    """Returns a list of weights associated to each gate in the input
     circuit. Measurement gates are ignored.
 
     The gate ordering is equal to the one used in the `all_operations()`
@@ -572,8 +588,16 @@ def fold_gates_from_left(
                 "Y"         | Pauli Y
                 "Z"         | Pauli Z
                 "I"         | Identity
+                "S"         | Phase
+                "T"         | Pi/8 gate
+                "rx"        | X-rotation
+                "ry"        | Y-rotation
+                "rz"        | Z-rotation
                 "CNOT"      | CNOT
                 "CZ"        | CZ gate
+                "SWAP"      | Swap
+                "ISWAP"     | Imaginary swap
+                "CSWAP"     | CSWAP
                 "TOFFOLI"   | Toffoli gate
                 "single"    | All single qubit gates
                 "double"    | All two-qubit gates
@@ -649,8 +673,16 @@ def fold_gates_from_right(
                 "Y"         | Pauli Y
                 "Z"         | Pauli Z
                 "I"         | Identity
+                "S"         | Phase
+                "T"         | Pi/8 gate
+                "rx"        | X-rotation
+                "ry"        | Y-rotation
+                "rz"        | Z-rotation
                 "CNOT"      | CNOT
                 "CZ"        | CZ gate
+                "SWAP"      | Swap
+                "ISWAP"     | Imaginary swap
+                "CSWAP"     | CSWAP
                 "TOFFOLI"   | Toffoli gate
                 "single"    | All single qubit gates
                 "double"    | All two-qubit gates
@@ -730,8 +762,16 @@ def fold_gates_at_random(
                 "Y"         | Pauli Y
                 "Z"         | Pauli Z
                 "I"         | Identity
+                "S"         | Phase
+                "T"         | Pi/8 gate
+                "rx"        | X-rotation
+                "ry"        | Y-rotation
+                "rz"        | Z-rotation
                 "CNOT"      | CNOT
                 "CZ"        | CZ gate
+                "SWAP"      | Swap
+                "ISWAP"     | Imaginary swap
+                "CSWAP"     | CSWAP
                 "TOFFOLI"   | Toffoli gate
                 "single"    | All single qubit gates
                 "double"    | All two-qubit gates

--- a/mitiq/zne/scaling/folding.py
+++ b/mitiq/zne/scaling/folding.py
@@ -42,9 +42,9 @@ _cirq_gates_to_string_keys = {
     ops.I: "I",
     ops.S: "S",
     ops.T: "T",
-    ops.rx: "RX",
-    ops.ry: "RY",
-    ops.rz: "RZ",
+    ops.rx: "rx",
+    ops.ry: "ry",
+    ops.rz: "rz",
     ops.CNOT: "CNOT",
     ops.CZ: "CZ",
     ops.SWAP: "SWAP",
@@ -245,8 +245,8 @@ def fold_all(
                 "Y"         | Pauli Y
                 "Z"         | Pauli Z
                 "I"         | Identity
-                "S"         | Phase
-                "T"         | Pi/8 gate
+                "S"         | Phase gate
+                "T"         | T gate
                 "rx"        | X-rotation
                 "ry"        | Y-rotation
                 "rz"        | Z-rotation
@@ -588,8 +588,8 @@ def fold_gates_from_left(
                 "Y"         | Pauli Y
                 "Z"         | Pauli Z
                 "I"         | Identity
-                "S"         | Phase
-                "T"         | Pi/8 gate
+                "S"         | Phase gate
+                "T"         | T gate
                 "rx"        | X-rotation
                 "ry"        | Y-rotation
                 "rz"        | Z-rotation
@@ -673,8 +673,8 @@ def fold_gates_from_right(
                 "Y"         | Pauli Y
                 "Z"         | Pauli Z
                 "I"         | Identity
-                "S"         | Phase
-                "T"         | Pi/8 gate
+                "S"         | Phase gate
+                "T"         | T gate
                 "rx"        | X-rotation
                 "ry"        | Y-rotation
                 "rz"        | Z-rotation
@@ -762,8 +762,8 @@ def fold_gates_at_random(
                 "Y"         | Pauli Y
                 "Z"         | Pauli Z
                 "I"         | Identity
-                "S"         | Phase
-                "T"         | Pi/8 gate
+                "S"         | Phase gate
+                "T"         | T gate
                 "rx"        | X-rotation
                 "ry"        | Y-rotation
                 "rz"        | Z-rotation

--- a/mitiq/zne/scaling/tests/test_folding.py
+++ b/mitiq/zne/scaling/tests/test_folding.py
@@ -1677,6 +1677,10 @@ def test_create_weight_mask_with_fidelities():
     weight_mask = _create_weight_mask(circ, fidelities)
     assert np.allclose(weight_mask, [0.9, 0.9, 0.9, 0.8, 0.0, 0.7])
 
+    fidelities = {"rx": 1.0, "H": 0.1}
+    with pytest.warns(UserWarning, match="don't currently support"):
+        weight_mask = _create_weight_mask(circ, fidelities)
+
 
 @pytest.mark.parametrize(
     "weight_mask",

--- a/mitiq/zne/scaling/tests/test_folding.py
+++ b/mitiq/zne/scaling/tests/test_folding.py
@@ -1661,23 +1661,36 @@ def test_create_weight_mask_with_fidelities():
         ops.H.on_each(*qreg),
         ops.CNOT.on(qreg[0], qreg[1]),
         ops.T.on(qreg[2]),
+        ops.ISWAP.on(qreg[1], qreg[0]),
         ops.TOFFOLI.on(*qreg),
         ops.measure_each(*qreg),
     )
     # Measurement gates should be ignored
-    fidelities = {"H": 0.9, "CNOT": 0.8, "T": 0.7, "TOFFOLI": 0.6}
+    fidelities = {
+        "H": 0.9,
+        "CNOT": 0.8,
+        "T": 0.7,
+        "TOFFOLI": 0.6,
+        "ISWAP": 0.5,
+    }
     weight_mask = _create_weight_mask(circ, fidelities)
-    assert np.allclose(weight_mask, [0.1, 0.1, 0.1, 0.2, 0.3, 0.4])
+    assert np.allclose(weight_mask, [0.1, 0.1, 0.1, 0.2, 0.3, 0.5, 0.4])
 
     fidelities = {"single": 1.0, "double": 0.5, "triple": 0.1}
     weight_mask = _create_weight_mask(circ, fidelities)
-    assert np.allclose(weight_mask, [0.0, 0.0, 0.0, 0.5, 0.0, 0.9])
+    assert np.allclose(weight_mask, [0.0, 0.0, 0.0, 0.5, 0.0, 0.5, 0.9])
 
-    fidelities = {"single": 1.0, "H": 0.1, "CNOT": 0.2, "TOFFOLI": 0.3}
+    fidelities = {
+        "single": 1.0,
+        "double": 1.0,
+        "H": 0.1,
+        "CNOT": 0.2,
+        "TOFFOLI": 0.3,
+    }
     weight_mask = _create_weight_mask(circ, fidelities)
-    assert np.allclose(weight_mask, [0.9, 0.9, 0.9, 0.8, 0.0, 0.7])
+    assert np.allclose(weight_mask, [0.9, 0.9, 0.9, 0.8, 0.0, 0.0, 0.7])
 
-    fidelities = {"rx": 1.0, "H": 0.1}
+    fidelities = {"waitgate": 1.0, "H": 0.1}
     with pytest.warns(UserWarning, match="don't currently support"):
         weight_mask = _create_weight_mask(circ, fidelities)
 


### PR DESCRIPTION
## Description

I've gone with the `#2` proposed solution in https://github.com/unitaryfund/mitiq/issues/1179. I.e. warn the user when they pass a fidelity along with a gate that we don't support yet. I would be happy to add more gates to the supported group, but I figured I would get feedback before going down that route. If we do decide to do that, I'd offer to pair on it as I have a few questions about how to add support for gates with parameters.

fixes https://github.com/unitaryfund/mitiq/issues/1179

cc @purva-thakre as you had previously been assigned this issue. Sorry if you were working on this!

---

**EDIT:** I've _also_ added more supported gates in this PR, so not only does it warn now, but it should warn less!