### PR TITLE
Fix bug for Qiskit circuits with idle qubits

### DIFF
--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -234,7 +234,6 @@ def noise_scaling_converter(
     ) -> QPROGRAM:
 
         # Pre atomic conversion
-        idle_indices = set()
         if "qiskit" in circuit.__module__:
             from mitiq.interface.mitiq_qiskit.conversions import (
                 _add_identity_to_idle,
@@ -247,7 +246,7 @@ def noise_scaling_converter(
             circuit = RemoveBarriers()(circuit)
             # Apply identity gates to idle qubits otherwise they get lost
             # when converting to Cirq. Eventually, identities will be removed.
-            idle_indices = _add_identity_to_idle(circuit)
+            idle_qubits = _add_identity_to_idle(circuit)
 
         scaled_circuit = atomic_converter(noise_scaling_function)(
             circuit, *args, **kwargs
@@ -304,7 +303,7 @@ def noise_scaling_converter(
                 scaled_circuit,
                 new_qregs=circuit.qregs,  # type: ignore
             )
-            _remove_identity_from_idle(scaled_circuit, idle_indices)
+            _remove_identity_from_idle(scaled_circuit, idle_qubits)
             if circuit.cregs and not scaled_circuit.cregs:  # type: ignore
                 scaled_circuit.add_register(*circuit.cregs)  # type: ignore
 

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -254,7 +254,7 @@ def noise_scaling_converter(
 
         # Post atomic conversion
         # PyQuil: Restore declarations, measurements, and metadata.
-        if "pyquil" in scaled_circuit.__module__:
+        if "pyquil" in circuit.__module__:
             from pyquil import Program
             from pyquil.quilbase import Declare, Measurement
 
@@ -291,7 +291,7 @@ def noise_scaling_converter(
             scaled_circuit.num_shots = circuit.num_shots
 
         # Qiskit: Keep the same register structure and measurement order.
-        if "qiskit" in scaled_circuit.__module__:
+        if "qiskit" in circuit.__module__:
             from mitiq.interface.mitiq_qiskit.conversions import (
                 _transform_registers,
                 _measurement_order,

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -254,7 +254,7 @@ def noise_scaling_converter(
 
         # Post atomic conversion
         # PyQuil: Restore declarations, measurements, and metadata.
-        if "pyquil" in circuit.__module__:
+        if "pyquil" in scaled_circuit.__module__:
             from pyquil import Program
             from pyquil.quilbase import Declare, Measurement
 
@@ -291,7 +291,7 @@ def noise_scaling_converter(
             scaled_circuit.num_shots = circuit.num_shots
 
         # Qiskit: Keep the same register structure and measurement order.
-        if "qiskit" in circuit.__module__:
+        if "qiskit" in scaled_circuit.__module__:
             from mitiq.interface.mitiq_qiskit.conversions import (
                 _transform_registers,
                 _measurement_order,

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -167,9 +167,8 @@ def _remove_identity_from_idle(
         if gate.name == "id" and set(qubits).intersection(idle_qubits):
             to_delete_indices.append(index)
     # Traverse data from list end to preserve index
-    for index in to_delete_indices[-1:]:
+    for index in to_delete_indices[::-1]:
         del circuit._data[index]
-
 
 def _measurement_order(
     circuit: qiskit.QuantumCircuit,

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -154,8 +154,8 @@ def _remove_identity_from_idle(
 ) -> None:
     """Removes identities from the circuit corresponding to the input
     idle qubits.
-    Used in conjunction with _add_identity_to_idle to preserve idle qubits and
-    indices in conversion.
+    Used in conjunction with _add_identity_to_idle to preserve idle qubits in
+    conversion.
 
     Args:
         circuit: Qiskit circuit to have identities removed

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -120,7 +120,7 @@ def _map_qubits(
 
 def _add_identity_to_idle(
     circuit: qiskit.QuantumCircuit,
-) -> Set[int]:
+) -> Set[qiskit.circuit.Qubit]:
     """Adds identities to idle qubits in the circuit and returns the altered
     indices. Used to preserve idle qubits and indices in conversion.
 
@@ -133,45 +133,42 @@ def _add_identity_to_idle(
     Note: An idle qubit is a qubit without any gates (including Qiskit
         barriers) acting on it.
     """
+    all_qubits = set(circuit.qubits)
+    used_qubits = set()
+    idle_qubits = set()
+    # Get used qubits
+    for op in circuit.data:
+        _, qubits, _ = op
+        used_qubits.update(set(qubits))
+    idle_qubits = all_qubits - used_qubits
+    # Modify input circuit applying I to idle qubits
+    for q in idle_qubits:
+        circuit.i(q)
 
-    data = copy.deepcopy(circuit._data)
-    bit_indices = set()
-    idle_bit_indices = set()
-    for op in data:
-        gate, qubits, cbits = op
-        bit_indices.update(set(bit.index for bit in qubits))
-    for index in range(circuit.num_qubits):
-        if index not in bit_indices:
-            idle_bit_indices.add(index)
-            circuit.i(index)
-    return idle_bit_indices
+    return idle_qubits
 
 
 def _remove_identity_from_idle(
     circuit: qiskit.QuantumCircuit,
-    idle_indices: Set[int],
+    idle_qubits: Set[qiskit.circuit.Qubit],
 ) -> None:
-    """Removes identities from the circuit corresponding to the set of indices.
+    """Removes identities from the circuit corresponding to the input
+    idle qubits.
     Used in conjunction with _add_identity_to_idle to preserve idle qubits and
     indices in conversion.
 
     Args:
         circuit: Qiskit circuit to have identities removed
-        idle_indices: Set of altered idle qubit indices
+        idle_indices: Set of altered idle qubits.
     """
-    index_list: List[int] = []
-    data = copy.deepcopy(circuit._data)
-    for target_index, op in enumerate(data):
-        bit_indices = set()
+    to_delete_indices: List[int] = []
+    for index, op in enumerate(circuit._data):
         gate, qubits, cbits = op
-        bit_indices.update(set(bit.index for bit in qubits))
-        if gate.name == "id" and bit_indices.intersection(idle_indices):
-            # Reverse index list order for data index preservation
-            index_list.insert(0, target_index)
+        if gate.name == "id" and set(qubits).intersection(idle_qubits):
+            to_delete_indices.append(index)
     # Traverse data from list end to preserve index
-    for target_index in index_list:
-        del data[target_index]
-    circuit._data = data
+    for index in to_delete_indices[-1:]:
+        del circuit._data[index]
 
 
 def _measurement_order(

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -170,6 +170,7 @@ def _remove_identity_from_idle(
     for index in to_delete_indices[::-1]:
         del circuit._data[index]
 
+
 def _measurement_order(
     circuit: qiskit.QuantumCircuit,
 ) -> List[Tuple[Any, ...]]:

--- a/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -35,6 +35,25 @@ from mitiq.interface.mitiq_qiskit.conversions import (
     _add_identity_to_idle,
     _remove_identity_from_idle,
 )
+from mitiq.interface import convert_to_mitiq
+from mitiq.utils import _equal
+
+
+def _multi_reg_circuits():
+    """Returns a circuit with multiple registers
+    and an equivalent circuit with a single register."""
+    qregs = [qiskit.QuantumRegister(1, f"q{j}") for j in range(4)]
+    circuit_multi_reg = qiskit.QuantumCircuit(*qregs)
+    for q in qregs[1:]:
+        circuit_multi_reg.x(q)
+        circuit_multi_reg.x(3)
+    qreg = qiskit.QuantumRegister(4, "q")
+    circuit_single_reg = qiskit.QuantumCircuit(qreg)
+    for q in qreg[1:]:
+        circuit_single_reg.x(q)
+        circuit_single_reg.x(3)
+
+    return circuit_multi_reg, circuit_single_reg
 
 
 def test_remove_qasm_barriers():
@@ -373,13 +392,15 @@ def test_add_identity_to_idle():
     circuit = qiskit.QuantumCircuit(9)
     circuit.x([0, 8])
     circuit.cx(0, 8)
-    idle_indices = _add_identity_to_idle(circuit)
-    id_indices = []
+    expected_idle_qubits = circuit.qubits[1:-1]
+
+    idle_qubits = _add_identity_to_idle(circuit)
+    id_qubits = []
     for gates, qubits, cargs in circuit.get_instructions("id"):
         for qubit in qubits:
-            id_indices.append(qubit.index)
-    assert idle_indices == set(range(1, 8))
-    assert id_indices == sorted(idle_indices)
+            id_qubits.append(qubit)
+    assert idle_qubits == set(expected_idle_qubits)
+    assert set(id_qubits) == idle_qubits
 
 
 def test_remove_identity_from_idle():
@@ -393,3 +414,33 @@ def test_remove_identity_from_idle():
         for qubit in qubits:
             id_indices.append(qubit.index)
     assert id_indices == []
+
+
+def test_add_identity_to_idle_with_multiple_registers():
+    """Tests idle qubits are correctly detected even with multiple registers."""
+    circuit_multi_reg, circuit_single_reg = _multi_reg_circuits()
+    _add_identity_to_idle(circuit_multi_reg)
+    _add_identity_to_idle(circuit_single_reg)
+
+    # The result should be the same for both types of registers
+    assert _equal(
+        convert_to_mitiq(circuit_multi_reg)[0],
+        convert_to_mitiq(circuit_single_reg)[0],
+        require_qubit_equality=False,  # Qubit names can be different
+    )
+
+
+def test_remove_identity_from_idle_with_multiple_registers():
+    """Tests identities are correctly removed even with multiple registers."""
+    circuit_multi_reg, circuit_single_reg = _multi_reg_circuits()
+
+    idle_qubits_multi = _add_identity_to_idle(circuit_multi_reg.copy())
+    idle_qubits_single = _add_identity_to_idle(circuit_single_reg.copy())
+
+    _remove_identity_from_idle(circuit_multi_reg, idle_qubits_multi)
+    _remove_identity_from_idle(circuit_single_reg, idle_qubits_single)
+
+    # Adding and removing identities should preserve the input
+    input_multi, input_single = _multi_reg_circuits()
+    assert circuit_multi_reg == input_multi
+    assert circuit_single_reg == input_single

--- a/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -36,7 +36,6 @@ from mitiq.interface.mitiq_qiskit.conversions import (
     _remove_identity_from_idle,
 )
 from mitiq.interface import convert_to_mitiq
-from mitiq.utils import _equal
 
 
 def _multi_reg_circuits():
@@ -417,7 +416,7 @@ def test_remove_identity_from_idle():
 
 
 def test_add_identity_to_idle_with_multiple_registers():
-    """Tests idle qubits are correctly detected even with multiple registers."""
+    """Tests idle qubits are correctly detected even with many registers."""
     circuit_multi_reg, circuit_single_reg = _multi_reg_circuits()
     _add_identity_to_idle(circuit_multi_reg)
     _add_identity_to_idle(circuit_single_reg)
@@ -431,7 +430,7 @@ def test_add_identity_to_idle_with_multiple_registers():
 
 
 def test_remove_identity_from_idle_with_multiple_registers():
-    """Tests identities are correctly removed even with multiple registers."""
+    """Tests identities are correctly removed even with many registers."""
     circuit_multi_reg, circuit_single_reg = _multi_reg_circuits()
 
     idle_qubits_multi = _add_identity_to_idle(circuit_multi_reg.copy())


### PR DESCRIPTION
- Fixes #1255

The problem was caused by using integer indices for identifying idle qubits.
The problem is now fixed by using `qiskit.circuit.Qubit` objects instead of integer indeces.

The implemented solution doesn't use a Qiskit Transpiler pass as originally discussed, due to the 
complexity of defining a custom transpiler.   

### License

- [x ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.