### PR TITLE
Fix mypy errors on #1728

### DIFF
--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -213,6 +213,8 @@ class Settings:
             circuit_type = benchmark["circuit_type"]
             num_qubits = benchmark["num_qubits"]
             depth = benchmark.get("circuit_depth")
+            if not depth:
+                depth = num_qubits
             if circuit_type == "ghz":
                 circuit = generate_ghz_circuit(num_qubits)
                 ideal = {"0" * num_qubits: 0.5, "1" * num_qubits: 0.5}

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -212,9 +212,8 @@ class Settings:
         for i, benchmark in enumerate(self.benchmarks):
             circuit_type = benchmark["circuit_type"]
             num_qubits = benchmark["num_qubits"]
-            depth = benchmark.get("circuit_depth")
-            if not depth:
-                depth = num_qubits
+            # Circuits only generated when depth is specified
+            depth = benchmark.get("circuit_depth", -1)
             if circuit_type == "ghz":
                 circuit = generate_ghz_circuit(num_qubits)
                 ideal = {"0" * num_qubits: 0.5, "1" * num_qubits: 0.5}

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -212,7 +212,7 @@ class Settings:
         for i, benchmark in enumerate(self.benchmarks):
             circuit_type = benchmark["circuit_type"]
             num_qubits = benchmark["num_qubits"]
-            # Circuits only generated when depth is specified
+            # Set default to return correct type
             depth = benchmark.get("circuit_depth", -1)
             if circuit_type == "ghz":
                 circuit = generate_ghz_circuit(num_qubits)

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -160,14 +160,14 @@ class Strategy:
 
 
 class Settings:
-    r"""A class to store the configuration settings of a :class:`.Calibrator`.
+    """A class to store the configuration settings of a :class:`.Calibrator`.
 
     Args:
         benchmarks: A list where each element is a dictionary of parameters for
             generating circuits to be used in calibration experiments. The
-            dictionary keys include ``"circuit_type"``, ``"num_qubits"``,
-            ``"circuit_depth"``, and in the case of mirror circuits, a random
-            seed ``"circuit_seed"``. An example of input to ``benchmarks`` is::
+            dictionary keys include ``circuit_type``, ``num_qubits``,
+            ``circuit_depth``, and in the case of mirror circuits, a random
+            seed ``circuit_seed``. An example of input to ``benchmarks`` is::
 
                 [
                     {
@@ -212,13 +212,7 @@ class Settings:
         for i, benchmark in enumerate(self.benchmarks):
             circuit_type = benchmark["circuit_type"]
             num_qubits = benchmark["num_qubits"]
-            if (
-                "circuit_depth" in benchmark.keys()
-                and benchmark["circuit_depth"] is not None
-            ):
-                depth = benchmark["circuit_depth"]
-            else:
-                depth = num_qubits
+            depth = benchmark.get("circuit_depth")
             if circuit_type == "ghz":
                 circuit = generate_ghz_circuit(num_qubits)
                 ideal = {"0" * num_qubits: 0.5, "1" * num_qubits: 0.5}


### PR DESCRIPTION
## Description
Type check failing on `master` due to missing default on `benchmark.get("circuit_depth")`

See https://github.com/unitaryfund/mitiq/actions/runs/4286350547/jobs/7465806334#step:5:13

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file