### PR TITLE
Further updates related to the measurement result class

### DIFF
--- a/docs/source/guide/calibrators.md
+++ b/docs/source/guide/calibrators.md
@@ -6,7 +6,7 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.14.1
 kernelspec:
-  display_name: dev
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 ---
@@ -32,17 +32,9 @@ from mitiq import MeasurementResult
 ```{code-cell} ipython3
 def execute(circuit, noise_level=0.001):
     circuit = circuit.with_noise(cirq.amplitude_damp(noise_level))
-
     result = cirq.DensityMatrixSimulator().run(circuit, repetitions=100)
-    return MeasurementResult(
-        result=np.column_stack(list(result.measurements.values())).tolist(),
-        qubit_indices=tuple(
-            # q[2:-1] is necessary to convert "q(number)" into "number"
-            int(q[2:-1])
-            for k in result.measurements.keys()
-            for q in k.split(",")
-        ),
-    )
+    bitstrings = np.column_stack(list(result.measurements.values()))
+    return MeasurementResult(bitstrings)
 ```
 
 We can now import the required objects and functions required for calibration.

--- a/docs/source/guide/executors.myst
+++ b/docs/source/guide/executors.myst
@@ -80,7 +80,7 @@ To run a circuit of sequence of circuits, use the `Executor.evaluate` method.
 ```{code-cell} ipython3
 import cirq
 
-q = cirq.GridQubit(0, 0)
+q = cirq.LineQubit(0)
 circuit = cirq.Circuit(cirq.H.on(q))
 
 obs = Observable(PauliString("Z"))
@@ -203,7 +203,12 @@ def noisy_sampler(circuit, noise_level=0.1, shots=1000) -> MeasurementResult:
     simulator = cirq.DensityMatrixSimulator()
     result = simulator.run(circuit_to_run, repetitions=shots)
     bitstrings = np.column_stack(list(result.measurements.values()))
-    return MeasurementResult(bitstrings)
+    qubit_indices = tuple(
+            int(q[2:-1])  # Extract index from "q(index)" string
+            for k in result.measurements.keys()
+            for q in k.split(",")
+    )
+    return MeasurementResult(bitstrings, qubit_indices)
 ```
 
 ```{code-cell} ipython3
@@ -219,7 +224,7 @@ The rest of the Mitiq workflow is the same as in the case of a density matrix ex
 
 ```{code-cell} ipython3
 executor = Executor(noisy_sampler)
-obs = Observable(PauliString("Z"))
+obs = Observable(PauliString("X"))
 results = executor.evaluate(circuit, obs)
 
 print("Results:", results)

--- a/docs/source/guide/executors.myst
+++ b/docs/source/guide/executors.myst
@@ -4,7 +4,7 @@ jupytext:
     extension: .myst
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.12.0
+    jupytext_version: 1.14.1
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -183,4 +183,47 @@ print(f"ZNE value: {zne_value :g}")
 print("Calls to executor:", batched_executor.calls_to_executor)
 print("\nExecuted circuits:\n", *batched_executor.executed_circuits, sep="\n")
 print("\nQuantum results:\n", *batched_executor.quantum_results, sep="\n")
