### PR TITLE
Improve default `ZNESettings` for calibration

### DIFF
--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -159,16 +159,15 @@ class Strategy:
 
 
 class Settings:
-    """A class to store the configuration settings of a :class:`.Calibrator`.
+    r"""A class to store the configuration settings of a :class:`.Calibrator`.
 
     Args:
         benchmarks: A list where each element is a dictionary of parameters for
             generating circuits to be used in calibration experiments. The
             dictionary keys include ``"circuit_type"``, ``"num_qubits"``,
             ``"circuit_depth"``, and in the case of mirror circuits, a random
-            seed ``"circuit_seed"``.
-            An example of input to ``benchmarks`` is
-            .. code-block:: python
+            seed ``"circuit_seed"``. An example of input to ``benchmarks`` is::
+
                 [
                     {
                         "circuit_type": "mirror",
@@ -182,6 +181,7 @@ class Settings:
                         "circuit_depth": 7,
                     }
                 ]
+
         strategies: A specification of the methods/parameters to be used in
             calibration experiments.
     """

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -162,10 +162,26 @@ class Settings:
     """A class to store the configuration settings of a :class:`.Calibrator`.
 
     Args:
-        benchmarks: A specification of the parameters for generating circuits
-            to be used in calibration experiments, which are `"circuit_type"`,
-            `"num_qubits"`, `"circuit_depth"`, and in the case of mirror
-            circuits, a random seed `"circuit_seed"`.
+        benchmarks: A list where each element is a dictionary of parameters for
+            generating circuits to be used in calibration experiments. The
+            dictionary keys include ``"circuit_type"``, ``"num_qubits"``,
+            ``"circuit_depth"``, and in the case of mirror circuits, a random
+            seed ``"circuit_seed"``.
+            An example of input to ``benchmarks`` is
+            .. code-block:: python
+                [
+                    {
+                        "circuit_type": "mirror",
+                        "num_qubits": 3,
+                        "circuit_depth": 5,
+                        "circuit_seed": 1,
+                    },
+                    {
+                        "circuit_type": "rb",
+                        "num_qubits": 2,
+                        "circuit_depth": 7,
+                    }
+                ]
         strategies: A specification of the methods/parameters to be used in
             calibration experiments.
     """
@@ -194,9 +210,14 @@ class Settings:
         circuits = []
         for i, benchmark in enumerate(self.benchmarks):
             circuit_type = benchmark["circuit_type"]
-            depth = benchmark["circuit_depth"]
             num_qubits = benchmark["num_qubits"]
-
+            if (
+                "circuit_depth" in benchmark.keys()
+                and benchmark["circuit_depth"] is not None
+            ):
+                depth = benchmark["circuit_depth"]
+            else:
+                depth = num_qubits
             if circuit_type == "ghz":
                 circuit = generate_ghz_circuit(num_qubits)
                 ideal = {"0" * num_qubits: 0.5, "1" * num_qubits: 0.5}
@@ -264,7 +285,6 @@ ZNESettings = Settings(
         {
             "circuit_type": "ghz",
             "num_qubits": 2,
-            "circuit_depth": None,
         },
         {
             "circuit_type": "rb",

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -15,7 +15,7 @@
 
 from dataclasses import dataclass, asdict
 from functools import partial
-from typing import Any, Callable, cast, List, Dict, Optional
+from typing import Any, Callable, cast, List, Dict
 from enum import Enum, auto
 
 import networkx as nx
@@ -182,21 +182,15 @@ class Settings:
 
     def __init__(
         self,
-        circuit_types: List[str],
-        num_qubits: int,
-        circuit_depth: int,
+        benchmarks: List[Dict[str, Any]],
         strategies: List[Dict[str, Any]],
-        circuit_seed: Optional[int] = None,
     ):
         self.techniques = [
             MitigationTechnique[technique["technique"].upper()]
             for technique in strategies
         ]
         self.technique_params = strategies
-        self.circuit_types = circuit_types
-        self.num_qubits = num_qubits
-        self.circuit_depth = circuit_depth
-        self.circuit_seed = circuit_seed
+        self.benchmarks = benchmarks
         self.strategy_dict: Dict[int, Strategy] = {}
         self.problem_dict: Dict[int, BenchmarkProblem] = {}
 
@@ -208,29 +202,29 @@ class Settings:
         Returns:
             A list of :class:`BenchmarkProblem` objects"""
         circuits = []
