### PR TITLE
Format examples' titles and list

### DIFF
--- a/docs/source/examples/examples.myst
+++ b/docs/source/examples/examples.myst
@@ -1,21 +1,21 @@
 # Examples
 
 ```{nbgallery}
-Mirror circuit benchmark improved with zero-noise extrapolation on AWS Braket <braket_mirror_circuit.md>
-Probabilistic error cancellation (PEC) with Mirror Circuits <pec_tutorial.myst>
-Zero-noise extrapolation with Qiskit on IBMQ backends <ibmq-backends.myst>
-Zero-noise extrapolation with Cirq on IBMQ backends <cirq-ibmq-backends.myst>
-Zero-noise extrapolation with Braket on IonQ backend <zne-braket-ionq.myst>
-Zero-noise extrapolation with Pennylane on IBMQ backends <pennylane-ibmq-backends.myst>
-Zero-noise extrapolation on PyQuil parametric programs <pyquil_demo.ipynb>
-Variational quantum eigensolver improved with zero-noise extrapolation <vqe-pyquil-demo.ipynb>
-Using ZNE to compute the energy landscape of a variational circuit with Cirq <simple-landscape-cirq.myst>
-Using ZNE to compute the energy landscape of a variational circuit with Qiskit <simple-landscape-qiskit.myst>
-MaxCut benchmark with zero-noise extrapolation <maxcut-demo.myst>
+ZNE with Braket on a Rigetti backend: Improving mirror circuits <braket_mirror_circuit.md>
+PEC with Braket on a Braket simulator: Improving mirror circuits <pec_tutorial.myst>
+ZNE with Qiskit on IBM Quantum backends <ibmq-backends.myst>
+ZNE with Cirq on IBM Quantum backends <cirq-ibmq-backends.myst>
+ZNE with Braket on IonQ backends <zne-braket-ionq.myst>
+ZNE with Pennylane on IBMQ backends <pennylane-ibmq-backends.myst>
+ZNE with PyQuil: Parametric programs <pyquil_demo.ipynb>
+ZNE with PyQuil: Improving VQE <vqe-pyquil-demo.ipynb>
+ZNE with Cirq: Energy landscape of a variational circuit <simple-landscape-cirq.myst>
+ZNE with Qiskit: Energy landscape of a variational circuit <simple-landscape-qiskit.myst>
+ZNE: MaxCut benchmark <maxcut-demo.myst>
 Defining a Mitiq executor with a hamiltonian <hamiltonians.md>
 Mitiq paper codeblocks <mitiq-paper/mitiq-paper-codeblocks>
-Estimating the potential energy surface of molecular Hydrogen with ZNE <molecular_hydrogen.myst>
-Estimating the potential energy surface of molecular Hydrogen with ZNE and PennyLane + Cirq <molecular_hydrogen_pennylane.myst>
-Improving the accuracy of BQSKit compiled circuits with error mitigation <bqskit.myst>
-Learning quasiprobability representations with a depolarizing noise model <learning-depolarizing-noise.myst>
+ZNE with Cirq: Energy of molecular Hydrogen <molecular_hydrogen.myst>
+ZNE with PennyLane + Cirq: Energy of molecular Hydrogen <molecular_hydrogen_pennylane.myst>
+ZNE with OpenQASM: BQSKit compiler <bqskit.myst>
+PEC with Cirq: Representation learning with depolarizing noise <learning-depolarizing-noise.myst>
 ```

--- a/docs/source/examples/examples.myst
+++ b/docs/source/examples/examples.myst
@@ -1,10 +1,13 @@
 # Examples
 
+Below you can find a gallery of tutorials applying Zero Noise Extrapolation (ZNE)
+and Probabilistic Error Cancellation (PEC) with Mitiq:
+
 ```{nbgallery}
 ZNE on a Rigetti backend with Braket: Mirror circuits <braket_mirror_circuit.md>
 ZNE on IonQ backends with Braket <zne-braket-ionq.myst>
 ZNE on IBM Quantum backends with Qiskit <ibmq-backends.myst>
-ZNE on IBMQ backends with Pennylane <pennylane-ibmq-backends.myst>
+ZNE on IBM Quantum backends with Pennylane <pennylane-ibmq-backends.myst>
 ZNE on IBM Quantum backends with Cirq <cirq-ibmq-backends.myst>
 ZNE with PyQuil: Parametric programs <pyquil_demo.ipynb>
 ZNE with PyQuil: Improving VQE <vqe-pyquil-demo.ipynb>
@@ -14,7 +17,7 @@ ZNE with Cirq: Solving MaxCut with QAOA <maxcut-demo.myst>
 ZNE with Cirq: Hamiltonian simulation with Pauli gates<hamiltonians.md>
 ZNE with Cirq: Energy of molecular Hydrogen <molecular_hydrogen.myst>
 ZNE with PennyLane + Cirq: Energy of molecular Hydrogen <molecular_hydrogen_pennylane.myst>
-ZNE with OpenQASM: BQSKit compiler <bqskit.myst>
+ZNE with BQSKit compiled circuits <bqskit.myst>
 PEC on a Braket simulator: Mirror circuits <pec_tutorial.myst>
 PEC with Cirq: Learning representations <learning-depolarizing-noise.myst>
 The Mitiq paper code <mitiq-paper/mitiq-paper-codeblocks>

--- a/docs/source/examples/examples.myst
+++ b/docs/source/examples/examples.myst
@@ -1,21 +1,22 @@
 # Examples
 
 ```{nbgallery}
