### PR TITLE
Remove unnecessary circuit conversion in PEC

### DIFF
--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -30,11 +30,8 @@ from functools import wraps
 import warnings
 import numpy as np
 
-from cirq import Circuit as CirqCircuit
-
 from mitiq import Executor, Observable, QPROGRAM, QuantumResult
 from mitiq.pec import sample_circuit, OperationRepresentation
-from mitiq.interface import convert_to_mitiq, convert_from_mitiq
 
 
 class LargeSampleWarning(Warning):
@@ -118,7 +115,6 @@ def execute_with_pec(
             "The value of 'precision' should be within the interval (0, 1],"
             f" but precision is {precision}."
         )
-
 
     # Get the 1-norm of the circuit quasi-probability representation
     _, _, norm = sample_circuit(

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -119,11 +119,10 @@ def execute_with_pec(
             f" but precision is {precision}."
         )
 
-    converted_circuit, input_type = convert_to_mitiq(circuit)
 
     # Get the 1-norm of the circuit quasi-probability representation
     _, _, norm = sample_circuit(
-        converted_circuit,
+        circuit,
         representations,
         num_samples=1,
     )
@@ -138,17 +137,11 @@ def execute_with_pec(
 
     # Sample all the circuits
     sampled_circuits, signs, _ = sample_circuit(
-        converted_circuit,
+        circuit,
         representations,
         random_state=random_state,
         num_samples=num_samples,
     )
-
-    # Convert back to the original type
-    sampled_circuits = [
-        convert_from_mitiq(cast(CirqCircuit, c), input_type)
-        for c in sampled_circuits
-    ]
 
     # Execute all sampled circuits
     if not isinstance(executor, Executor):


### PR DESCRIPTION
## Description

Fixes #1634 

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file