### PR TITLE
Update learning depolarizing noise tutorial to avoid long execution time

### DIFF
--- a/docs/source/examples/learning-depolarizing-noise.myst
+++ b/docs/source/examples/learning-depolarizing-noise.myst
@@ -103,6 +103,11 @@ However, we avoid using a number of PEC samples that is too small, as it can res
 ```{code-cell} ipython3
 pec_kwargs = {"num_samples": 500, "random_state": 1}
 observable = Observable(PauliString("XZ"), PauliString("YY"))
+
+import warnings
+# suppress warnings about missing representations
+# this example only simulates noise on CNOT
+warnings.simplefilter("ignore", UserWarning)
 ```
 
 ```{code-cell} ipython3
@@ -118,11 +123,6 @@ ideal_values = np.array(ideal_executor.evaluate(training_circuits, observable))
 
 epsilons = np.linspace(0.03, 0.07, 9)
 
-import warnings
-
-# suppress warnings about missing representations
-# this example only simulates noise on CNOT
-warnings.simplefilter("ignore", UserWarning)
 loss = [
     depolarizing_noise_loss_function(
         [eps],

--- a/docs/source/examples/learning-depolarizing-noise.myst
+++ b/docs/source/examples/learning-depolarizing-noise.myst
@@ -101,6 +101,7 @@ Here we set a relatively small value of `num_samples` to obtain a reasonable exe
 However, we avoid using a number of PEC samples that is too small, as it can result in a large statistical error and ultimately cause the optimization process to fail.
 
 ```{code-cell} ipython3
+:tags: ["skip-execution"]
 pec_kwargs = {"num_samples": 500, "random_state": 1}
 
 training_circuits = generate_training_circuits(
@@ -140,6 +141,16 @@ plt.xlabel("Noise strength")
 plt.ylabel("Loss")
 plt.show()
 ```
+
+```{figure} ../_thumbnails/learn-depolarizing.png
+---
+
+name: depolarizing_noise_loss_function
+---
+The figure is a plot of the loss function for optimizing quasi-probability representations assuming a depolarizing noise model depending on
+one real parameter.
+```
+
 
 Now we set the initial conditions for the optimization. For purposes of this demonstration, our initial guess for epsilon, `epsilon0`, is
 slightly offset from the true value of `epsilon`.

--- a/docs/source/examples/learning-depolarizing-noise.myst
+++ b/docs/source/examples/learning-depolarizing-noise.myst
@@ -101,17 +101,18 @@ Here we set a relatively small value of `num_samples` to obtain a reasonable exe
 However, we avoid using a number of PEC samples that is too small, as it can result in a large statistical error and ultimately cause the optimization process to fail.
 
 ```{code-cell} ipython3
-:tags: ["skip-execution"]
 pec_kwargs = {"num_samples": 500, "random_state": 1}
+observable = Observable(PauliString("XZ"), PauliString("YY"))
+```
 
+```{code-cell} ipython3
+:tags: ["skip-execution"]
 training_circuits = generate_training_circuits(
     circuit=circuit,
     num_training_circuits=5,
     fraction_non_clifford=0.2,
     random_state=np.random.RandomState(1),
 )
-
-observable = Observable(PauliString("XZ"), PauliString("YY"))
 
 ideal_values = np.array(ideal_executor.evaluate(training_circuits, observable))
 


### PR DESCRIPTION
## Description

Fixes #1621.

Use saved image for plot instead of loss fn loop

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file