-ZNE with Braket on a Rigetti backend: Improving mirror circuits <braket_mirror_circuit.md>
-PEC with Braket on a Braket simulator: Improving mirror circuits <pec_tutorial.myst>
-ZNE with Qiskit on IBM Quantum backends <ibmq-backends.myst>
-ZNE with Cirq on IBM Quantum backends <cirq-ibmq-backends.myst>
-ZNE with Braket on IonQ backends <zne-braket-ionq.myst>
-ZNE with Pennylane on IBMQ backends <pennylane-ibmq-backends.myst>
+PEC on a Braket simulator: Mirror circuits <pec_tutorial.myst>
+PEC with Cirq: Learning representations <learning-depolarizing-noise.myst>
+ZNE on a Rigetti backend with Braket: Mirror circuits <braket_mirror_circuit.md>
+ZNE on IonQ backends with Braket <zne-braket-ionq.myst>
+ZNE on IBM Quantum backends with Qiskit <ibmq-backends.myst>
+ZNE on IBMQ backends with Pennylane <pennylane-ibmq-backends.myst>
+ZNE on IBM Quantum backends with Cirq <cirq-ibmq-backends.myst>
 ZNE with PyQuil: Parametric programs <pyquil_demo.ipynb>
 ZNE with PyQuil: Improving VQE <vqe-pyquil-demo.ipynb>
 ZNE with Cirq: Energy landscape of a variational circuit <simple-landscape-cirq.myst>
 ZNE with Qiskit: Energy landscape of a variational circuit <simple-landscape-qiskit.myst>
-ZNE: MaxCut benchmark <maxcut-demo.myst>
-Defining a Mitiq executor with a hamiltonian <hamiltonians.md>
-Mitiq paper codeblocks <mitiq-paper/mitiq-paper-codeblocks>
+ZNE with Cirq: Solving MaxCut with QAOA <maxcut-demo.myst>
+ZNE with Cirq: Hamiltonian simulation with Pauli gates<hamiltonians.md>
 ZNE with Cirq: Energy of molecular Hydrogen <molecular_hydrogen.myst>
 ZNE with PennyLane + Cirq: Energy of molecular Hydrogen <molecular_hydrogen_pennylane.myst>
+The Mitiq paper code <mitiq-paper/mitiq-paper-codeblocks>
 ZNE with OpenQASM: BQSKit compiler <bqskit.myst>
-PEC with Cirq: Representation learning with depolarizing noise <learning-depolarizing-noise.myst>
+
 ```

--- a/docs/source/examples/examples.myst
+++ b/docs/source/examples/examples.myst
@@ -1,8 +1,6 @@
 # Examples
 
 ```{nbgallery}
-PEC on a Braket simulator: Mirror circuits <pec_tutorial.myst>
-PEC with Cirq: Learning representations <learning-depolarizing-noise.myst>
 ZNE on a Rigetti backend with Braket: Mirror circuits <braket_mirror_circuit.md>
 ZNE on IonQ backends with Braket <zne-braket-ionq.myst>
 ZNE on IBM Quantum backends with Qiskit <ibmq-backends.myst>
@@ -16,7 +14,9 @@ ZNE with Cirq: Solving MaxCut with QAOA <maxcut-demo.myst>
 ZNE with Cirq: Hamiltonian simulation with Pauli gates<hamiltonians.md>
 ZNE with Cirq: Energy of molecular Hydrogen <molecular_hydrogen.myst>
 ZNE with PennyLane + Cirq: Energy of molecular Hydrogen <molecular_hydrogen_pennylane.myst>
-The Mitiq paper code <mitiq-paper/mitiq-paper-codeblocks>
 ZNE with OpenQASM: BQSKit compiler <bqskit.myst>
+PEC on a Braket simulator: Mirror circuits <pec_tutorial.myst>
+PEC with Cirq: Learning representations <learning-depolarizing-noise.myst>
+The Mitiq paper code <mitiq-paper/mitiq-paper-codeblocks>
 
 ```


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.

  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.

  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->
Close #1508 by:
- Enabling a shorter format for titles in the gallery on the [Examples page](https://mitiq.readthedocs.io/en/latest/examples/examples.html) of the Mitiq documentation: All titles start with the acronym of the technique (ZNE or PEC). Generally then the frontend and backend (when relevant) are listed, additionally with more information on specifics, e.g., adding information on solving MaxCut "with QAOA". Generally tried to make titles more clear and consistent. 
- Reordering examples so that they are grouped per technique (PEC, ZNE), per example (same example with multiple languages / frontend are grouped), and generally alphabetically with regard to frontend (Braket, Cirq, Pyquil, Qiskit).

---

### License

- [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file