### PR TITLE
Simplify noisy operation

### DIFF
--- a/mitiq/pec/representations/tests/test_biased_noise.py
+++ b/mitiq/pec/representations/tests/test_biased_noise.py
@@ -211,7 +211,7 @@ def test_biased_noise_representation_with_choi(
     ]
 
     for noisy_op, coeff in op_rep.basis_expansion.items():
-        implementable_circ = noisy_op.circuit()
+        implementable_circ = noisy_op.circuit
         # Apply noise after each sequence.
         # NOTE: noise is not applied after each operation.
         biased_op = ops.MixedUnitaryChannel(mix).on_each(*qreg)

--- a/mitiq/pec/representations/tests/test_damping.py
+++ b/mitiq/pec/representations/tests/test_damping.py
@@ -67,7 +67,7 @@ def test_amplitude_damping_representation_with_choi(
     )
     choi_components = []
     for noisy_op, coeff in op_rep.basis_expansion.items():
-        implementable_circ = noisy_op.circuit()
+        implementable_circ = noisy_op.circuit
         depolarizing_op = AmplitudeDampingChannel(noise).on(q)
         # Apply noise after each sequence.
         # NOTE: noise is not applied after each operation.

--- a/mitiq/pec/representations/tests/test_depolarizing.py
+++ b/mitiq/pec/representations/tests/test_depolarizing.py
@@ -120,7 +120,7 @@ def test_depolarizing_representation_with_choi(gate: Gate, noise: float):
     )
     choi_components = []
     for noisy_op, coeff in op_rep.basis_expansion.items():
-        implementable_circ = noisy_op.circuit()
+        implementable_circ = noisy_op.circuit
         # Apply noise after each sequence.
         # NOTE: noise is not applied after each operation.
         depolarizing_op = DepolarizingChannel(noise, len(qreg))(*qreg)
@@ -143,7 +143,7 @@ def test_local_depolarizing_representation_with_choi(gate: Gate, noise: float):
     )
     choi_components = []
     for noisy_op, coeff in op_rep.basis_expansion.items():
-        implementable_circ = noisy_op.circuit()
+        implementable_circ = noisy_op.circuit
         # The representation assume local noise on each qubit.
         depolarizing_op = DepolarizingChannel(noise).on_each(*qreg)
         # Apply noise after each sequence.

--- a/mitiq/pec/sampling.py
+++ b/mitiq/pec/sampling.py
@@ -35,7 +35,7 @@ def sample_sequence(
     representations: Sequence[OperationRepresentation],
     random_state: Optional[Union[int, np.random.RandomState]] = None,
     num_samples: int = 1,
-) -> Tuple[List[QPROGRAM], List[int], float]:
+) -> Tuple[List[Circuit], List[int], float]:
     """Samples a list of implementable sequences from the quasi-probability
     representation of the input ideal operation.
     Returns the list of sequences, the corresponding list of signs and the
@@ -84,7 +84,7 @@ def sample_sequence(
             UserWarning(f"No representation found for \n\n{ideal_operation}.")
         )
         return (
-            [ideal_operation] * num_samples,
+            [ideal] * num_samples,
             [1] * num_samples,
             1.0,
         )
@@ -97,7 +97,7 @@ def sample_sequence(
         noisy_op, sign, _ = operation_representation.sample(
             random_state  # type: ignore
         )
-        sequences.append(noisy_op.circuit())
+        sequences.append(noisy_op.circuit)
         signs.append(sign)
 
     return sequences, signs, norm

--- a/mitiq/pec/sampling.py
+++ b/mitiq/pec/sampling.py
@@ -35,7 +35,7 @@ def sample_sequence(
     representations: Sequence[OperationRepresentation],
     random_state: Optional[Union[int, np.random.RandomState]] = None,
     num_samples: int = 1,
-) -> Tuple[List[Circuit], List[int], float]:
+) -> Tuple[List[QPROGRAM], List[int], float]:
     """Samples a list of implementable sequences from the quasi-probability
     representation of the input ideal operation.
     Returns the list of sequences, the corresponding list of signs and the
@@ -84,7 +84,7 @@ def sample_sequence(
             UserWarning(f"No representation found for \n\n{ideal_operation}.")
         )
         return (
-            [ideal] * num_samples,
+            [ideal_operation] * num_samples,
             [1] * num_samples,
             1.0,
         )
@@ -97,7 +97,7 @@ def sample_sequence(
         noisy_op, sign, _ = operation_representation.sample(
             random_state  # type: ignore
         )
-        sequences.append(noisy_op.circuit)
+        sequences.append(noisy_op.native_circuit)
         signs.append(sign)
 
     return sequences, signs, norm

--- a/mitiq/pec/tests/test_pec_sampling.py
+++ b/mitiq/pec/tests/test_pec_sampling.py
@@ -51,6 +51,12 @@ from mitiq.pec.representations import (
 from mitiq.pec.channels import _operation_to_choi, _circuit_to_choi
 
 
+xcirq = Circuit(cirq.X(cirq.LineQubit(0)))
+zcirq = Circuit(cirq.Z(cirq.LineQubit(0)))
+cnotcirq = Circuit(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)))
+czcirq = Circuit(cirq.CZ(cirq.LineQubit(0), cirq.LineQubit(1)))
+
+
 def test_sample_sequence_cirq():
     circuit = Circuit(cirq.H(LineQubit(0)))
 
@@ -59,8 +65,8 @@ def test_sample_sequence_cirq():
     rep = OperationRepresentation(
         ideal=circuit,
         basis_expansion={
-            NoisyOperation.from_cirq(circuit=cirq.X): 0.5,
-            NoisyOperation.from_cirq(circuit=cirq.Z): -0.5,
+            NoisyOperation(xcirq): 0.5,
+            NoisyOperation(zcirq): -0.5,
         },
     )
 
@@ -121,8 +127,8 @@ def test_sample_sequence_cirq_random_state(seed):
     rep = OperationRepresentation(
         ideal=circuit,
         basis_expansion={
-            NoisyOperation.from_cirq(circuit=cirq.X): 0.5,
-            NoisyOperation.from_cirq(circuit=cirq.Z): -0.5,
+            NoisyOperation(xcirq): 0.5,
+            NoisyOperation(zcirq): -0.5,
         },
     )
 
@@ -147,8 +153,8 @@ def test_qubit_independent_representation_cirq(qubit):
     rep = OperationRepresentation(
         ideal=Circuit(cirq.H.on(LineQubit(qubit))),
         basis_expansion={
-            NoisyOperation.from_cirq(circuit=cirq.X): 0.5,
-            NoisyOperation.from_cirq(circuit=cirq.Z): -0.5,
+            NoisyOperation(xcirq): 0.5,
+            NoisyOperation(zcirq): -0.5,
         },
         is_qubit_dependent=False,
     )
