### PR TITLE
REM: Utility method maintenance

### DIFF
--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Cirq utility functions."""
 
-from functools import reduce
 from typing import Tuple
 
 import numpy as np
@@ -102,30 +101,3 @@ def execute_with_depolarizing_noise(
     rho = simulator.simulate(circuit).final_density_matrix
     expectation = np.real(np.trace(rho @ obs))
     return expectation
-
-
-def generate_inverse_confusion_matrix(
-    num_qubits: int,
-    p0: float = 0.01,
-    p1: float = 0.01,
-) -> npt.NDArray[np.float64]:
-    """
-    Generates the inverse confusion matrix assuming a single-qubit
-    model for measurement errors. This is useful for applying
-    the measurement error mitigation technique in ``mitiq.rem``.
-
-    Args:
-        num_qubits: The number of qubits in the system.
-        p0: Probability of flipping a 0 to a 1.
-        p1: Probability of flipping a 1 to a 0.
-
-    Returns:
-        The inverse confusion matrix.
-    """
-    # Build a tensored confusion matrix using a smaller single qubit confusion
-    # matrix. Implies that errors are uncorrelated among qubits.
-    cm = np.array([[1 - p0, p1], [p0, 1 - p1]])
-    inv_cm = np.linalg.pinv(cm)
-
-    tensored_inv_cm = reduce(np.kron, [inv_cm] * num_qubits)
-    return tensored_inv_cm

--- a/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
@@ -23,9 +23,6 @@ from mitiq.interface.mitiq_cirq import (
     execute_with_depolarizing_noise,
 )
 from mitiq._typing import MeasurementResult
-from mitiq.interface.mitiq_cirq.cirq_utils import (
-    generate_inverse_confusion_matrix,
-)
 
 
 def test_sample_bitstrings():
@@ -107,15 +104,3 @@ def test_execute_with_depolarizing_noise():
         qc, observable, noise3
     )
     assert np.isclose(observable_exp_value, 0.062452)
-
-
-def test_generate_inverse_confusion_matrix():
-    num_qubits = 2
-    identity = np.identity(4)
-    assert (
-        generate_inverse_confusion_matrix(num_qubits, p0=0, p1=0) == identity
-    ).all()
-    assert (
-        generate_inverse_confusion_matrix(num_qubits, p0=1, p1=1)
-        == np.flipud(identity)
-    ).all()

--- a/mitiq/rem/__init__.py
+++ b/mitiq/rem/__init__.py
@@ -16,7 +16,13 @@
 """Readout error mitigation (REM) techniques."""
 
 from mitiq.rem.post_select import post_select
-from mitiq.rem.inverse_confusion_matrix import mitigate_measurements
+from mitiq.rem.inverse_confusion_matrix import (
+    sample_probability_vector,
+    bitstrings_to_probability_vector,
+    generate_inverse_confusion_matrix,
+    generate_tensored_inverse_confusion_matrix,
+    mitigate_measurements,
+)
 from mitiq.rem.rem import (
     execute_with_rem,
     mitigate_executor,

--- a/mitiq/rem/inverse_confusion_matrix.py
+++ b/mitiq/rem/inverse_confusion_matrix.py
@@ -95,8 +95,9 @@ def generate_inverse_confusion_matrix(
     Returns:
         The inverse confusion matrix.
     """
-    # Build a tensored confusion matrix using a smaller single qubit confusion
-    # matrix. Implies that errors are uncorrelated among qubits.
+    # Use a smaller single qubit confusion matrix for generating
+    # the larger inverse confusion matrix (by tensoring).
+    # Implies that errors are uncorrelated among qubits.
     cm = np.array([[1 - p0, p1], [p0, 1 - p1]])
     inv_cm = np.linalg.pinv(cm)
 