-        nqubits, depth, seed = (
-            self.num_qubits,
-            self.circuit_depth,
-            self.circuit_seed,
-        )
-        for i, circuit_type in enumerate(self.circuit_types):
+        for i, benchmark in enumerate(self.benchmarks):
+            circuit_type = benchmark["circuit_type"]
+            depth = benchmark["circuit_depth"]
+            num_qubits = benchmark["num_qubits"]
+
             if circuit_type == "ghz":
-                circuit = generate_ghz_circuit(nqubits)
-                ideal = {"0" * nqubits: 0.5, "1" * nqubits: 0.5}
+                circuit = generate_ghz_circuit(num_qubits)
+                ideal = {"0" * num_qubits: 0.5, "1" * num_qubits: 0.5}
             elif circuit_type == "rb":
-                circuit = generate_rb_circuits(nqubits, depth)[0]
-                ideal = {"0" * nqubits: 1.0}
+                circuit = generate_rb_circuits(num_qubits, depth)[0]
+                ideal = {"0" * num_qubits: 1.0}
             elif circuit_type == "mirror":
+                seed = benchmark["circuit_seed"]
                 circuit, bitstring_list = generate_mirror_circuit(
                     nlayers=depth,
                     two_qubit_gate_prob=1.0,
-                    connectivity_graph=nx.complete_graph(nqubits),
+                    connectivity_graph=nx.complete_graph(num_qubits),
                     seed=seed,
                 )
                 ideal_bitstring = "".join(map(str, bitstring_list))
                 ideal = {ideal_bitstring: 1.0}
             elif circuit_type == "qv":
-                circuit, _ = generate_quantum_volume_circuit(nqubits, depth)
+                circuit, _ = generate_quantum_volume_circuit(num_qubits, depth)
                 raise NotImplementedError(
                     "quantum volume circuits not yet supported in calibration"
                 )