@@ -220,8 +226,8 @@ def test_qubit_independent_representation_pyquil(qubit):
             OperationRepresentation(
                 Circuit(cirq.H.on(LineQubit(0))),
                 {
-                    NoisyOperation.from_cirq(circuit=cirq.X): 0.5,
-                    NoisyOperation.from_cirq(circuit=cirq.Z): -0.5,
+                    NoisyOperation(xcirq): 0.5,
+                    NoisyOperation(zcirq): -0.5,
                 },
             )
         ],
@@ -249,16 +255,16 @@ def test_sample_circuit_cirq(measure):
     h_rep = OperationRepresentation(
         ideal=circuit[:1],
         basis_expansion={
-            NoisyOperation.from_cirq(circuit=cirq.X): 0.6,
-            NoisyOperation.from_cirq(circuit=cirq.Z): -0.6,
+            NoisyOperation(xcirq): 0.6,
+            NoisyOperation(zcirq): -0.6,
         },
     )
 
     cnot_rep = OperationRepresentation(
         ideal=circuit[1:2],
         basis_expansion={
-            NoisyOperation.from_cirq(circuit=cirq.CNOT): 0.7,
-            NoisyOperation.from_cirq(circuit=cirq.CZ): -0.7,
+            NoisyOperation(cnotcirq): 0.7,
+            NoisyOperation(czcirq): -0.7,
         },
     )
 
@@ -282,8 +288,8 @@ def test_sample_circuit_partial_representations():
     cnot_rep = OperationRepresentation(
         ideal=circuit[1:2],
         basis_expansion={
-            NoisyOperation.from_cirq(circuit=cirq.CNOT): 0.7,
-            NoisyOperation.from_cirq(circuit=cirq.CZ): -0.7,
+            NoisyOperation(cnotcirq): 0.7,
+            NoisyOperation(czcirq): -0.7,
         },
     )
 
@@ -333,8 +339,8 @@ def test_sample_circuit_with_seed():
     rep = OperationRepresentation(
         ideal=Circuit(cirq.X.on(LineQubit(0))),
         basis_expansion={
-            NoisyOperation.from_cirq(cirq.Z): 1.0,
-            NoisyOperation.from_cirq(cirq.X): -1.0,
+            NoisyOperation(zcirq): 1.0,
+            NoisyOperation(xcirq): -1.0,
         },
     )
 

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -692,3 +692,17 @@ def test_equal_method_of_representations():
         basis_expansion={noisy_xop_b: 0.7, noisy_zop_b: 0.5},
     )
     assert rep_a != rep_b
+
+
+def test_noisy_operation_copy():
+    cnot_qiskit = qiskit.QuantumCircuit(2)
+    cnot_qiskit.cnot(0, 1)
+    matrix = np.random.rand(16, 16)
+    op_a = NoisyOperation(cnot_qiskit, matrix)
+    op_b = op_a.copy()
+    assert np.allclose(op_a.channel_matrix, op_b.channel_matrix)
+    assert op_a.num_qubits == op_b.num_qubits
+    assert op_a.qubits == op_b.qubits
+    assert op_a.circuit == op_b.circuit
+    assert op_a.native_circuit == op_b.native_circuit
+    assert str(op_a) == str(op_b)

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -692,17 +692,3 @@ def test_equal_method_of_representations():
         basis_expansion={noisy_xop_b: 0.7, noisy_zop_b: 0.5},
     )
     assert rep_a != rep_b
-
-
-def test_noisy_operation_copy():
-    cnot_qiskit = qiskit.QuantumCircuit(2)
-    cnot_qiskit.cnot(0, 1)
-    matrix = np.random.rand(16, 16)
-    op_a = NoisyOperation(cnot_qiskit, matrix)
-    op_b = op_a.copy()
-    assert np.allclose(op_a.channel_matrix, op_b.channel_matrix)
-    assert op_a.num_qubits == op_b.num_qubits
-    assert op_a.qubits == op_b.qubits
-    assert op_a.circuit == op_b.circuit
-    assert op_a.native_circuit == op_b.native_circuit
-    assert str(op_a) == str(op_b)

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -42,11 +42,11 @@ def test_init_with_cirq_circuit():
     assert isinstance(noisy_op._circuit, cirq.Circuit)
 
     assert noisy_op.qubits == (cirq.LineQubit(0),)
-    assert np.allclose(noisy_op.ideal_unitary, cirq.unitary(cirq.Z))
     assert np.allclose(noisy_op.channel_matrix, real)
     assert noisy_op.channel_matrix is not real
 
     assert noisy_op._native_type == "cirq"
+    assert _equal(zcirq, noisy_op.circuit)
     assert _equal(noisy_op._native_circuit, noisy_op.circuit)
 
 
@@ -66,11 +66,11 @@ def test_init_with_different_qubits(qubit):
         require_qubit_equality=True,
     )
     assert noisy_op.qubits == (qubit,)
-    assert np.allclose(noisy_op.ideal_unitary, cirq.unitary(ideal_op))
     assert np.allclose(noisy_op.channel_matrix, real)
     assert noisy_op.channel_matrix is not real
 
     assert noisy_op._native_type == "cirq"
+    assert _equal(cirq.Circuit(ideal_op), noisy_op.circuit)
     assert _equal(noisy_op._native_circuit, noisy_op.circuit)
 
 
@@ -83,7 +83,6 @@ def test_init_with_cirq_input():
     assert isinstance(noisy_op._circuit, cirq.Circuit)
     assert _equal(noisy_op.circuit, circ, require_qubit_equality=True)
     assert set(noisy_op.qubits) == set(qreg)
-    assert np.allclose(noisy_op.ideal_unitary, cirq.unitary(circ))
     assert np.allclose(noisy_op.channel_matrix, real)
     assert noisy_op.channel_matrix is not real
 
@@ -107,7 +106,6 @@ def test_init_with_qiskit_circuit():
     assert noisy_op._native_circuit == circ
     assert noisy_op._native_type == "qiskit"
 
-    assert np.allclose(noisy_op.ideal_unitary, cirq.unitary(cirq_circ))
     assert np.allclose(noisy_op.channel_matrix, real)
     assert noisy_op.channel_matrix is not real
 
@@ -144,7 +142,6 @@ def test_init_with_pyquil_program():
     assert noisy_op._native_circuit == circ
     assert noisy_op._native_type == "pyquil"
 
-    assert np.allclose(noisy_op.ideal_unitary, cirq.unitary(cirq_circ))
     assert np.allclose(noisy_op.channel_matrix, real)
     assert noisy_op.channel_matrix is not real
 
@@ -173,8 +170,6 @@ def test_unknown_channel_matrix():
     assert noisy_op.native_circuit == circ
     assert noisy_op._native_circuit == circ
     assert noisy_op._native_type == "qiskit"
-
-    assert np.allclose(noisy_op.ideal_unitary, cirq.unitary(cirq_circ))
 
     with pytest.raises(ValueError, match="The channel matrix is unknown."):
         _ = noisy_op.channel_matrix
