### PR TITLE
REM: Update the fifth section of the docs

### DIFF
--- a/docs/source/apidoc.md
+++ b/docs/source/apidoc.md
@@ -212,7 +212,7 @@ See Ref. :cite:`Czarnik_2021_Quantum` for more details on these methods.
 
 ## Readout-Error Mitigation
 
-### Post-selection
+### Postselection
 ```{eval-rst}
 .. automodule:: mitiq.rem.post_select
    :members:

--- a/docs/source/guide/rem-1-intro.md
+++ b/docs/source/guide/rem-1-intro.md
@@ -88,7 +88,7 @@ print(f"Error without mitigation: {error:.3}")
 
 ## Apply Postselection
 The simplest version of readout error mitigation that we could do is to postselect specific bitstrings using 
-{mod}`mitiq.rem.post_select`. We observe that the circuit in our example is symmetric with respect to interchanging the
+{mod}`mitiq.rem.post_select`. This strategy is only applicable if, from the structure of the problem, there is some kind symmetry that we can assume and therefore enforce by post-selection. For example, we observe that the circuit in our example is symmetric with respect to interchanging the
 two qubits. Assuming we are given the promise that the ideal result must be a unique bitstring, such a bitstring must
 be symmetric with respect to a bit swap. Therefore, a possible error mitigation strategy is to keep only the results
 where the bits match.

--- a/docs/source/guide/rem-1-intro.md
+++ b/docs/source/guide/rem-1-intro.md
@@ -111,9 +111,7 @@ error = abs((ideal_value - mitigated_result)/ideal_value)
 print(f"Error with mitigation (PS): {error:.3}")
 ```
 
-So, if we used these postselected results, then we'd get closer to the expected noiseless expectation value. However, 
-that comes at the cost of throwing away many of our measurements, which doesn't scale well in practice with the 
-number of qubits we are measuring. 
+So, if we used these postselected results, then we'd get closer to the expected noiseless expectation value. However, that comes at the cost of throwing away a fraction of our measurements. 
 
 ## Apply REM
 A more elaborate readout-error mitigation technique can be easily applied with the function

--- a/docs/source/guide/rem-3-options.md
+++ b/docs/source/guide/rem-3-options.md
@@ -15,30 +15,7 @@ kernelspec:
 
 ## Overview
 The main options the user has when using REM concern how to specify the inverse
