### PR TITLE
color output from pytest on CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ line-length = 79
 target-version = ['py310']
 
 [tool.pytest.ini_options]
+addopts = "--color=yes"
 filterwarnings = [
     # TODO: these are probably too restrictive
     'ignore::UserWarning',


### PR DESCRIPTION
## Description

I recently discovered that the terminal output in github actions can be colorized ([announced](https://github.blog/2020-09-23-a-better-logs-experience-with-github-actions/#opening-the-door-to-a-more-colorful-experience) in 2020, but better late than never)! This should make reading through pytest logs much quicker as the red text is spotted much more easily.

Color output is the default on my terminal, so this should mainly affect CI, but it might force color output for others as well.