@@ -212,7 +207,6 @@ def test_add_pyquil_noisy_operations():
     correct = cirq.Circuit([cirq.X.on(cirq.NamedQubit("Q"))] * 2)
 
     assert _equal(noisy_op._circuit, correct, require_qubit_equality=False)
-    assert np.allclose(noisy_op.ideal_unitary, np.identity(2))
     assert np.allclose(noisy_op.channel_matrix, real @ real)
 
 
@@ -230,7 +224,6 @@ def test_add_qiskit_noisy_operations():
     correct = cirq.Circuit([cirq.X.on(cirq.NamedQubit("Q"))] * 2)
 
     assert _equal(noisy_op._circuit, correct, require_qubit_equality=False)
-    assert np.allclose(noisy_op.ideal_unitary, np.identity(2))
     assert np.allclose(noisy_op.channel_matrix, real @ real)
 
 
@@ -498,7 +491,10 @@ def test_representation_sample_zero_coefficient():
         noisy_op, sign, coeff = decomp.sample(random_state=random_state)
         assert sign == 1
         assert coeff == 0.5
-        assert np.allclose(noisy_op.ideal_unitary, cirq.unitary(cirq.X))
+        assert np.allclose(
+            cirq.unitary(noisy_op.circuit),
+            cirq.unitary(cirq.X),
+        )
 
 
 def test_print_cirq_operation_representation():

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -101,8 +101,9 @@ def test_init_with_qiskit_circuit():
     noisy_op = NoisyOperation(circ, real)
     assert isinstance(noisy_op._circuit, cirq.Circuit)
     assert _equal(noisy_op._circuit, cirq_circ)
+    assert _equal(noisy_op.circuit, cirq_circ)
 
-    assert noisy_op.circuit == circ
+    assert noisy_op.native_circuit == circ
     assert noisy_op._native_circuit == circ
     assert noisy_op._native_type == "qiskit"
 
@@ -137,8 +138,9 @@ def test_init_with_pyquil_program():
     noisy_op = NoisyOperation(circ, real)
     assert isinstance(noisy_op._circuit, cirq.Circuit)
     assert _equal(noisy_op._circuit, cirq_circ)
+    assert _equal(noisy_op.circuit, cirq_circ)
 
-    assert noisy_op.circuit == circ
+    assert noisy_op.native_circuit == circ
     assert noisy_op._native_circuit == circ
     assert noisy_op._native_type == "pyquil"
 
@@ -166,8 +168,9 @@ def test_unknown_channel_matrix():
     noisy_op = NoisyOperation(circ)
     assert isinstance(noisy_op._circuit, cirq.Circuit)
     assert _equal(noisy_op._circuit, cirq_circ)
+    assert _equal(noisy_op.circuit, cirq_circ)
 
-    assert noisy_op.circuit == circ
+    assert noisy_op.native_circuit == circ
     assert noisy_op._native_circuit == circ
     assert noisy_op._native_type == "qiskit"
 
@@ -285,7 +288,7 @@ def test_pyquil_noisy_basis():
     assert len(noisy_basis) == 2
 
     for op in noisy_basis.elements:
-        assert isinstance(op.circuit(), pyquil.Program)
+        assert isinstance(op.native_circuit, pyquil.Program)
         assert isinstance(op._circuit, cirq.Circuit)
 
 
@@ -305,7 +308,7 @@ def test_qiskit_noisy_basis():
     assert len(noisy_basis) == 2
 
     for op in noisy_basis.elements:
-        assert isinstance(op.circuit(), qiskit.QuantumCircuit)
+        assert isinstance(op.native_circuit, qiskit.QuantumCircuit)
         assert isinstance(op._circuit, cirq.Circuit)
 
 
@@ -364,7 +367,7 @@ def test_get_sequences_simple(length):
     assert len(sequences) == len(noisy_basis) ** length
 
     for sequence in sequences:
-        assert len(sequence.circuit()) == length
+        assert len(sequence.circuit) == length
 
 
 def get_test_representation():

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -17,6 +17,7 @@ import numpy as np
 import pytest
 
 import cirq
+from cirq import Circuit
 import pyquil
 import qiskit
 
@@ -27,39 +28,40 @@ from mitiq.pec.types import (
     OperationRepresentation,
 )
 
+icirq = Circuit(cirq.I(cirq.LineQubit(0)))
+xcirq = Circuit(cirq.X(cirq.LineQubit(0)))
+ycirq = Circuit(cirq.Y(cirq.LineQubit(0)))
+zcirq = Circuit(cirq.Z(cirq.LineQubit(0)))
+hcirq = Circuit(cirq.H(cirq.LineQubit(0)))
+cnotcirq = Circuit(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)))
 
-def test_init_with_gate():
-    ideal_gate = cirq.Z
+
+def test_init_with_cirq_circuit():
     real = np.zeros(shape=(4, 4))
-    noisy_op = NoisyOperation.from_cirq(ideal_gate, real)
+    noisy_op = NoisyOperation(zcirq, real)
     assert isinstance(noisy_op._circuit, cirq.Circuit)
 
-    assert _equal(
-        noisy_op.circuit(),
-        cirq.Circuit(ideal_gate.on(cirq.LineQubit(0))),
-        require_qubit_equality=False,
-    )
     assert noisy_op.qubits == (cirq.LineQubit(0),)
     assert np.allclose(noisy_op.ideal_unitary, cirq.unitary(cirq.Z))
     assert np.allclose(noisy_op.channel_matrix, real)
     assert noisy_op.channel_matrix is not real
 
     assert noisy_op._native_type == "cirq"
-    assert _equal(noisy_op._native_circuit, noisy_op.circuit())
+    assert _equal(noisy_op._native_circuit, noisy_op.circuit)
 
 
 @pytest.mark.parametrize(
     "qubit",
     (cirq.LineQubit(0), cirq.GridQubit(1, 2), cirq.NamedQubit("Qubit")),
 )
-def test_init_with_operation(qubit):
-    ideal_op = cirq.H.on(qubit)
+def test_init_with_different_qubits(qubit):
+    ideal_op = Circuit(cirq.H.on(qubit))
     real = np.zeros(shape=(4, 4))
-    noisy_op = NoisyOperation.from_cirq(ideal_op, real)
+    noisy_op = NoisyOperation(ideal_op, real)
 
     assert isinstance(noisy_op._circuit, cirq.Circuit)
     assert _equal(
-        noisy_op.circuit(),
+        noisy_op.circuit,
         cirq.Circuit(ideal_op),
         require_qubit_equality=True,
     )
@@ -69,37 +71,17 @@ def test_init_with_operation(qubit):
     assert noisy_op.channel_matrix is not real
 
     assert noisy_op._native_type == "cirq"
