### PR TITLE
Remove PDF build option for docs

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,11 +1,11 @@
 on:
   push:
     tags:
-      - 'v[0-9].[0-9]+.[0-9]+' # Push events to matching sematic versioning, i.e. v1.0, v20.15.10
+      - "v[0-9].[0-9]+.[0-9]+" # Push events to matching sematic versioning, i.e. v1.0, v20.15.10
 
 jobs:
   #generate_artifacts:
-  # TODO: make docs pdf and tarball
+  # TODO: make docs tarball
   create_release:
     if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,21 +7,17 @@ version: 2
 
 # Set build configuration
 build:
-   os: ubuntu-22.04
-   tools:
-      python: "3.10"
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/source/conf.py
-
-# Optionally build your docs in additional formats such as PDF
-formats:
-   - pdf
+  configuration: docs/source/conf.py
 
 # Declare the installation process
 python:
-   install:
-   # Install Mitiq with "pip install .[development]"
-   - method: pip
-     path: .[development]
+  install:
+    # Install Mitiq with "pip install .[development]"
+    - method: pip
+      path: .[development]

--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,6 @@ format:
 install:
 	pip install -e .[development]
 
-.PHONY: pdf
-pdf:
-	echo "s" | make -C docs latexpdf
-
 .PHONY: requirements
 requirements: requirements.txt
 	pip install -r requirements.txt

--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -126,8 +126,7 @@ source code, and to the API page `apidoc.md`.
 
 ## Build the documentation locally
 The easiest way to build the docs is to run `make docs` from the project 
-root directory, which by default builds the html docs output.
-You can also use run `make pdf` to generate a PDF version.
+root directory, which builds the html docs output.
 
 ```{tip}
 If you want a fresh build with no caching, run `make docs-clean`!
@@ -138,14 +137,8 @@ To call sphinx directly, `cd` into the `docs` directory and run
 sphinx-build -b html source build
 ```
 
-These commands generate the `docs/build` folder. This folder is not kept track of in the
-github repository, as `docs/build` is present in the `.gitignore` file.
-Once the documentation is generated you can view it by opening it in your browser (HTML output) or your PDF viewer (PDF output).
-
-```{note}
-The `html` and `latex` and `pdf` files will be automatically created in the
-`docs/build` folder.
-```
+These commands generate the `docs/build` folder, which is ignore by the `.gitignore` file.
+Once the documentation is generated you can view it by opening it in your browser.
 
 ## Testing the Documentation 
 
@@ -189,7 +182,7 @@ If you have code blocks you want to run, but not be displayed, use the
 
 ````
 ```{testsetup} python
-   import numpy as np  # this block is not rendered in the html or pdf
+   import numpy as np  # this block is not rendered in the html
 ```
 
 ```{testcode} python

--- a/docs/source/examples/template.md
+++ b/docs/source/examples/template.md
@@ -160,7 +160,7 @@ ax.scatter(*data, c=data[2])
 The following cells setup a test (which won't be rendered in the notebook), the test code and the test output cell:
 
 ```{testsetup}
-# this block is not rendered in the html or pdf
+# this block is not rendered in the html
 import numpy as np
 from cirq import Circuit, depolarize
 from cirq import LineQubit, X, DensityMatrixSimulator


### PR DESCRIPTION
## Description

As discussed at the Mitiq meeting (and discovered by @Misty-W), RTD "latest" has been failing for the past 2-3 weeks. The error is related to PDF builds of the docs which we think are not being used by anyone. For that reason we have decided to drop this part of the docs build system, and in particular in our RTD build to workaround this error.

I've removed the code, and associated mentions of PDFs in our docs.

### Testing

As for testing, I'm not sure how to test that this will fix our problems on latest. Any ideas?