### PR TITLE
use python 3.10 for asv

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,7 +4,7 @@
   "project_url": "https://github.com/unitaryfund/mitiq",
   "repo": "https://github.com/unitaryfund/mitiq.git",
   "branches": ["master"],
-  "pythons": ["3.8"],
+  "pythons": ["3.10"],
   "environment_type": "virtualenv",
   "show_commit_url": "https://github.com/unitaryfund/mitiq/commit/"
 }


### PR DESCRIPTION
## Description

[ASV](https://github.com/airspeed-velocity/asv) has been causing our CI to fail due to a mismatch in configuration. The [github action that runs `asv`](https://github.com/unitaryfund/mitiq/blob/3fe70da498213272d64ea753f3809e61f522b090/.github/workflows/asv.yaml) sets up python 3.10, but our [`asv.conf.json`](https://github.com/unitaryfund/mitiq/blob/3fe70da498213272d64ea753f3809e61f522b090/asv.conf.json) requests python 3.8.

This PR ensures both run on the same version. If these were timing benchmarks, swapping the python versions would not be ideal since there could be speed improvements in the language that would make it seem as though our code improved without doing anything. That said, our benchmarks are EM factor-related and hence should not be affected by this.

I think ASV is also smart enough to show new lines on https://unitaryfund.github.io/mitiq-bench/#benchmarks.track_zne when the python version changes anyway.

### Diagnosis

Support for python 3.10 was added in mitiq in https://github.com/unitaryfund/mitiq/pull/1504 (Sep 30th) which would have originally caused this mismatch. However, up until Nov 1, all of our actions running on `ubuntu-latest` defaulted to running on Ubuntu 20.04 which comes pre-installed with a list of software detailed [here](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md), but most importantly has python 3.8 installed as a default. Hence even though we specified use 3.10 in setting up, it was still able to find python 3.8 to run the `asv` benchmarks. On Nov 1 that changed when `ubuntu-latest` was upgraded to run on Ubuntu 22.04 ([runner images release](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20221027.1)). This finally reared it's head on our CI builds starting Nov 1st since the Ubuntu 22.04 image defaults to python 3.10 as can be seen in the announcement issue: https://github.com/actions/runner-images/issues/6399.