+```
+
+## Defining an `Executor` that returns measurement outcomes (bitstrings)
+
++++
+
+In the previous examples we have shown executors that return the density matrix of the final state. This is possible only for classical simulations.
+The typical result of a real quantum computation is instead a list of bitstrings corresponding to the ("0" or "1") outcomes obtained when measuring each qubit in the computational basis.
+In Mitiq this type of quantum backend is captured by an {class}`.Executor` that returns a {class}`.MeasurementResult` object.
+
+For example, here is an example of a Cirq executor function that returns raw measurement outcomes:
+
+```{code-cell} ipython3
+from mitiq import MeasurementResult
+
+def noisy_sampler(circuit, noise_level=0.1, shots=1000) -> MeasurementResult:
+    circuit_to_run = circuit.with_noise(cirq.depolarize(noise_level))
+    simulator = cirq.DensityMatrixSimulator()
+    result = simulator.run(circuit_to_run, repetitions=shots)
+    bitstrings = np.column_stack(list(result.measurements.values()))
+    return MeasurementResult(bitstrings)
+```
+
+```{code-cell} ipython3
+# Circuit with measurements to test the noisy_sampler function
+circuit_with_measurements = circuit.copy()
+circuit_with_measurements.append(cirq.measure(*circuit.all_qubits()))
+
+print("Circuit to execute:", circuit_with_measurements)
+noisy_sampler(circuit_with_measurements)
+```
+
+The rest of the Mitiq workflow is the same as in the case of a density matrix executor. For example:
+
+```{code-cell} ipython3
+executor = Executor(noisy_sampler)
+obs = Observable(PauliString("Z"))
+results = executor.evaluate(circuit, obs)
+
+print("Results:", results)
+print("Calls to executor:", executor.calls_to_executor)
+print("\nExecuted circuits:\n", *executor.executed_circuits, sep="\n")
+print("\nQuantum results:\n", *executor.quantum_results, sep="\n")
 ```

--- a/docs/source/guide/rem-1-intro.myst
+++ b/docs/source/guide/rem-1-intro.myst
@@ -35,7 +35,7 @@ from mitiq.observable.observable import Observable
 from mitiq.observable.pauli import PauliString
 
 qreg = [LineQubit(i) for i in range(2)]
-circuit = Circuit(X.on_each(*qreg), measure_each(*qreg))
+circuit = Circuit(X.on_each(*qreg))
 observable = Observable(PauliString("ZI"), PauliString("IZ"))
 
 print(circuit)
@@ -67,10 +67,8 @@ def noisy_readout_executor(
     # Replace with code based on your frontend and backend.
     simulator = NoisySingleQubitReadoutSampler(p0, p1)
     result = simulator.run(circuit, repetitions=shots)
-
-    return MeasurementResult(
-        result=np.column_stack(list(result.measurements.values()))
-    )
+    bitstrings = np.column_stack(list(result.measurements.values()))
+    return MeasurementResult(bitstrings, qubit_indices = (0, 1))
 ```
 
 The [executor](executors.myst) can be used to evaluate noisy (unmitigated)
@@ -103,9 +101,11 @@ from mitiq import rem
 # you can supply your own confusion matrices and invert them using the helper
 # function generate_tensored_inverse_confusion_matrix().
 inverse_confusion_matrix = generate_inverse_confusion_matrix(2, p_flip, p_flip)
+circuit_with_measurements = circuit.copy()
+circuit_with_measurements.append(measure_each(*qreg))
 
 mitigated_result = rem.execute_with_rem(
-    circuit,
+    circuit_with_measurements,
     noisy_executor,
     observable,
     inverse_confusion_matrix=inverse_confusion_matrix,

--- a/docs/source/guide/rem-1-intro.myst
+++ b/docs/source/guide/rem-1-intro.myst
@@ -4,7 +4,7 @@ jupytext:
     extension: .myst
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.11.1
+    jupytext_version: 1.14.1
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -20,7 +20,6 @@ import mitiq
 
 mitiq.SUPPORTED_PROGRAM_TYPES.keys()
 ```
-
 
 ## Problem setup
 In this example we will simulate a noisy device that flips qubits just before
@@ -70,13 +69,7 @@ def noisy_readout_executor(
     result = simulator.run(circuit, repetitions=shots)
 
     return MeasurementResult(
-        result=np.column_stack(list(result.measurements.values())),
-        qubit_indices=tuple(
-            # q[2:-1] is necessary to convert "q(number)" into "number"
-            int(q[2:-1])
-            for k in result.measurements.keys()
-            for q in k.split(",")
-        ),
+        result=np.column_stack(list(result.measurements.values()))
     )
 ```
 

--- a/mitiq/tests/test_measurement_result.py
+++ b/mitiq/tests/test_measurement_result.py
@@ -148,3 +148,16 @@ def test_measurement_repr_():
     )
     assert repr(result) == expected
     assert str(result) == expected
