### PR TITLE
Revert "Update pennylane requirement from ~=0.27.0 to ~=0.28.0"

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,7 +2,7 @@
 qiskit~=0.39.4
 pyquil~=3.3.2
 pennylane-qiskit~=0.27.0
-pennylane~=0.28.0
+pennylane~=0.27.0
 amazon-braket-sdk~=1.35.1
 
 # Unit tests, coverage, and formatting/style.


### PR DESCRIPTION
Reverts unitaryfund/mitiq#1640

There's a dependency conflict I didn't catch. In particular 0.28 of pennylane, wants numpy < 1.24. We just upgraded to numpy 1.24.

GitHub does not allow for one to review their own PRs, to assigning @andreamari since he'll likely be able to see this and merge it asap.