### PR TITLE
Upgrade to qiskit 0.41.0 manually after failed dependabot PR

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 # Third-party integration.
-qiskit~=0.40.0
+qiskit~=0.41.0
 pyquil~=3.3.3
 pennylane-qiskit~=0.28.0
 pennylane~=0.28.0

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -184,7 +184,7 @@
   title     = {Hybrid Quantum-Classical Algorithms and Quantum Error Mitigation},
   volume    = {90},
   issn      = {1347-4073},
-  url       = {http://dx.doi.org/10.7566/JPSJ.90.032001},
+  url       = {https://doi.org/10.7566/JPSJ.90.032001},
   doi       = {10.7566/jpsj.90.032001},
   number    = {3},
   journal   = {Journal of the Physical Society of Japan},


### PR DESCRIPTION
## Description

Upgrade to qiskit 0.41.0 manually after failed dependabot PR. Dependabot PR #1697 rebased and then failed on Codecov. Appears unrelated to actual upgrade, so attempting 0.41.0 upgrade manually.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file