### PR TITLE
Fix typo in `ddd_tutorial.myst`

### DIFF
--- a/docs/source/examples/ddd_tutorial.myst
+++ b/docs/source/examples/ddd_tutorial.myst
@@ -99,7 +99,7 @@ We will use a subgraph of the device, and our first step is picking a subgraph w
 Now that we have the device graph, we can generate a mirror circuit and the bitstring it should sample as follows.
 
 ```{code-cell} ipython3
-def get_circuit(depth: int, seed: int) -> Tuple[cirq.Circuit, List[int]:
+def get_circuit(depth: int, seed: int) -> Tuple[cirq.Circuit, List[int]]:
     circuit, correct_bitstring = benchmarks.generate_mirror_circuit(
         nlayers=depth,
         two_qubit_gate_prob=1.0,


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.

  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.

  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

Add missing bracket in type hint of `get_circuit `

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file