-    assert _equal(noisy_op._native_circuit, noisy_op.circuit())
+    assert _equal(noisy_op._native_circuit, noisy_op.circuit)
 
 
-def test_init_with_op_tree():
-    qreg = cirq.LineQubit.range(2)
-    ideal_ops = [cirq.H.on(qreg[0]), cirq.CNOT.on(*qreg)]
-    real = np.zeros(shape=(16, 16))
-    noisy_op = NoisyOperation.from_cirq(ideal_ops, real)
-
-    assert isinstance(noisy_op._circuit, cirq.Circuit)
-    assert _equal(
-        noisy_op.circuit(),
-        cirq.Circuit(ideal_ops),
-        require_qubit_equality=True,
-    )
-    assert set(noisy_op.qubits) == set(qreg)
-    assert np.allclose(
-        noisy_op.ideal_unitary, cirq.unitary(cirq.Circuit(ideal_ops))
-    )
-    assert np.allclose(noisy_op.channel_matrix, real)
-    assert noisy_op.channel_matrix is not real
-
-
-def test_init_with_cirq_circuit():
+def test_init_with_cirq_input():
     qreg = cirq.LineQubit.range(2)
     circ = cirq.Circuit(cirq.H.on(qreg[0]), cirq.CNOT.on(*qreg))
     real = np.zeros(shape=(16, 16))
     noisy_op = NoisyOperation(circ, real)
 
     assert isinstance(noisy_op._circuit, cirq.Circuit)
-    assert _equal(noisy_op.circuit(), circ, require_qubit_equality=True)
+    assert _equal(noisy_op.circuit, circ, require_qubit_equality=True)
     assert set(noisy_op.qubits) == set(qreg)
     assert np.allclose(noisy_op.ideal_unitary, cirq.unitary(circ))
     assert np.allclose(noisy_op.channel_matrix, real)
@@ -120,7 +102,7 @@ def test_init_with_qiskit_circuit():
     assert isinstance(noisy_op._circuit, cirq.Circuit)
     assert _equal(noisy_op._circuit, cirq_circ)
 
-    assert noisy_op.circuit() == circ
+    assert noisy_op.circuit == circ
     assert noisy_op._native_circuit == circ
     assert noisy_op._native_type == "qiskit"
 
@@ -141,7 +123,7 @@ def test_init_with_qiskit_circuit():
 )
 def test_init_with_gates_raises_error(gate):
     rng = np.random.RandomState(seed=1)
-    with pytest.raises(TypeError, match="Arg `circuit` must be one of"):
+    with pytest.raises(TypeError, match="Failed to convert to an internal"):
         NoisyOperation(circuit=gate, channel_matrix=rng.rand(4, 4))
 
 
@@ -156,20 +138,13 @@ def test_init_with_pyquil_program():
     assert isinstance(noisy_op._circuit, cirq.Circuit)
     assert _equal(noisy_op._circuit, cirq_circ)
 
-    assert noisy_op.circuit() == circ
+    assert noisy_op.circuit == circ
     assert noisy_op._native_circuit == circ
     assert noisy_op._native_type == "pyquil"
 
     assert np.allclose(noisy_op.ideal_unitary, cirq.unitary(cirq_circ))
     assert np.allclose(noisy_op.channel_matrix, real)
     assert noisy_op.channel_matrix is not real
-
-
-def test_init_with_bad_types():
-    ideal_ops = [cirq.H, cirq.CNOT]
-    real = np.zeros(shape=(16, 16))
-    with pytest.raises(ValueError, match="must be cirq.CIRCUIT_LIKE"):
-        NoisyOperation.from_cirq(ideal_ops, real)
 
 
 def test_init_dimension_mismatch_error():
@@ -192,7 +167,7 @@ def test_unknown_channel_matrix():
     assert isinstance(noisy_op._circuit, cirq.Circuit)
     assert _equal(noisy_op._circuit, cirq_circ)
 
-    assert noisy_op.circuit() == circ
+    assert noisy_op.circuit == circ
     assert noisy_op._native_circuit == circ
     assert noisy_op._native_type == "qiskit"
 
@@ -277,169 +252,18 @@ def test_add_noisy_operation_no_channel_matrix():
         (noisy_op1 + noisy_op2).channel_matrix
 
 