+
+
+def test_measurement_result_prob_distribution():
+    """Test initialization from a dictionary of counts."""
+    int_bitstrings = [[0, 0], [0, 1], [0, 1], [0, 1]]
+    result = MeasurementResult(
+        result=int_bitstrings,
+        qubit_indices=(1, 20),
+    )
+    dist = result.prob_distribution()
+    assert len(dist) == 2
+    assert np.isclose(dist["00"], 0.25)
+    assert np.isclose(dist["01"], 0.75)

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -92,11 +92,11 @@ class MeasurementResult:
             is the bitstring length deduced from ``result``.
 
     Note:
-        Using the default option for ``qubit_indeces`` can be
-        dangerous, especially when estimating an :class:`.Observable`
+        Use caution when selecting the default option for ``qubit_indices``,
+        especially when estimating an :class:`.Observable`
         acting on a subset of qubits. In this case Mitiq
         only applies measurement gates to the specific qubits and, therefore,
-        it is essential to specify the corresponding ``qubit_indeces``.
+        it is essential to specify the corresponding ``qubit_indices``.
     """
 
     result: Sequence[Bitstring]

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -146,7 +146,7 @@ class MeasurementResult:
         strings = ["".join(map(str, bits)) for bits in self.result]
         return dict(Counter(strings))
 
-    def prob_distribution(self) -> Dict[str, int]:
+    def prob_distribution(self) -> Dict[str, float]:
         """Returns a Python dictionary whose keys are the measured
         bitstrings and whose values are their empirical frequencies.
         """

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -76,7 +76,16 @@ Bitstring = Union[str, List[int]]
 
 @dataclass
 class MeasurementResult:
-    """Bitstrings sampled from a quantum computer."""
+    """Bitstrings sampled from a quantum computer.
+
+    Args:
+        result: The sequence of measured bitstrings.
+        qubit_indeces: The qubit indices associated to each
+            bit in a bitstring (from left to right).
+            If not given, Mitiq assumes the default ordering
+            ``tuple(range(self.nqubits))``, where ``self.nqubits``
+            is the bitstring length deduced from ``result``.
+    """
 
     result: Sequence[Bitstring]
     qubit_indices: Optional[Tuple[int, ...]] = None

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -76,15 +76,27 @@ Bitstring = Union[str, List[int]]
 
 @dataclass
 class MeasurementResult:
-    """Bitstrings sampled from a quantum computer.
+    """Mitiq object for collecting the bitstrings sampled from a quantum
+    computer when executing a circuit. This is one of the possible types
+    (see :class:`~mitiq.typing.QuantumResult`) that an
+    :class:`.Executor` can return.
 
     Args:
-        result: The sequence of measured bitstrings.
-        qubit_indeces: The qubit indices associated to each
+        result:
+            The sequence of measured bitstrings.
+        qubit_indices:
+            The qubit indices associated to each
             bit in a bitstring (from left to right).
             If not given, Mitiq assumes the default ordering
             ``tuple(range(self.nqubits))``, where ``self.nqubits``
             is the bitstring length deduced from ``result``.
+
+    Note:
+        Using the default option for ``qubit_indeces`` can be
+        dangerous, especially when estimating an :class:`.Observable`
+        acting on a subset of qubits. In this case Mitiq
+        only applies measurement gates to the specific qubits and, therefore,
+        it is essential to specify the corresponding ``qubit_indeces``.
     """
 
     result: Sequence[Bitstring]

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -146,6 +146,12 @@ class MeasurementResult:
         strings = ["".join(map(str, bits)) for bits in self.result]
         return dict(Counter(strings))
 
+    def prob_distribution(self) -> Dict[str, int]:
+        """Returns a Python dictionary whose keys are the measured
+        bitstrings and whose values are their empirical frequencies.
+        """
+        return {k: v / self.shots for k, v in self.get_counts().items()}
+
     def to_dict(self) -> Dict[str, Any]:
         """Exports data to a Python dictionary.
 


### PR DESCRIPTION
This PR has two main updates:

- A new section on the Executor docs, about executors that return measurement results.
- A new method for MeasurementResult that returns a probability distribution instead of counts.
- Simplification of a couple of executors defined in the docs.

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