-confusion matrix that is used to mitigate errors in the raw measurement (or "readout") results. Currently Mitiq does not implement methods for estimating readout-error confusion matrices (which is a form of measurement noise calibration and therefore a device specific task), so the user must provide enough information to allow Mitiq to construct one. As described below, Mitiq's options support the differing levels of information a user may have about the readout-error characteristics of their device. After the confusion matrix has been constructed, the remaining steps of standard REM are straightforward (compute the pseudoinverse of the confusion matrix and then apply this to the raw measurement results). 
-
-
-
-## What is a Confusion Matrix?
-
-A device's readout-error confusion matrix $A$ is a square matrix that encodes, for each pair of measurement basis states $|u\rangle$ and $|v\rangle$, the probability that the device will report $|u\rangle$ as the measurement outcome when the true state being measured was $|v\rangle$. On an ideal, noise-free device, $|u\rangle$ would always equal $|v\rangle$, so the corresponding confusion matrix would have ones on the diagonal and zeros elsewhere. For simplicity of exposition, we will assume throughout that the measurement basis (i.e. the eigenbasis of the observable being measured) is the computational or $Z$ basis. For a two qubit device, the general picture of a confusion matrix to have in mind is:
-
-$$
-\begin{bmatrix}
-Pr(00|00) & Pr(01|00) & Pr(10|00) & Pr(11|00) \\
-Pr(00|01) & Pr(01|01) & Pr(10|01) & Pr(11|01) \\
-Pr(00|10) & Pr(01|10) & Pr(10|10) & Pr(11|10) \\
-Pr(00|11) & Pr(01|11) & Pr(10|11) & Pr(11|11)
-\end{bmatrix}
-$$
-
-
-where $Pr(ij|kl)$ is the probability of observing state $|ij\rangle$ when measuring true state $|kl\rangle$. 
-
-The most straightforward way to empirically estimate a device's full confusion matrix is to go through all the measurement basis states, and for each one $|u\rangle$, repeatedly prepare-then-measure $|u\rangle$ and record the histogram of observed outcomes. This histogram, normalized to give a probability distribution, is an estimate for the $u$th column of the confusion matrix A (i.e. the distribution of measurement outcomes when the true state is $|u\rangle$). Since the number of basis states scales exponentially with the number of qubits $n$, estimating the full confusion matrix in this way requires $O(2^n)$ samples and is therefore only practical for small devices. 
-
-Note that the estimated confusion matrix $A$ is circuit-independent---it characterizes the readout noise of the device regardless of what circuit is being executed. So in principle (assuming the noise characteristics of the device do not shift over time) $A$ only needs to be estimated once, and its [Moore-Penrose](https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse) [pseudoinverse](https://numpy.org/doc/stable/reference/generated/numpy.linalg.pinv.html) $A^{+}$ only needs to be computed once. One can then perform REM for any particular circuit on the device by applying $A^{+}$ to the measurement outcomes from repeated runs of that circuit. For more details, see [What is the theory behind REM?](rem-5-theory.md).
-
+confusion matrix that is used to mitigate errors in the raw measurement (or "readout") results. Currently Mitiq does not implement methods for estimating readout-error confusion matrices (which is a form of measurement noise calibration and therefore a device specific task), so the user must provide enough information to allow Mitiq to construct one. As described below, Mitiq's options support the differing levels of information a user may have about the readout-error characteristics of their device. After the confusion matrix has been constructed, the remaining steps of standard REM are straightforward (compute the pseudoinverse of the confusion matrix and then apply this to the raw measurement results). For more information on what a confusion matrix is, see [What is the theory behind REM?](rem-5-theory.md#what-is-a-confusion-matrix).
 
 ## Options for specifying the inverse confusion matrix  
 

--- a/docs/source/guide/rem-5-theory.md
+++ b/docs/source/guide/rem-5-theory.md
@@ -33,10 +33,10 @@ A device's readout-error confusion matrix $A$ is a square matrix that encodes, f
 
 $$
 \begin{bmatrix}
-Pr(00|00) & Pr(01|00) & Pr(10|00) & Pr(11|00) \\
-Pr(00|01) & Pr(01|01) & Pr(10|01) & Pr(11|01) \\
-Pr(00|10) & Pr(01|10) & Pr(10|10) & Pr(11|10) \\
-Pr(00|11) & Pr(01|11) & Pr(10|11) & Pr(11|11)
+Pr(00|00) & Pr(00|01) & Pr(00|10) & Pr(00|11) \\
+Pr(01|00) & Pr(01|01) & Pr(01|10) & Pr(01|11) \\
+Pr(10|00) & Pr(10|01) & Pr(10|10) & Pr(10|11) \\
+Pr(11|00) & Pr(11|01) & Pr(11|10) & Pr(11|11)
 \end{bmatrix}
 $$
 

--- a/docs/source/guide/rem-5-theory.md
+++ b/docs/source/guide/rem-5-theory.md
@@ -57,6 +57,6 @@ distribution to obtain an adjusted *quasi*-probability distribution, $p' = A^{+}
 non-positive. As such, we want to find the closest *positive* probability distribution {cite}`Bravyi_2021` to our
 empirical probability distribution:
 
- $$ p'' = \min_{p_{\rm positive}} \||p' - p_{\rm positive}\||_1$$
+ $$ p'' = \min_{p_{\rm positive}} \|p' - p_{\rm positive}\|_1$$
 
 Finally, we can draw samples from this new probability distribution, $x \sim p''$ , and return those as our mitigated results.

--- a/docs/source/guide/rem-5-theory.md
+++ b/docs/source/guide/rem-5-theory.md
@@ -13,7 +13,7 @@ kernelspec:
 
 # What is the theory behind REM?
 
-Readout error mitigation (REM), is one of the most general and earliest studied error mitigation techniques, which can refer to a variety of specific approaches.
+Readout error mitigation (REM), is one of the most general and earliest studied error mitigation techniques, which can encompass a variety of specific approaches.
 
 A simple version of readout error mitigation is postselection of bitstrings. For
 example, if one knows that the measured bitstrings should preserve some
@@ -21,4 +21,42 @@ symmetry, bitstrings that do not preserve it can be discarded. Such capability
 is indeed available in {mod}`mitiq.rem.post_select`.
 
 With regards to the more elaborate technique of confusion matrix inversion,
-also [supported](rem-1-intro) in Mitiq, some relevant references are Refs. {cite}`Maciejewski_2020,Bravyi_2021,Garion_2021,Geller_2021`.
+also [supported](rem-1-intro) in Mitiq, some relevant references are Refs. {cite}`Maciejewski_2020,Bravyi_2021,Garion_2021,Geller_2021`. The technique is based on two main ideas:
+
+- Generating a confusion matrix for a specific device;
+
+- Computing the psuedoinverse of this confusion matrix and applying it to the raw measurement (or "readout") results.
+
+## What is a confusion matrix?
+
+A device's readout-error confusion matrix $A$ is a square matrix that encodes, for each pair of measurement basis states $|u\rangle$ and $|v\rangle$, the probability that the device will report $|u\rangle$ as the measurement outcome when the true state being measured was $|v\rangle$. On an ideal, noise-free device, $|u\rangle$ would always equal $|v\rangle$, so the corresponding confusion matrix would have ones on the diagonal and zeros elsewhere. For simplicity of exposition, we will assume throughout that the measurement basis (i.e. the eigenbasis of the observable being measured) is the computational or $Z$ basis. For a two qubit device, the general picture of a confusion matrix to have in mind is:
+
+$$
+\begin{bmatrix}
+Pr(00|00) & Pr(01|00) & Pr(10|00) & Pr(11|00) \\
+Pr(00|01) & Pr(01|01) & Pr(10|01) & Pr(11|01) \\
+Pr(00|10) & Pr(01|10) & Pr(10|10) & Pr(11|10) \\
+Pr(00|11) & Pr(01|11) & Pr(10|11) & Pr(11|11)
+\end{bmatrix}
+$$
+
+
+where $Pr(ij|kl)$ is the probability of observing state $|ij\rangle$ when measuring true state $|kl\rangle$. 
+
+The most straightforward way to empirically estimate a device's full confusion matrix is to go through all the measurement basis states, and for each one $|u\rangle$, repeatedly prepare-then-measure $|u\rangle$ and record the histogram of observed outcomes. This histogram, normalized to give a probability distribution, is an estimate for the $u$th column of the confusion matrix A (i.e. the distribution of measurement outcomes when the true state is $|u\rangle$). Since the number of basis states scales exponentially with the number of qubits $n$, estimating the full confusion matrix in this way requires $O(2^n)$ samples and is therefore only practical for small devices. 
+
+## Computing the pseudoinverse
+
+Note that the estimated confusion matrix $A$ is circuit-independent---it characterizes the readout noise of the device regardless of what circuit is being executed. So in principle (assuming the noise characteristics of the device do not shift over time) $A$ only needs to be estimated once, and its [Moore-Penrose](https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse) [pseudoinverse](https://numpy.org/doc/stable/reference/generated/numpy.linalg.pinv.html) $A^{+}$ only needs to be computed once. One can then perform REM for any particular circuit on the device by applying $A^{+}$ to the measurement outcomes from repeated runs of that circuit. In practice, the noise characteristics of devices tend to drift, which necessitates a recalibration effort that results in an updated confusion matrix.
+
+## Applying the inverse confusion matrix to results
+
+With our raw measurement results we convert our bitstrings into a probability vector, $p$, representing our empirical
+probability distribution. After obtaining the psuedoinverse matrix $A^{+}$, we can apply it to our empirical probability
+distribution to obtain an adjusted *quasi*-probability distribution, $p' = A^{+} p$, which could possibly be 
+non-positive. As such, we want to find the closest *positive* probability distribution {cite}`Bravyi_2021` to our
+empirical probability distribution:
+
+ $$ p'' = \min_{p_{\rm positive}} \||p' - p_{\rm positive}\||_1$$
+
+Finally, we can draw samples from this new probability distribution, $x \sim p''$ , and return those as our mitigated results.

--- a/mitiq/rem/tests/test_post_select.py
+++ b/mitiq/rem/tests/test_post_select.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Unit tests for post-selection of measurement results."""
+"""Unit tests for postselection of measurement results."""
 import pytest
 
 from mitiq.rem import post_select


### PR DESCRIPTION
<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.

  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.

  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

Resolves #1455:
- Adds a small portion about postselection to the intro.
- Moves the explanation about confusion matrices from the third to the fifth section of the docs.
- Fills out the theory section by providing info about applying inverse confusion matrices to the probability distribution

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [X] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file