-@pytest.mark.parametrize(
-    "qreg",
-    (
-        cirq.LineQubit.range(5),
-        cirq.GridQubit.square(5),
-        [cirq.NamedQubit(str(i)) for i in range(5)],
-    ),
-)
-@pytest.mark.parametrize("real", [np.zeros(shape=(4, 4)), None])
-def test_on_each_single_qubit(qreg, real):
-    noisy_ops = NoisyOperation.on_each(
-        cirq.X, qubits=qreg, channel_matrix=real
-    )
-
-    assert len(noisy_ops) == len(qreg)
-
-    for i, op in enumerate(noisy_ops):
-        if real is not None:
-            assert np.allclose(op.channel_matrix, real)
-        assert op.num_qubits == 1
-        assert list(op.circuit().all_qubits())[0] == qreg[i]
-
-
-@pytest.mark.parametrize(
-    "qubits",
-    (
-        [cirq.LineQubit.range(2), cirq.LineQubit.range(2, 4)],
-        [cirq.LineQubit.range(5, 7), cirq.LineQubit.range(10, 12)],
-        [cirq.GridQubit.rect(1, 2), cirq.GridQubit.rect(2, 1)],
-    ),
-)
-@pytest.mark.parametrize("real", [np.zeros(shape=(16, 16)), None])
-def test_on_each_multiple_qubits(qubits, real):
-    noisy_ops = NoisyOperation.on_each(
-        cirq.CNOT, qubits=qubits, channel_matrix=real
-    )
-    assert len(noisy_ops) == 2
-
-    for i, op in enumerate(noisy_ops):
-        if real is not None:
-            assert np.allclose(op.channel_matrix, real)
-        assert op.num_qubits == 2
-        assert set(op.qubits) == set(qubits[i])
-
-
-def test_on_each_multiple_qubits_bad_qubits_shape():
-    real_cnot = np.zeros(shape=(16, 16))
-    qubits = [cirq.LineQubit.range(3)]
-    with pytest.raises(
-        ValueError, match="Number of qubits in each register should be"
-    ):
-        NoisyOperation.on_each(
-            cirq.CNOT, qubits=qubits, channel_matrix=real_cnot
-        )
-
-
-def test_on_each_bad_types():
-    ideal = cirq.Circuit(cirq.I(cirq.LineQubit(0)))
-    real = np.identity(4)
-    with pytest.raises(TypeError, match="must be iterable"):
-        NoisyOperation.on_each(
-            ideal, qubits=cirq.NamedQubit("new"), channel_matrix=real
-        )
-
-
-@pytest.mark.parametrize(
-    "qubit", (cirq.NamedQubit("New qubit"), cirq.GridQubit(2, 3))
-)
-@pytest.mark.parametrize("real", [np.zeros(shape=(4, 4)), None])
-def test_transform_qubits_single_qubit(qubit, real):
-    gate = cirq.H
-    noisy_op = NoisyOperation.from_cirq(gate, real)
-
-    assert set(noisy_op.qubits) != {qubit}
-    noisy_op.transform_qubits(qubit)
-    assert set(noisy_op.qubits) == {qubit}
-
-
-@pytest.mark.parametrize(
-    "qubits", (cirq.LineQubit.range(4, 6), cirq.GridQubit.rect(1, 2))
-)
-@pytest.mark.parametrize("real", [np.zeros(shape=(16, 16)), None])
-def test_transform_qubits_multiple_qubits(qubits, real):
-    qreg = [cirq.NamedQubit("Dummy 1"), cirq.NamedQubit("Dummy 2")]
-    ideal = cirq.Circuit(cirq.ops.H.on(qreg[0]), cirq.ops.CNOT.on(*qreg))
-    noisy_op = NoisyOperation(ideal, real)
-
-    assert set(noisy_op.qubits) != set(qubits)
-    if real is not None:
-        assert np.allclose(noisy_op.channel_matrix, real)
-
-    noisy_op.transform_qubits(qubits)
-    assert set(noisy_op.qubits) == set(qubits)
-    if real is not None:
-        assert np.allclose(noisy_op.channel_matrix, real)
-
-
-def test_transform_qubits_wrong_number():
-    real = np.zeros(shape=(16, 16))
-    qreg = [cirq.NamedQubit("Dummy 1"), cirq.NamedQubit("Dummy 2")]
-    ideal = cirq.Circuit(cirq.ops.CNOT.on(*qreg))
-    noisy_op = NoisyOperation(ideal, real)
-
-    with pytest.raises(ValueError, match="Expected 2 qubits but received"):
-        noisy_op.transform_qubits(qubits=[cirq.NamedQubit("new")])
-
-
-def test_with_qubits():
-    real = np.zeros(shape=(16, 16))
-    qreg = [cirq.NamedQubit("Dummy 1"), cirq.NamedQubit("Dummy 2")]
-    ideal = cirq.Circuit(cirq.ops.H.on(qreg[0]), cirq.ops.CNOT.on(*qreg))
-    noisy_op = NoisyOperation(ideal, real)
-
-    assert set(noisy_op.qubits) == set(qreg)
-    assert np.allclose(noisy_op.channel_matrix, real)
-
-    qubits = cirq.LineQubit.range(2)
-    new_noisy_op = noisy_op.with_qubits(qubits)
-    assert set(new_noisy_op.qubits) == set(qubits)
-    assert np.allclose(new_noisy_op.channel_matrix, real)
-
-
-@pytest.mark.parametrize("real", [np.zeros(shape=(4, 4)), None])
-def test_extend_to_single_qubit(real):
-    qbit, qreg = cirq.LineQubit(0), cirq.LineQubit.range(1, 10)
-    ideal = cirq.Z.on(qbit)
-    noisy_op_on_one_qubit = NoisyOperation.from_cirq(ideal, real)
-
-    noisy_ops_on_all_qubits = noisy_op_on_one_qubit.extend_to(qreg)
-
-    assert isinstance(noisy_ops_on_all_qubits, list)
-    assert len(noisy_ops_on_all_qubits) == 10
-
-    for op in noisy_ops_on_all_qubits:
-        assert _equal(op.circuit(), cirq.Circuit(ideal))
-        assert np.allclose(op.ideal_unitary, cirq.unitary(ideal))
-
-        if real is not None:
-            assert np.allclose(op.channel_matrix, real)
-
-
 def test_noisy_operation_str():
-    noisy_op = NoisyOperation.from_cirq(
-        circuit=cirq.I, channel_matrix=np.identity(4)
-    )
+    noisy_op = NoisyOperation(circuit=icirq, channel_matrix=np.identity(4))
     assert isinstance(noisy_op.__str__(), str)
 
 
 def test_noisy_basis_simple():
     rng = np.random.RandomState(seed=1)
     noisy_basis = NoisyBasis(
-        NoisyOperation.from_cirq(
-            circuit=cirq.I, channel_matrix=rng.rand(4, 4)
-        ),
-        NoisyOperation.from_cirq(
-            circuit=cirq.X, channel_matrix=rng.rand(4, 4)
-        ),
-        NoisyOperation.from_cirq(
-            circuit=cirq.Y, channel_matrix=rng.rand(4, 4)
-        ),
-        NoisyOperation.from_cirq(
-            circuit=cirq.Z, channel_matrix=rng.rand(4, 4)
-        ),
+        NoisyOperation(circuit=icirq, channel_matrix=rng.rand(4, 4)),
+        NoisyOperation(circuit=xcirq, channel_matrix=rng.rand(4, 4)),
+        NoisyOperation(circuit=ycirq, channel_matrix=rng.rand(4, 4)),
+        NoisyOperation(circuit=zcirq, channel_matrix=rng.rand(4, 4)),
     )
     assert len(noisy_basis) == 4
     assert noisy_basis.all_qubits() == {cirq.LineQubit(0)}
@@ -504,22 +328,14 @@ def test_noisy_basis_bad_types(element):
 def test_noisy_basis_add():
     rng = np.random.RandomState(seed=1)
     noisy_basis = NoisyBasis(
-        NoisyOperation.from_cirq(
-            circuit=cirq.I, channel_matrix=rng.rand(4, 4)
-        ),
-        NoisyOperation.from_cirq(
-            circuit=cirq.X, channel_matrix=rng.rand(4, 4)
-        ),
+        NoisyOperation(circuit=icirq, channel_matrix=rng.rand(4, 4)),
+        NoisyOperation(circuit=xcirq, channel_matrix=rng.rand(4, 4)),
     )
     assert len(noisy_basis) == 2
 
     noisy_basis.add(
-        NoisyOperation.from_cirq(
-            circuit=cirq.Y, channel_matrix=rng.rand(4, 4)
-        ),
-        NoisyOperation.from_cirq(
-            circuit=cirq.Z, channel_matrix=rng.rand(4, 4)
-        ),
+        NoisyOperation(circuit=ycirq, channel_matrix=rng.rand(4, 4)),
+        NoisyOperation(circuit=zcirq, channel_matrix=rng.rand(4, 4)),
     )
     assert len(noisy_basis) == 4
 
@@ -527,44 +343,20 @@ def test_noisy_basis_add():
 def test_noisy_basis_add_bad_types():
     rng = np.random.RandomState(seed=1)
     noisy_basis = NoisyBasis(
-        NoisyOperation.from_cirq(
-            circuit=cirq.I, channel_matrix=rng.rand(4, 4)
-        ),
-        NoisyOperation.from_cirq(
-            circuit=cirq.X, channel_matrix=rng.rand(4, 4)
-        ),
+        NoisyOperation(icirq, channel_matrix=rng.rand(4, 4)),
+        NoisyOperation(xcirq, channel_matrix=rng.rand(4, 4)),
     )
 
     with pytest.raises(TypeError, match="All basis elements must be of type"):
         noisy_basis.add(cirq.Y)
 
 
