### PR TITLE
[calibration] usability improvements

### DIFF
--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -110,9 +110,7 @@ class ExperimentResults:
         return strategy_id
 
     def reset_data(self) -> None:
-        self = ExperimentResults(
-            num_strategies=self.num_strategies, num_problems=self.num_problems
-        )
+        self.__init__(self.num_strategies, self.num_problems)
 
 
 class Calibrator:

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -109,6 +109,11 @@ class ExperimentResults:
         strategy_id = int(np.argmin(strategy_errors))
         return strategy_id
 
+    def reset_data(self) -> None:
+        self = ExperimentResults(
+            num_strategies=self.num_strategies, num_problems=self.num_problems
+        )
+
 
 class Calibrator:
     """An object used to orchestrate experiments for calibrating optimal error
@@ -167,8 +172,11 @@ class Calibrator:
 
     def run(self, log: bool = False) -> None:
         """Runs all the circuits required for calibration."""
+        if not self.results.is_missing_data():
+            self.results.reset_data()
+
         for problem in self.circuits:
-            circuit = problem.circuit
+            circuit = problem.circuit.copy()
             circuit.append(cirq.measure(circuit.all_qubits()))
 
             bitstring_to_measure = problem.most_likely_bitstring()

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -69,7 +69,7 @@ class ExperimentResults:
         )
         performance = "✅" if mitigated_better else "❌"
         print(
-            f"Running {problem.type} circuit using:",
+            f"Ran {problem.type} circuit using:",
             list(strategy.to_dict().values()),
         )
         print(

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -45,9 +45,7 @@ class ExperimentResults:
     def __init__(self, num_strategies: int, num_problems: int) -> None:
         self.num_strategies = num_strategies
         self.num_problems = num_problems
-        self.mitigated = np.full((num_strategies, num_problems), np.nan)
-        self.noisy = np.full((num_strategies, num_problems), np.nan)
-        self.ideal = np.full((num_strategies, num_problems), np.nan)
+        self.reset_data()
 
     def add_result(
         self,
@@ -110,7 +108,12 @@ class ExperimentResults:
         return strategy_id
 
     def reset_data(self) -> None:
-        self.__init__(self.num_strategies, self.num_problems)
+        """Reset all experiment result data using NaN values."""
+        self.mitigated = np.full(
+            (self.num_strategies, self.num_problems), np.nan
+        )
+        self.noisy = np.full((self.num_strategies, self.num_problems), np.nan)
+        self.ideal = np.full((self.num_strategies, self.num_problems), np.nan)
 
 
 class Calibrator:

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -75,7 +75,9 @@ class ExperimentResults:
             list(strategy.to_dict().values()),
         )
         print(
-            f"{performance} ideal: {ideal_val:.2f}\tnoisy: {noisy_val:.2f}\tmitigated: {mitigated_val:.2f}"
+            f"{performance} ideal: {ideal_val:.2f}\t"
+            f"noisy: {noisy_val:.2f}\t"
+            f"mitigated: {mitigated_val:.2f}"
         )
 
     def is_missing_data(self) -> bool:
@@ -239,7 +241,7 @@ def execute_with_mitigation(
     observable: Optional[Observable] = None,
     *,
     calibrator: Calibrator,
-) -> QuantumResult:
+) -> Union[QuantumResult, None]:
     """Estimates the error-mitigated expectation value associated to the
     input circuit, via the application of the best mitigation strategy, as
     determined by calibration.
