### PR TITLE
Uprade python support to 3.11

### DIFF
--- a/.github/workflows/asv.yaml
+++ b/.github/workflows/asv.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.11"
 
       - name: Run benchmarks
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.11"
 
       - name: Install ASV
         run: pip install asv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.11"
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.11"
 
       - name: Install Python dependencies
         run: |
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.11"
       - name: Install Mitiq
         run: |
           python -m pip install --upgrade pip
@@ -88,7 +88,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.11"
       - name: Install Mitiq
         run: |
           python -m pip install --upgrade pip
@@ -106,7 +106,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out mitiq
@@ -130,7 +130,7 @@ jobs:
         run: make test-all
       - name: Submit coverage report to Codecov
         # Only submit to Codecov once.
-        if: ${{ matrix.python-version == '3.10' }}
+        if: ${{ matrix.python-version == '3.11' }}
         uses: codecov/codecov-action@v3.1.2
         with:
           fail_ci_if_error: true
@@ -140,7 +140,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out mitiq

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,23 +14,23 @@ jobs:
     if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
     steps:
-    - name: Check out mitiq
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.ref }}
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        make install requirements
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+      - name: Check out mitiq
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make install requirements
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -5,45 +5,45 @@ name: Nightly Upload to Test PyPI
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   deploy:
     if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
     steps:
-    - name: Check out mitiq
-      uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        make install requirements
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.TESTPYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.TESTPYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload --repository testpypi dist/*
+      - name: Check out mitiq
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make install requirements
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.TESTPYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TESTPYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload --repository testpypi dist/*
 
   # TODO: Need a way to get the version number from previous step
   # download-test:
-    # runs-on: ubuntu-latest
-    # steps:
-    # - name: Check out mitiq
-      # uses: actions/checkout@v3
-    # - name: Set up Python
-      # uses: actions/setup-python@v4
-      # with:
-        # python-version: 3.8
-    # - name: Install Mitiq
-    # The ``--extra-index-url`` is necessary since otherwise ``TestPyPI``  would be
-    # looking for the required dependencies therein, but we want it to install them
-    # from the real PyPI channel.
-    #   run: |
-    #     pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.python.org/simple/ mitiq==x.y.z
+  # runs-on: ubuntu-latest
+  # steps:
+  # - name: Check out mitiq
+  # uses: actions/checkout@v3
+  # - name: Set up Python
+  # uses: actions/setup-python@v4
+  # with:
+  # python-version: 3.8
+  # - name: Install Mitiq
+  # The ``--extra-index-url`` is necessary since otherwise ``TestPyPI``  would be
+  # looking for the required dependencies therein, but we want it to install them
+  # from the real PyPI channel.
+  #   run: |
+  #     pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.python.org/simple/ mitiq==x.y.z

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,7 +4,7 @@
   "project_url": "https://github.com/unitaryfund/mitiq",
   "repo": "https://github.com/unitaryfund/mitiq.git",
   "branches": ["master"],
-  "pythons": ["3.10"],
+  "pythons": ["3.11"],
   "environment_type": "virtualenv",
   "show_commit_url": "https://github.com/unitaryfund/mitiq/commit/"
 }

--- a/docs/source/examples/bqskit.md
+++ b/docs/source/examples/bqskit.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .myst
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.14.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 79
-target-version = ['py310']
+target-version = ['py311']
 
 [tool.pytest.ini_options]
 addopts = "--color=yes"

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "Documentation": "https://mitiq.readthedocs.io/en/stable/",
         "Source": "https://github.com/unitaryfund/mitiq/",
     },
-    python_requires=">=3.8",
+    python_requires=">=3.8,<3.12",
 )
 
 # restore _version.py to its previous state


### PR DESCRIPTION
## Description

This PR builds Mitiq using python 3.11, as well as ensuring users know our latest, supported python range via the `python_requires` keyword in `setup.py`.

resolves https://github.com/unitaryfund/mitiq/issues/1560
