### PR TITLE
add robots.txt 🤖

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -307,6 +307,10 @@ html_logo = "img/mitiq-logo.png"
 
 html_favicon = "img/mitiq.ico"
 
+# Add extra paths that contain custom files here, relative to this directory.
+# These files are copied directly to the root of the documentation.
+html_extra_path = ["robots.txt"]
+
 myst_update_mathjax = False
 
 nbsphinx_custom_formats = {

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /*/stable/
+Allow: /en/stable/   # Fallback for bots that don't understand wildcards
+Disallow: /


### PR DESCRIPTION
## Description

This change should ensure that search engines only index our stable release docs, and nothing else. This is done by using a `robots.txt` file which all major search engines support. Further information about this file can be found [here](https://www.cloudflare.com/learning/bots/what-is-robots.txt/). The `robots.txt` can be seen on the RTD build here: https://mitiq--1543.org.readthedocs.build/en/1543/robots.txt

This change is based on https://github.com/astropy/astropy/commit/53991504e622ceb516d79d37dd562da95f6c845f

This change should solve https://github.com/unitaryfund/mitiq/issues/1526, but we will have to check search engines a few weeks after this is merged to ensure as their search results do not update automatically.