@@ -260,7 +262,18 @@ def execute_with_mitigation(
     """
 
     if calibrator.results.is_missing_data():
-        calibrator.run()
+        cost = calibrator.get_cost()
+        answer = input(
+            "Calibration experiments have not yet been run. You can run the "
+            "experiments manually by calling `calibrator.run()`, or they can "
+            f"be run now. The potential cost is:\n{cost}\n"
+            "Would you like the experiments to be run automatically? (yes/no)"
+        )
+        if answer.lower() == "yes":
+            calibrator.run()
+        else:
+            return None
+
     strategy = calibrator.best_strategy()
     em_func = strategy.mitigation_function
     return em_func(circuit, executor=executor, observable=observable)

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -104,6 +104,7 @@ class BenchmarkProblem:
         base = asdict(self)
         # remove circuit; it can be regenerated if needed
         del base["circuit"]
+        del base["id"]
         base["num_qubits"] = self.num_qubits
         base["circuit_depth"] = self.circuit_depth
         base["two_qubit_gate_count"] = self.two_qubit_gate_count
@@ -141,7 +142,7 @@ class Strategy:
 
         Returns:
             A dictionary describing the strategies parameters."""
-        summary = {"id": self.id, "technique": self.technique.name}
+        summary = {"technique": self.technique.name}
         if self.technique is MitigationTechnique.ZNE:
             inference_func = self.technique_params["factory"]
             summary["factory"] = inference_func.__class__.__name__

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -148,7 +148,7 @@ def test_convert_to_expval_executor():
     assert np.isclose(rb_circuit_expval, 1.0)
 
 
-def test_execute_with_mitigation():
+def test_execute_with_mitigation(monkeypatch):
     cal = Calibrator(execute, ZNESettings)
 
     expval_executor = convert_to_expval_executor(
@@ -157,6 +157,8 @@ def test_execute_with_mitigation():
     rb_circuit = generate_rb_circuits(2, 10)[0]
     rb_circuit.append(cirq.measure(rb_circuit.all_qubits()))
 
+    # override the def of `input` so that it returns "yes"
+    monkeypatch.setattr("builtins.input", lambda _: "yes")
     expval = execute_with_mitigation(
         rb_circuit, expval_executor, calibrator=cal
     )

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -195,3 +195,11 @@ def test_ExtrapolationResults_best_strategy():
     er.mitigated[4, 2] = 0.8
     er.ideal = np.ones((num_strategies, num_problems))
     assert er.best_strategy_id() == 4
+
+
+def test_logging(capfd):
+    cal = Calibrator(execute, ZNESettings)
+    cal.run(log=True)
+
+    captured = capfd.readouterr()
+    assert "circuit" in captured.out


### PR DESCRIPTION
## Description

This PR has some minor improvements to the usability of calibration. In particular,

1. adds a logging option when running the calibration experiments. I envision this being useful to give a user more immediate understanding of what's happening, and how techniques are performing. The results can be seen [below](#logging).
2. adds a check if the user would like to proceed when using `execute_with_mitigation` if the `calibrator` object has not yet been run. Running automatically without the user's permission could be unintended if they are using a real backend.
3. Allows calibrators to run the specified experiments multiple times. Previously running `calibrator.run()` twice would cause an error (and an unhelpful one at that). If a user would like to refresh their experiments, I don't see a reason why we shouldn't allow them to.

### Testing performed
Tests, and some further user flow ideas in a notebook.

#### Logging example output
```
Running ghz circuit using: ['ZNE', 'LinearFactory', [1.0, 3.0, 5.0], 'fold_global']
✅ ideal: 0.50	noisy: 0.58	mitigated: 0.50
Running ghz circuit using: ['ZNE', 'RichardsonFactory', [1.0, 2.0, 3.0], 'fold_gates_at_random']
❌ ideal: 0.50	noisy: 0.58	mitigated: 0.38
Running ghz circuit using: ['ZNE', 'RichardsonFactory', [1.0, 3.0, 5.0], 'fold_gates_at_random']
❌ ideal: 0.50	noisy: 0.58	mitigated: 0.72
Running ghz circuit using: ['ZNE', 'LinearFactory', [1.0, 2.0, 3.0], 'fold_gates_at_random']
❌ ideal: 0.50	noisy: 0.58	mitigated: 0.61
Running ghz circuit using: ['ZNE', 'LinearFactory', [1.0, 3.0, 5.0], 'fold_gates_at_random']
✅ ideal: 0.50	noisy: 0.58	mitigated: 0.53
```

### Technical note

The base branch for this PR is that of https://github.com/unitaryfund/mitiq/pull/1706, and should only be merged once that has been merged.