### PR TITLE
add pytest dependency to asv build

### DIFF
--- a/.github/workflows/asv.yaml
+++ b/.github/workflows/asv.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          pip install asv virtualenv
+          pip install asv virtualenv pytest
           asv machine --machine ghrunner
           asv run --attribute rounds=4
           cp asv.conf.json results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run ASV benchmarks
         run: |
-          pip install asv virtualenv
+          pip install asv virtualenv pytest
           export BENCHMARK_CI=1
           asv machine --yes
           asv run --quick --strict


### PR DESCRIPTION
## Description

CI is [failing](https://github.com/unitaryfund/mitiq/actions/runs/3526487137/jobs/5916670876) after the merging of https://github.com/unitaryfund/mitiq/pull/1449 due to the addition of `NoisySingleQubitReadoutSampler` in `mitiq/interface/mitiq_cirq/cirq_utils.py`. https://github.com/unitaryfund/mitiq/blob/dedc6e2f447339261c691fee33f06e4b1795ba1c/mitiq/interface/mitiq_cirq/cirq_utils.py#L24-L26 The file in `cirq` that the `NoisySingleQubitReadoutSampler` comes from [imports `pytest`](https://github.com/unitaryfund/mitiq/blob/dedc6e2f447339261c691fee33f06e4b1795ba1c/mitiq/interface/mitiq_cirq/cirq_utils.py#L24-L26) (as it's a test file) which is causing the asv build to fail as pytest is not installed on the github runner. 

I think we should merge this ASAP, but @amirebrahimi are there any ways around using this class? It seems a bit strange to import an object from a test file, but if it's needed, no problem. Just wanted to ask.