### PR TITLE
Raise error when inserting DDD sequence with midcircuit measurement

### DIFF
--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -141,7 +141,7 @@ def _insert_ddd_sequences(
     # Copy to avoid mutating the input circuit
     circuit_with_ddd = circuit.copy()
     qubits = sorted(circuit.all_qubits())
-    for moment_idx, moment in enumerate(circuit):
+    for moment_idx in range(len(circuit)):
         slack_column = slack_matrix[:, moment_idx]
         for row_index, slack_length in enumerate(slack_column):
             if slack_length > 1:

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -129,6 +129,12 @@ def _insert_ddd_sequences(
         The circuit with DDD sequences added.
     """
     circuit = synchronize_terminal_measurements(circuit)
+    if not circuit.are_all_measurements_terminal():
+        raise ValueError(
+            "This circuit contains midcircuit measurements which "
+            "are not currently supported by DDD."
+        )
+
     slack_matrix = get_slack_matrix_from_circuit_mask(
         _get_circuit_mask(circuit)
     )

--- a/mitiq/ddd/tests/test_insertion.py
+++ b/mitiq/ddd/tests/test_insertion.py
@@ -253,3 +253,17 @@ def test_get_slack_matrix_from_circuit__bad_input_errors():
 def test_insert_sequences(circuit, result, rule):
     circuit_with_sequences = insert_ddd_sequences(circuit, rule)
     assert circuit_with_sequences == result
+
+
+def test_midcircuit_measurement_raises_error():
+    qreg = qiskit.QuantumRegister(2)
+    creg = qiskit.ClassicalRegister(1)
+    circuit = qiskit.QuantumCircuit(qreg, creg)
+    for q in qreg:
+        circuit.x(q)
+
+    circuit.measure(0, 0)
+    circuit.cx(0, 1)
+
+    with pytest.raises(ValueError, match="midcircuit measurements"):
+        insert_ddd_sequences(circuit, xx)

--- a/mitiq/ddd/tests/test_insertion.py
+++ b/mitiq/ddd/tests/test_insertion.py
@@ -24,6 +24,7 @@ from mitiq.ddd.insertion import (
 )
 import pytest
 import qiskit
+import pyquil
 from mitiq.ddd.rules import xx, xyxy
 
 circuit_cirq_one = cirq.Circuit(
@@ -267,3 +268,15 @@ def test_midcircuit_measurement_raises_error():
 
     with pytest.raises(ValueError, match="midcircuit measurements"):
         insert_ddd_sequences(circuit, xx)
+
+
+def test_pyquil_midcircuit_measurement_raises_error():
+    p = pyquil.Program()
+    cbit = p.declare("cbit")
+    p += pyquil.gates.X(0)
+    p += pyquil.gates.X(1)
+    p += pyquil.gates.MEASURE(0, cbit[0])
+    p += pyquil.gates.X(0)
+
+    with pytest.raises(ValueError, match="midcircuit measurements"):
+        insert_ddd_sequences(p, xx)


### PR DESCRIPTION
## Description

When inserting DDD sequences into a circuit, all measurements must be terminal. Previously we have used [`synchronize_terminal_measurements`](https://quantumai.google/reference/python/cirq/synchronize_terminal_measurements) to push measurements to the end, but this does not raise an error when it is not possible. This PR raises an error when the circuit contains unavoidable midcircuit measurements so the user more quickly knows this is not supported.

fixes https://github.com/unitaryfund/mitiq/issues/1466