-def test_extend_to_simple():
-    rng = np.random.RandomState(seed=1)
-    noisy_basis = NoisyBasis(
-        NoisyOperation.from_cirq(
-            circuit=cirq.I, channel_matrix=rng.rand(4, 4)
-        ),
-        NoisyOperation.from_cirq(
-            circuit=cirq.X, channel_matrix=rng.rand(4, 4)
-        ),
-    )
-    assert len(noisy_basis.elements) == 2
-
-    noisy_basis.extend_to(cirq.LineQubit.range(1, 3))
-    assert len(noisy_basis.elements) == 6
-
-
 @pytest.mark.parametrize("length", (2, 3, 5))
 def test_get_sequences_simple(length):
     rng = np.random.RandomState(seed=1)
     noisy_basis = NoisyBasis(
-        NoisyOperation.from_cirq(
-            circuit=cirq.I, channel_matrix=rng.rand(4, 4)
-        ),
-        NoisyOperation.from_cirq(
-            circuit=cirq.X, channel_matrix=rng.rand(4, 4)
-        ),
+        NoisyOperation(circuit=icirq, channel_matrix=rng.rand(4, 4)),
+        NoisyOperation(circuit=xcirq, channel_matrix=rng.rand(4, 4)),
     )
 
     sequences = noisy_basis.get_sequences(length=length)
@@ -578,11 +370,11 @@ def test_get_sequences_simple(length):
 def get_test_representation():
     ideal = cirq.Circuit(cirq.H(cirq.LineQubit(0)))
 