@@ -276,9 +270,24 @@ class Settings:
 
 
 ZNESettings = Settings(
-    circuit_types=["ghz", "rb", "mirror"],
-    num_qubits=2,
-    circuit_depth=5,
+    benchmarks=[
+        {
+            "circuit_type": "ghz",
+            "num_qubits": 2,
+            "circuit_depth": None,
+        },
+        {
+            "circuit_type": "rb",
+            "num_qubits": 2,
+            "circuit_depth": 7,
+        },
+        {
+            "circuit_type": "mirror",
+            "num_qubits": 3,
+            "circuit_depth": 5,
+            "circuit_seed": 1,
+        },
+    ],
     strategies=[
         {
             "technique": "zne",

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -170,15 +170,15 @@ class Settings:
 
                 [
                     {
-                        "circuit_type": "mirror",
-                        "num_qubits": 3,
-                        "circuit_depth": 5,
-                        "circuit_seed": 1,
-                    },
-                    {
                         "circuit_type": "rb",
                         "num_qubits": 2,
                         "circuit_depth": 7,
+                    },
+                    {
+                        "circuit_type": "mirror",
+                        "num_qubits": 2,
+                        "circuit_depth": 7,
+                        "circuit_seed": 1,
                     }
                 ]
 
@@ -293,8 +293,8 @@ ZNESettings = Settings(
         },
         {
             "circuit_type": "mirror",
-            "num_qubits": 3,
-            "circuit_depth": 5,
+            "num_qubits": 2,
+            "circuit_depth": 7,
             "circuit_seed": 1,
         },
     ],

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -162,22 +162,12 @@ class Settings:
     """A class to store the configuration settings of a :class:`.Calibrator`.
 
     Args:
-        circuit_types: List of strings specifying circuit types to use.
-            Must be drawn from the Identifier column::
-
-                Identifier  | Circuit Type
-                ----------------------------
-                "ghz"       | GHZ circuit
-                "rb"        | Randomized Benchmarking
-                "mirror"    | Mirror circuit
-
-        num_qubits: Number of qubits to use for circuit generation.
-        circuit_depth: Circuit depth to use when generating circuits. Only
-            used when ``num_qubits`` in combination with the circuit type does
-            not specify the depth.
+        benchmarks: A specification of the parameters for generating circuits
+            to be used in calibration experiments, which are `"circuit_type"`,
+            `"num_qubits"`, `"circuit_depth"`, and in the case of mirror
+            circuits, a random seed `"circuit_seed"`.
         strategies: A specification of the methods/parameters to be used in
             calibration experiments.
-        seed: A random seed for (mirror) circuit generation.
     """
 
     def __init__(

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -49,9 +49,14 @@ def execute(circuit, noise_level=0.001):
 
 
 settings = Settings(
-    circuit_types=["ghz", "rb"],
-    num_qubits=2,
-    circuit_depth=10,
+    [
+        {
+            "circuit_type": "ghz",
+            "num_qubits": 2,
+            "circuit_depth": 10,
+        },
+        {"circuit_type": "rb", "num_qubits": 2, "circuit_depth": 10},
+    ],
     strategies=[
         {
             "technique": "zne",
@@ -100,9 +105,15 @@ def test_get_cost():
 
 def test_best_strategy():
     test_strategy_settings = Settings(
-        circuit_types=["ghz", "mirror"],
-        num_qubits=2,
-        circuit_depth=10,
+        benchmarks=[
+            {"circuit_type": "ghz", "num_qubits": 2, "circuit_depth": 10},
+            {
+                "circuit_type": "mirror",
+                "num_qubits": 2,
+                "circuit_depth": 10,
+                "circuit_seed": 1,
+            },
+        ],
         strategies=[
             {
                 "technique": "zne",
@@ -125,7 +136,6 @@ def test_best_strategy():
                 "factory": LinearFactory([1.0, 3.0, 5.0]),
             },
         ],
-        circuit_seed=1,
     )
 
     cal = Calibrator(execute, test_strategy_settings)

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -35,9 +35,13 @@ def test_MitigationTechnique():
 
 def test_basic_settings():
     settings = Settings(
-        circuit_types=["ghz"],
-        num_qubits=2,
-        circuit_depth=999,
+        benchmarks=[
+            {
+                "circuit_type": "ghz",
+                "num_qubits": 2,
+                "circuit_depth": 999,
+            }
+        ],
         strategies=[
             {
                 "technique": "zne",
@@ -78,9 +82,13 @@ def test_basic_settings():
 
 def test_make_circuits_qv_circuits():
     settings = Settings(
-        circuit_types=["qv"],
-        num_qubits=2,
-        circuit_depth=999,
+        [
+            {
+                "circuit_type": "qv",
+                "num_qubits": 2,
+                "circuit_depth": 999,
+            }
+        ],
         strategies=[
             {
                 "technique": "zne",
@@ -95,9 +103,7 @@ def test_make_circuits_qv_circuits():
 
 def test_make_circuits_invalid_circuit_type():
     settings = Settings(
-        circuit_types=["foobar"],
-        num_qubits=2,
-        circuit_depth=999,
+        [{"circuit_type": "foobar", "num_qubits": 2, "circuit_depth": 999}],
         strategies=[
             {
                 "technique": "zne",
@@ -115,9 +121,7 @@ def test_make_circuits_invalid_circuit_type():
 def test_make_strategies_invalid_technique():
     with pytest.raises(KeyError, match="DESTROY"):
         Settings(
-            circuit_types=["shor"],
-            num_qubits=2,
-            circuit_depth=999,
+            [{"circuit_types": "shor", "num_qubits": 2, "circuit_depth": 999}],
             strategies=[
                 {
                     "technique": "destroy_my_errors",


### PR DESCRIPTION
## Description

Fixes #1679. 

Create the `benchmarks`  parameter in  `Settings` as  a list of dictionaries containing the circuit type, number of qubits, depth, and (for mirror circuits) an optional random seed to be used in generating the circuit for each calibration experiment.


### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file