### PR TITLE
upgrade `_run` to a public function

### DIFF
--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -235,7 +235,7 @@ def convert_to_expval_executor(
         bitstring_to_measure = bitstring
 
     def expval_executor(circuit: cirq.Circuit) -> float:
-        raw = cast(MeasurementResult, executor._run([circuit])[0]).result
+        raw = cast(MeasurementResult, executor.run([circuit])[0]).result
         raw = cast(List[List[int]], raw)
         bitstring_distribution = bitstrings_to_distribution(raw)
         return bitstring_distribution.get(bitstring_to_measure, 0)

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -187,7 +187,7 @@ class Executor:
             result_step = 1
 
         # Run all required circuits.
-        all_results = self._run(all_circuits, force_run_all, **kwargs)
+        all_results = self.run(all_circuits, force_run_all, **kwargs)
 
         # Parse the results.
         if self._executor_return_type in FloatLike:
@@ -221,7 +221,7 @@ class Executor:
 
         return results  # type: ignore[return-value]
 
-    def _run(
+    def run(
         self,
         circuits: Sequence[QPROGRAM],
         force_run_all: bool = False,
@@ -233,8 +233,8 @@ class Executor:
         Args:
             circuits: Sequence of circuits to execute using the executor.
             force_run_all: If True, force every circuit in the input sequence
-            to be executed (if some are identical). Else, detects identical
-            circuits and runs a minimal set.
+                to be executed (if some are identical). Else, detects identical
+                circuits and runs a minimal set.
         """
         start_result_index = len(self._quantum_results)
 
@@ -312,10 +312,10 @@ class Executor:
         The executor is detected as "batched" if and only if it is annotated
         with a return type that is one of the following:
 
-            * ``Iterable[QuantumResult]``
-            * ``List[QuantumResult]``
-            * ``Sequence[QuantumResult]``
-            * ``Tuple[QuantumResult]``
+        * ``Iterable[QuantumResult]``
+        * ``List[QuantumResult]``
+        * ``Sequence[QuantumResult]``
+        * ``Tuple[QuantumResult]``
 
         Otherwise, it is considered "serial".
 
@@ -325,10 +325,10 @@ class Executor:
         Args:
             executor: A "serial executor" (1) or a "batched executor" (2).
 
-                (1) A function which inputs a single ``QPROGRAM`` and outputs a
-                single ``QuantumResult``.
-                (2) A function which inputs a list of ``QPROGRAM``s and outputs
-                a list of ``QuantumResult``s (one for each ``QPROGRAM``).
+                #. A function which inputs a single ``QPROGRAM`` and outputs a
+                   single ``QuantumResult``.
+                #. A function which inputs a list of ``QPROGRAM``\s and outputs
+                   a list of ``QuantumResult``\s (one for each ``QPROGRAM``).
 
         Returns:
             True if the executor is detected as batched, else False.

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -327,8 +327,9 @@ class Executor:
 
                 #. A function which inputs a single ``QPROGRAM`` and outputs a
                    single ``QuantumResult``.
-                #. A function which inputs a list of ``QPROGRAM``\s and outputs
-                   a list of ``QuantumResult``\s (one for each ``QPROGRAM``).
+                #. A function which inputs a list of ``QPROGRAM`` objects and
+                   returns a list of ``QuantumResult`` instances (one for each
+                   ``QPROGRAM``).
 
         Returns:
             True if the executor is detected as batched, else False.

--- a/mitiq/executor/tests/test_executor.py
+++ b/mitiq/executor/tests/test_executor.py
@@ -117,7 +117,7 @@ def test_executor_non_hermitian_observable():
 def test_run_executor_identical_circuits_batched(ncircuits, executor):
     collector = Executor(executor=executor, max_batch_size=10)
     circuits = [cirq.Circuit(cirq.H(cirq.LineQubit(0)))] * ncircuits
-    results = collector._run(circuits)
+    results = collector.run(circuits)
 
     assert np.allclose(results, np.zeros(ncircuits))
     assert collector.calls_to_executor == 1
@@ -134,7 +134,7 @@ def test_run_executor_nonidentical_pyquil_programs(batch_size):
         pyquil.Program(pyquil.gates.X(0)),
         pyquil.Program(pyquil.gates.H(0)),
     ] * 10
-    results = collector._run(circuits)
+    results = collector.run(circuits)
 
     assert np.allclose(results, np.zeros(len(circuits)))
     if batch_size == 1:
@@ -156,7 +156,7 @@ def test_run_executor_all_unique(ncircuits, batch_size):
         )
         for _ in range(ncircuits)
     ]
-    results = collector._run(circuits)
+    results = collector.run(circuits)
 
     assert np.allclose(results, np.zeros(ncircuits))
     assert collector.calls_to_executor == np.ceil(ncircuits / batch_size)
@@ -171,7 +171,7 @@ def test_run_executor_force_run_all_serial_executor_identical_circuits(
     assert not collector.can_batch
 
     circuits = [cirq.Circuit(cirq.H(cirq.LineQubit(0)))] * ncircuits
-    results = collector._run(circuits, force_run_all=force_run_all)
+    results = collector.run(circuits, force_run_all=force_run_all)
 
     assert np.allclose(results, np.zeros(ncircuits))
     if force_run_all:
@@ -192,7 +192,7 @@ def test_run_executor_preserves_order(s, b):
     ]
     batch = choices(circuits, k=s)
 
-    assert np.allclose(collector._run(batch), executor_batched_unique(batch))
+    assert np.allclose(collector.run(batch), executor_batched_unique(batch))
 
 
 @pytest.mark.parametrize(

--- a/mitiq/rem/rem.py
+++ b/mitiq/rem/rem.py
@@ -50,7 +50,7 @@ def execute_with_rem(
     if not isinstance(executor, Executor):
         executor = Executor(executor)
 
-    result = executor._run([circuit])
+    result = executor.run([circuit])
     noisy_result = result[0]
     if not isinstance(noisy_result, MeasurementResult):
         raise TypeError("Results are not of type MeasurementResult.")


### PR DESCRIPTION
## Description

Upgrade the `_run` function which, like the commonly used [`evaluate`](https://github.com/unitaryfund/mitiq/blob/ecfbfa5481b54ffdc82273a0a3da5251308da50c/mitiq/executor/executor.py#L119) method, runs all of the circuits, but does not post-process the results. The capability to run a series of circuits, without post-processing is potentially useful to users. This PR makes it "public", which includes the function in the API-doc.

resolves https://github.com/unitaryfund/mitiq/issues/1639

Also fixed a few minor docstrings issues while I was poking around here.