-    noisy_xop = NoisyOperation.from_cirq(
-        circuit=cirq.X, channel_matrix=np.zeros(shape=(4, 4))
+    noisy_xop = NoisyOperation(
+        circuit=xcirq, channel_matrix=np.zeros(shape=(4, 4))
     )
-    noisy_zop = NoisyOperation.from_cirq(
-        circuit=cirq.Z, channel_matrix=np.zeros(shape=(4, 4))
+    noisy_zop = NoisyOperation(
+        circuit=zcirq, channel_matrix=np.zeros(shape=(4, 4))
     )
 
     decomp = OperationRepresentation(
@@ -612,8 +404,8 @@ def test_representation_coeff_of():
 def test_representation_bad_type_for_basis_expansion():
     ideal = cirq.Circuit(cirq.H(cirq.LineQubit(0)))
 
-    noisy_xop = NoisyOperation.from_cirq(
-        circuit=cirq.X, channel_matrix=np.zeros(shape=(4, 4))
+    noisy_xop = NoisyOperation(
+        circuit=xcirq, channel_matrix=np.zeros(shape=(4, 4))
     )
 
     with pytest.raises(TypeError, match="All keys of `basis_expansion` must"):
@@ -626,16 +418,16 @@ def test_representation_coeff_of_nonexistant_operation():
     qbit = cirq.LineQubit(0)
     ideal = cirq.Circuit(cirq.X(qbit))
 
-    noisy_xop = NoisyOperation.from_cirq(
-        circuit=cirq.X, channel_matrix=np.zeros(shape=(4, 4))
+    noisy_xop = NoisyOperation(
+        circuit=xcirq, channel_matrix=np.zeros(shape=(4, 4))
     )
 
     decomp = OperationRepresentation(
         ideal=ideal, basis_expansion=dict([(noisy_xop, 0.5)])
     )
 
-    noisy_zop = NoisyOperation.from_cirq(
-        circuit=cirq.Z, channel_matrix=np.zeros(shape=(4, 4))
+    noisy_zop = NoisyOperation(
+        circuit=zcirq, channel_matrix=np.zeros(shape=(4, 4))
     )
     with pytest.raises(ValueError, match="does not appear in the basis"):
         decomp.coeff_of(noisy_zop)
@@ -683,11 +475,11 @@ def test_representation_sample_bad_seed_type():
 def test_representation_sample_zero_coefficient():
     ideal = cirq.Circuit(cirq.H(cirq.LineQubit(0)))
 
-    noisy_xop = NoisyOperation.from_cirq(
-        circuit=cirq.X, channel_matrix=np.zeros(shape=(4, 4))
+    noisy_xop = NoisyOperation(
+        circuit=xcirq, channel_matrix=np.zeros(shape=(4, 4))
     )
-    noisy_zop = NoisyOperation.from_cirq(
-        circuit=cirq.Z, channel_matrix=np.zeros(shape=(4, 4))
+    noisy_zop = NoisyOperation(
+        circuit=zcirq, channel_matrix=np.zeros(shape=(4, 4))
     )
 
     decomp = OperationRepresentation(
@@ -709,11 +501,11 @@ def test_representation_sample_zero_coefficient():
 def test_print_cirq_operation_representation():
     ideal = cirq.Circuit(cirq.H(cirq.LineQubit(0)))
 
-    noisy_xop = NoisyOperation.from_cirq(
-        circuit=cirq.X, channel_matrix=np.zeros(shape=(4, 4))
+    noisy_xop = NoisyOperation(
+        circuit=xcirq, channel_matrix=np.zeros(shape=(4, 4))
     )
-    noisy_zop = NoisyOperation.from_cirq(
-        circuit=cirq.Z, channel_matrix=np.zeros(shape=(4, 4))
+    noisy_zop = NoisyOperation(
+        circuit=zcirq, channel_matrix=np.zeros(shape=(4, 4))
     )
     # Positive first coefficient
     decomp = OperationRepresentation(
@@ -765,12 +557,12 @@ def test_print_operation_representation_two_qubits():
     qreg = cirq.LineQubit.range(2)
     ideal = cirq.Circuit(cirq.CNOT(*qreg))
 
-    noisy_a = NoisyOperation.from_cirq(
+    noisy_a = NoisyOperation(
         circuit=cirq.Circuit(
             cirq.H.on_each(qreg), cirq.CNOT(*qreg), cirq.H.on_each(qreg)
         )
     )
-    noisy_b = NoisyOperation.from_cirq(
+    noisy_b = NoisyOperation(
         circuit=cirq.Circuit(
             cirq.Z.on_each(qreg),
             cirq.CNOT(*qreg),
@@ -807,14 +599,12 @@ def test_print_operation_representation_two_qubits_neg():
     qreg = cirq.LineQubit.range(2)
     ideal = cirq.Circuit(cirq.CNOT(*qreg))
 
-    noisy_a = NoisyOperation.from_cirq(
+    noisy_a = NoisyOperation(
         circuit=cirq.Circuit(
             cirq.H.on_each(qreg[0]), cirq.CNOT(*qreg), cirq.H.on_each(qreg[1])
         )
     )
-    noisy_b = NoisyOperation.from_cirq(
-        circuit=cirq.Circuit(cirq.Z.on_each(qreg[1]))
-    )
+    noisy_b = NoisyOperation(circuit=cirq.Circuit(cirq.Z.on_each(qreg[1])))
     decomp = OperationRepresentation(
         ideal=ideal,
         basis_expansion={

--- a/mitiq/pec/types/types.py
+++ b/mitiq/pec/types/types.py
@@ -68,21 +68,20 @@ class NoisyOperation:
 
         self._circuit = cirq_circuit
         self._native_type = native_type
-        self._qubits = tuple(self._circuit.all_qubits())
-        self._num_qubits = len(self._qubits)
-        self._dimension = 2**self._num_qubits
+
+        dimension = 2**self.num_qubits
 
         if channel_matrix is None:
             self._channel_matrix = None
 
         elif channel_matrix.shape != (
-            self._dimension**2,
-            self._dimension**2,
+            dimension**2,
+            dimension**2,
         ):
             raise ValueError(
                 f"Arg `channel_matrix` has shape {channel_matrix.shape}"
                 " but the expected shape is"
-                f" {self._dimension ** 2, self._dimension ** 2}."
+                f" {dimension ** 2, dimension ** 2}."
             )
         self._channel_matrix = deepcopy(channel_matrix)
 
@@ -98,19 +97,11 @@ class NoisyOperation:
 
     @property
     def qubits(self) -> Tuple[cirq.Qid, ...]:
-        return self._qubits
+        return tuple(self._circuit.all_qubits())
 
     @property
     def num_qubits(self) -> int:
         return len(self.qubits)
-
-    @property
-    def ideal_unitary(self) -> npt.NDArray[np.complex64]:
-        return cirq.unitary(self._circuit)
-
-    @property
-    def ideal_channel_matrix(self) -> npt.NDArray[np.complex64]:
-        raise NotImplementedError
 
     @property
     def channel_matrix(self) -> npt.NDArray[np.complex64]:
@@ -120,7 +111,7 @@ class NoisyOperation:
 
     def copy(self) -> "NoisyOperation":
         """Returns a copy of the NoisyOperation."""
-        return NoisyOperation(self._circuit, self._channel_matrix)
+        return NoisyOperation(self._native_circuit, self._channel_matrix)
 
     def __add__(self, other: Any) -> "NoisyOperation":
         if not isinstance(other, NoisyOperation):
@@ -139,7 +130,7 @@ class NoisyOperation:
         return NoisyOperation(self._circuit + other._circuit, matrix)
 
     def __str__(self) -> str:
-        return self._circuit.__str__()
+        return self._native_circuit.__str__()
 
 
 class NoisyBasis:

--- a/mitiq/pec/types/types.py
+++ b/mitiq/pec/types/types.py
@@ -16,7 +16,7 @@
 """Types used in probabilistic error cancellation."""
 from copy import deepcopy
 from itertools import product
-from typing import Any, cast, Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, cast, Dict, List, Optional, Sequence, Set, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -26,7 +26,6 @@ from cirq.value.linear_dict import _format_coefficient
 
 from mitiq import QPROGRAM
 from mitiq.interface import (
-    convert_from_mitiq,
     convert_to_mitiq,
     CircuitConversionError,
     UnsupportedCircuitError,
@@ -57,72 +56,26 @@ class NoisyOperation:
         Raises:
             TypeError: If ``ideal`` is not a ``QPROGRAM``.
         """
-        self._native_circuit = circuit
+        self._native_circuit = deepcopy(circuit)
 
         try:
-            ideal_cirq, self._native_type = convert_to_mitiq(circuit)
+            cirq_circuit, native_type = convert_to_mitiq(circuit)
         except (CircuitConversionError, UnsupportedCircuitError):
             raise TypeError(
-                f"Arg `circuit` must be one of {QPROGRAM} but"
-                f" was {type(circuit)}."
+                "Failed to convert to an internal Mitiq representation"
+                f"the input circuit:\n{type(circuit)}\n"
             )
 
-        self._init_from_cirq(ideal_cirq, channel_matrix)
-
-    @staticmethod
-    def from_cirq(
-        circuit: cirq.CIRCUIT_LIKE,
-        channel_matrix: Optional[npt.NDArray[np.complex64]] = None,
-    ) -> "NoisyOperation":
-        if isinstance(circuit, cirq.Gate):
-            qubits = tuple(cirq.LineQubit.range(circuit.num_qubits()))
-            circuit = cirq.Circuit(circuit.on(*qubits))
-
-        elif isinstance(circuit, cirq.Operation):
-            circuit = cirq.Circuit(circuit)
-
-        elif isinstance(circuit, cirq.Circuit):
-            circuit = deepcopy(circuit)
-
-        else:
-            try:
-                circuit = cirq.Circuit(circuit)
-            except Exception:
-                raise ValueError(
-                    f"Arg `circuit` must be cirq.CIRCUIT_LIKE "
-                    f"but was {type(circuit)}."
-                )
-        return NoisyOperation(circuit, channel_matrix)
-
-    def _init_from_cirq(
-        self,
-        circuit: cirq.Circuit,
-        channel_matrix: Optional[npt.NDArray[np.complex64]] = None,
-    ) -> None:
-        """Initializes a noisy operation expressed as a Cirq circuit.
-
-        Args:
-            circuit: A circuit which, when executed on a given noisy quantum
-                computer, generates a noisy channel.
-            channel_matrix: Superoperator representation of the noisy channel
-                which is generated when executing the input ``circuit`` on the
-                noisy quantum computer.
-
-        Raises:
-            ValueError: If the shape of `channel_matrix` does not match the
-            shape expected from the size of `circuit`.
-        """
-        self._circuit = deepcopy(circuit)
-
+        self._circuit = cirq_circuit
+        self._native_type = native_type
         self._qubits = tuple(self._circuit.all_qubits())
         self._num_qubits = len(self._qubits)
         self._dimension = 2**self._num_qubits
 
         if channel_matrix is None:
             self._channel_matrix = None
-            return
 
-        if channel_matrix.shape != (
+        elif channel_matrix.shape != (
             self._dimension**2,
             self._dimension**2,
         ):
@@ -131,98 +84,17 @@ class NoisyOperation:
                 " but the expected shape is"
                 f" {self._dimension ** 2, self._dimension ** 2}."
             )
-        # TODO: Check if channel_matrix is a valid superoperator.
         self._channel_matrix = deepcopy(channel_matrix)
 
-    @staticmethod
-    def on_each(
-        circuit: cirq.CIRCUIT_LIKE,
-        qubits: Sequence[List[cirq.Qid]],
-        channel_matrix: Optional[npt.NDArray[np.complex64]] = None,
-    ) -> List["NoisyOperation"]:
-        """Returns a NoisyOperation(circuit, channel_matrix) on each
-        qubit in qubits.
+    @property
+    def circuit(self) -> cirq.Circuit:
+        """Returns the circuit of the NoisyOperation as a Cirq circuit."""
+        return self._circuit
 
-        Args:
-            circuit: A gate, operation, sequence of operations, or circuit.
-            channel_matrix: Superoperator representation of the noisy channel
-                which is generated when executing the input ``circuit`` on the
-                noisy quantum computer.
-            qubits: The qubits to implement ``circuit`` on.
-
-        Raises:
-            TypeError:
-                * If `qubits` is not iterable.
-                * If `qubits` is not an iterable of cirq.Qid's or
-                  a sequence of lists of cirq.Qid's of the same length.
-        """
-        try:
-            qubits = list(iter(qubits))
-        except TypeError:
-            raise TypeError("Argument `qubits` must be iterable.")
-
-        try:
-            num_qubits_needed = cirq.num_qubits(circuit)
-        except TypeError:
-            raise ValueError(
-                "Could not deduce number of qubits needed by `circuit`."
-            )
-
-        if all(isinstance(q, cirq.Qid) for q in qubits):
-            qubits = cast(Sequence[List[cirq.Qid]], [[q] for q in qubits])
-
-        if not all(len(qreg) == num_qubits_needed for qreg in qubits):
-            raise ValueError(
-                f"Number of qubits in each register should be"
-                f" {num_qubits_needed}."
-            )
-
-        noisy_ops = []  # type: List[NoisyOperation]
-        base_circuit = NoisyOperation.from_cirq(
-            circuit,
-            channel_matrix,
-        )._circuit
-        base_qubits = list(base_circuit.all_qubits())
-
-        for new_qubits in qubits:
-            try:
-                new_qubits = list(iter(new_qubits))
-            except TypeError:
-                new_qubits = list(new_qubits)
-
-            qubit_map = dict(zip(base_qubits, new_qubits))
-            new_circuit = base_circuit.transform_qubits(lambda q: qubit_map[q])
-
-            noisy_ops.append(NoisyOperation(new_circuit, channel_matrix))
-
-        return noisy_ops
-
-    def extend_to(
-        self, qubits: Sequence[List[cirq.Qid]]
-    ) -> Sequence["NoisyOperation"]:
-        return [self] + NoisyOperation.on_each(
-            self._circuit,
-            qubits,
-            self._channel_matrix,
-        )
-
-    @staticmethod
-    def from_noise_model(
-        circuit: cirq.CIRCUIT_LIKE, noise_model: Any
-    ) -> "NoisyOperation":
-        raise NotImplementedError
-
-    def circuit(self, return_type: Optional[str] = None) -> QPROGRAM:
-        """Returns the circuit of the NoisyOperation.
-
-        Args:
-            return_type: Type of the circuit to return.
-                If not specified, the returned type is the same type as the
-                circuit used to initialize the NoisyOperation.
-        """
-        if not return_type:
-            return self._native_circuit
-        return convert_from_mitiq(self._circuit, return_type)
+    @property
+    def native_circuit(self) -> QPROGRAM:
+        """Returns the circuit used to initialize the NoisyOperation."""
+        return self._native_circuit
 
     @property
     def qubits(self) -> Tuple[cirq.Qid, ...]:
@@ -245,47 +117,6 @@ class NoisyOperation:
         if self._channel_matrix is None:
             raise ValueError("The channel matrix is unknown.")
         return deepcopy(self._channel_matrix)
-
-    def transform_qubits(
-        self, qubits: Union[cirq.Qid, Sequence[cirq.Qid]]
-    ) -> None:
-        """Changes the qubit(s) that the noisy operation acts on.
-
-        Args:
-            qubits: Qubit(s) that the noisy operation will act on.
-
-        Raises:
-            ValueError: If the number of qubits does not match that
-                of the noisy operation.
-        """
-        try:
-            qubits = list(iter(cast(Sequence[cirq.Qid], qubits)))
-        except TypeError:
-            qubits = [cast(cirq.Qid, qubits)]
-
-        if len(qubits) != self._num_qubits:
-            raise ValueError(
-                f"Expected {self._num_qubits} qubits but received"
-                f" {len(qubits)} qubits."
-            )
-
-        qubit_map = dict(zip(self._qubits, qubits))
-        self._circuit = self._circuit.transform_qubits(lambda q: qubit_map[q])
-        self._qubits = tuple(qubits)
-
-    def with_qubits(self, qubits: Sequence[cirq.Qid]) -> "NoisyOperation":
-        """Returns the noisy operation acting on the input qubits.
-
-        Args:
-            qubits: Qubits that the returned noisy operation will act on.
-
-        Raises:
-            ValueError: If the number of qubits does not match that
-                of the noisy operation.
-        """
-        copy = self.copy()
-        copy.transform_qubits(qubits)
-        return copy
 
     def copy(self) -> "NoisyOperation":
         """Returns a copy of the NoisyOperation."""
@@ -355,23 +186,6 @@ class NoisyBasis:
                     "All basis elements must be of type `NoisyOperation`."
                 )
             self._basis_elements.add(noisy_op)
-
-    def extend_to(self, qubits: Sequence[List[cirq.Qid]]) -> None:
-        """Extends each basis element to act on the provided qubits.
-
-        Args:
-            qubits: Additional qubits for each basis element to act on.
-        """
-        for noisy_op in tuple(self._basis_elements):
-            self._basis_elements.update(
-                set(
-                    NoisyOperation.on_each(
-                        noisy_op.circuit(return_type="cirq"),  # type: ignore
-                        qubits,
-                        noisy_op.channel_matrix,
-                    )
-                )
-            )
 
     def get_sequences(self, length: int) -> List[NoisyOperation]:
         """Returns a list of all implementable NoisyOperation's of the given

--- a/mitiq/pec/types/types.py
+++ b/mitiq/pec/types/types.py
@@ -109,10 +109,6 @@ class NoisyOperation:
             raise ValueError("The channel matrix is unknown.")
         return deepcopy(self._channel_matrix)
 
-    def copy(self) -> "NoisyOperation":
-        """Returns a copy of the NoisyOperation."""
-        return NoisyOperation(self._native_circuit, self._channel_matrix)
-
     def __add__(self, other: Any) -> "NoisyOperation":
         if not isinstance(other, NoisyOperation):
             raise ValueError(


### PR DESCRIPTION
First step of the more general scope of #1712.
Since this is a self-contained step, I opened a new PR such that it can be reviewed more easily.
 
If this will be merged to master, the diff of #1712 will be much simpler to follow.

This PR simplifies the structure of the `NoisyOperation` class without compromising the workflow of PEC. 

Motivations:

- Short code is easier to maintain and less subject to bugs. 
- Some removed methods have inconsistent effects when applied to non-Cirq circuits. 
- Lightweight objects may speedup PEC. (Not sure how strong this effect is).
- Simpler code helps the more general refactoring process of #1712. 



### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
