### PR TITLE
Fix ASV errors by moving `generate_inverse_confusion_matrix` out of `mitiq-cirq`

### DIFF
--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -105,33 +105,3 @@ def execute_with_depolarizing_noise(
     rho = simulator.simulate(circuit).final_density_matrix
     expectation = np.real(np.trace(rho @ obs))
     return expectation
-
-
-def generate_inverse_confusion_matrix(
-    qubits: Sequence["cirq.Qid"],
-    p0: float = 0.01,
-    p1: float = 0.01,
-) -> npt.NDArray[np.float64]:
-    """
-    Generates the inverse confusion matrix assuming a single-qubit
-    model for measurement errors. This is useful for applying
-    the measurement error mitigation technique in ``mitiq.rem``.
-
-    Args:
-        qubits: The qubits to measure.
-        p0: Probability of flipping a 0 to a 1.
-        p1: Probability of flipping a 1 to a 0.
-
-    Returns:
-        The inverse confusion matrix.
-    """
-    # Build a tensored confusion matrix using smaller single qubit confusion
-    # matrices. Implies that errors are uncorrelated among qubits.
-    qubit_measures = [[q] for q in qubits]
-
-    tensored_matrix = cirq.measure_confusion_matrix(
-        NoisySingleQubitReadoutSampler(p0, p1), qubit_measures
-    )
-    inverse_confusion_matrix = tensored_matrix.correction_matrix()
-
-    return inverse_confusion_matrix

--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -21,10 +21,6 @@ import numpy.typing as npt
 import cirq
 from mitiq._typing import MeasurementResult
 
-from cirq.experiments.single_qubit_readout_calibration_test import (
-    NoisySingleQubitReadoutSampler,
-)
-
 
 # Executors.
 def sample_bitstrings(

--- a/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
@@ -107,15 +107,3 @@ def test_execute_with_depolarizing_noise():
         qc, observable, noise3
     )
     assert np.isclose(observable_exp_value, 0.062452)
-
-
-def test_generate_inverse_confusion_matrix():
-    qubits = [cirq.LineQubit(i) for i in range(2)]
-    identity = np.identity(4)
-    assert (
-        generate_inverse_confusion_matrix(qubits, p0=0, p1=0) == identity
-    ).all()
-    assert (
-        generate_inverse_confusion_matrix(qubits, p0=1, p1=1)
-        == np.flipud(identity)
-    ).all()

--- a/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
@@ -23,9 +23,6 @@ from mitiq.interface.mitiq_cirq import (
     execute_with_depolarizing_noise,
 )
 from mitiq._typing import MeasurementResult
-from mitiq.interface.mitiq_cirq.cirq_utils import (
-    generate_inverse_confusion_matrix,
-)
 
 
 def test_sample_bitstrings():


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.

  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.

  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->

---

### License

- [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file