@@ -121,8 +122,6 @@ def generate_tensored_inverse_confusion_matrix(
     Returns:
         The inverse confusion matrix.
     """
-    # Build a tensored confusion matrix using a smaller single qubit confusion
-    # matrix. Implies that errors are uncorrelated among qubits.
     inv_confusion_matrices = [np.linalg.pinv(cm) for cm in confusion_matrices]
     tensored_inv_cm = reduce(np.kron, inv_confusion_matrices)
 

--- a/mitiq/rem/inverse_confusion_matrix.py
+++ b/mitiq/rem/inverse_confusion_matrix.py
@@ -13,9 +13,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from functools import reduce
 from typing import List
 import numpy as np
 import numpy.typing as npt
+
 
 from mitiq._typing import MeasurementResult, Bitstring
 
@@ -73,6 +75,66 @@ def bitstrings_to_probability_vector(
     pv /= len(bitstrings)
 
     return pv
+
+
+def generate_inverse_confusion_matrix(
+    num_qubits: int,
+    p0: float = 0.01,
+    p1: float = 0.01,
+) -> npt.NDArray[np.float64]:
+    """
+    Generates the inverse confusion matrix assuming a single-qubit
+    model for measurement errors. This is useful for applying
+    the measurement error mitigation technique in ``mitiq.rem``.
+
+    Args:
+        num_qubits: The number of qubits in the system.
+        p0: Probability of flipping a 0 to a 1.
+        p1: Probability of flipping a 1 to a 0.
+
+    Returns:
+        The inverse confusion matrix.
+    """
+    # Build a tensored confusion matrix using a smaller single qubit confusion
+    # matrix. Implies that errors are uncorrelated among qubits.
+    cm = np.array([[1 - p0, p1], [p0, 1 - p1]])
+    inv_cm = np.linalg.pinv(cm)
+
+    tensored_inv_cm = reduce(np.kron, [inv_cm] * num_qubits)
+    return tensored_inv_cm
+
+
+def generate_tensored_inverse_confusion_matrix(
+    num_qubits: int, confusion_matrices: list[npt.NDArray[np.float64]]
+) -> npt.NDArray[np.float64]:
+    """
+    Generates the inverse confusion matrix utilizing the supplied
+    confusion matrices for individual or combined subsystems. This
+    is useful for applying the measurement error mitigation
+    technique in ``mitiq.rem``.
+
+    Args:
+        num_qubits: The number of qubits in the system.
+        confusion_matrices: The confusion matrices for the individual
+            or sometimes combined subsystems.
+
+    Returns:
+        The inverse confusion matrix.
+    """
+    # Build a tensored confusion matrix using a smaller single qubit confusion
+    # matrix. Implies that errors are uncorrelated among qubits.
+    inv_confusion_matrices = [np.linalg.pinv(cm) for cm in confusion_matrices]
+    tensored_inv_cm = reduce(np.kron, inv_confusion_matrices)
+
+    expected_shape = (2**num_qubits, 2**num_qubits)
+    if tensored_inv_cm.shape != expected_shape:
+        raise ValueError(
+            f"The supplied confusion matrices don't produce the "
+            f"correctly sized inverse confusion matrix: "
+            f"{tensored_inv_cm.shape} should be {expected_shape}."
+        )
+
+    return tensored_inv_cm
 
 
 def mitigate_measurements(

--- a/mitiq/rem/inverse_confusion_matrix.py
+++ b/mitiq/rem/inverse_confusion_matrix.py
@@ -106,7 +106,7 @@ def generate_inverse_confusion_matrix(
 
 
 def generate_tensored_inverse_confusion_matrix(
-    num_qubits: int, confusion_matrices: list[npt.NDArray[np.float64]]
+    num_qubits: int, confusion_matrices: List[npt.NDArray[np.float64]]
 ) -> npt.NDArray[np.float64]:
     """
     Generates the inverse confusion matrix utilizing the supplied

--- a/mitiq/rem/tests/test_inverse_confusion_matrix.py
+++ b/mitiq/rem/tests/test_inverse_confusion_matrix.py
@@ -15,12 +15,16 @@
 
 """Unit tests for inverse confusion matrix helper functions."""
 
+from functools import reduce
 from math import isclose
 import numpy as np
+import pytest
 
 from mitiq._typing import MeasurementResult
 from mitiq.rem.inverse_confusion_matrix import (
     bitstrings_to_probability_vector,
+    generate_inverse_confusion_matrix,
+    generate_tensored_inverse_confusion_matrix,
     mitigate_measurements,
     sample_probability_vector,
 )
@@ -82,6 +86,71 @@ def test_probability_vector_roundtrip():
             0,
             abs_tol=0.1,
         )
