### PR TITLE
Refactor generate_inverse_confusion_matrix

### DIFF
--- a/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
@@ -110,12 +110,12 @@ def test_execute_with_depolarizing_noise():
 
 
 def test_generate_inverse_confusion_matrix():
-    qubits = [cirq.LineQubit(i) for i in range(2)]
+    num_qubits = 2
     identity = np.identity(4)
     assert (
-        generate_inverse_confusion_matrix(qubits, p0=0, p1=0) == identity
+        generate_inverse_confusion_matrix(num_qubits, p0=0, p1=0) == identity
     ).all()
     assert (
-        generate_inverse_confusion_matrix(qubits, p0=1, p1=1)
+        generate_inverse_confusion_matrix(num_qubits, p0=1, p1=1)
         == np.flipud(identity)
     ).all()


### PR DESCRIPTION
Resolves #1562

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.

  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.

  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

Replaced the use of `NoisyReadoutSampler` and `cirq.measure_confusion_matrix` with a straightforward approach of inverting a single-qubit confusion matrix and tensoring.

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [ ] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file