+
+
+def test_generate_inverse_confusion_matrix():
+    num_qubits = 2
+    identity = np.identity(4)
+    assert (
+        generate_inverse_confusion_matrix(num_qubits, p0=0, p1=0) == identity
+    ).all()
+    assert (
+        generate_inverse_confusion_matrix(num_qubits, p0=1, p1=1)
+        == np.flipud(identity)
+    ).all()
+
+
+@pytest.mark.parametrize(
+    "num_qubits, confusion_matrices, expected",
+    [
+        (2, [np.identity(2), np.identity(2)], np.identity(4)),
+        (2, [np.identity(4)], np.identity(4)),
+        (3, [np.identity(4), np.identity(2)], np.identity(8)),
+        # all are faulty qubits, flipping to opposite value
+        (
+            2,
+            [np.flipud(np.identity(2)), np.flipud(np.identity(2))],
+            np.flipud(np.identity(4)),
+        ),
+        (
+            3,
+            [np.flipud(np.identity(4)), np.flipud(np.identity(2))],
+            np.flipud(np.identity(8)),
+        ),
+        # wrongly sized confusion matrices
+        (3, [np.identity(2), np.identity(2)], ValueError),
+        # one qubit flips values, one is perfect, one is random
+        (
+            3,
+            [np.flipud(np.identity(2)), np.identity(2), 0.5 * np.ones((2, 2))],
+            np.linalg.pinv(
+                reduce(
+                    np.kron,
+                    [
+                        np.flipud(np.identity(2)),
+                        np.identity(2),
+                        0.5 * np.ones((2, 2)),
+                    ],
+                )
+            ),
+        ),
+    ],
+)
+def test_generate_tensored_inverse_confusion_matrix(
+    num_qubits, confusion_matrices, expected
+):
+    if expected is ValueError:
+        with pytest.raises(ValueError):
+            generate_tensored_inverse_confusion_matrix(
+                num_qubits, confusion_matrices
+            )
+    else:
+        assert np.isclose(
+            generate_tensored_inverse_confusion_matrix(
+                num_qubits, confusion_matrices
+            ),
+            expected,
+        ).all()
 
 
 def test_mitigate_measurements():

--- a/mitiq/rem/tests/test_rem.py
+++ b/mitiq/rem/tests/test_rem.py
@@ -23,12 +23,12 @@ from cirq.experiments.single_qubit_readout_calibration_test import (
 import numpy as np
 import pytest
 
-from mitiq.interface.mitiq_cirq.cirq_utils import (
-    generate_inverse_confusion_matrix,
-)
 from mitiq.observable.observable import Observable
 from mitiq.observable.pauli import PauliString
 from mitiq._typing import MeasurementResult
+from mitiq.rem.inverse_confusion_matrix import (
+    generate_inverse_confusion_matrix,
+)
 from mitiq.rem.rem import execute_with_rem, mitigate_executor, rem_decorator
 from mitiq.raw import execute as raw_execute
 from mitiq.interface.mitiq_cirq import sample_bitstrings


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.

  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.

  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

This PR performs some cleanup by moving `generate_inverse_confusion_matrix` out of `cirq_utils.py` since it no longer involves Cirq and adding an additional utility method `generate_tensored_inverse_confusion_matrix`.

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [X] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file