### PR TITLE
simplify copyright notice

### DIFF
--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,14 +1,4 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Mitiq accuracy and timing benchmarks."""
 

--- a/mitiq/__init__.py
+++ b/mitiq/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 # Quantum computer input/output.
 from mitiq.typing import (

--- a/mitiq/__init__.py
+++ b/mitiq/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/_about.py
+++ b/mitiq/_about.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Information about Mitiq and dependencies."""
 import platform

--- a/mitiq/_about.py
+++ b/mitiq/_about.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/_version.py
+++ b/mitiq/_version.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Reads in version information.
 Note: This file will be overwritten by the packaging process."""

--- a/mitiq/_version.py
+++ b/mitiq/_version.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/benchmarks/__init__.py
+++ b/mitiq/benchmarks/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.benchmarks.randomized_benchmarking import generate_rb_circuits
 from mitiq.benchmarks.mirror_circuits import generate_mirror_circuit

--- a/mitiq/benchmarks/__init__.py
+++ b/mitiq/benchmarks/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/benchmarks/ghz_circuits.py
+++ b/mitiq/benchmarks/ghz_circuits.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/benchmarks/ghz_circuits.py
+++ b/mitiq/benchmarks/ghz_circuits.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions for creating GHZ circuits for benchmarking purposes."""
 from typing import Optional

--- a/mitiq/benchmarks/mirror_circuits.py
+++ b/mitiq/benchmarks/mirror_circuits.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/benchmarks/mirror_circuits.py
+++ b/mitiq/benchmarks/mirror_circuits.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions for creating mirror circuits as defined in
 :cite:`Proctor_2021_NatPhys` for benchmarking quantum computers

--- a/mitiq/benchmarks/quantum_volume_circuits.py
+++ b/mitiq/benchmarks/quantum_volume_circuits.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/benchmarks/quantum_volume_circuits.py
+++ b/mitiq/benchmarks/quantum_volume_circuits.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions for creating circuits of the form used in quantum
 volume experiments as defined in https://arxiv.org/abs/1811.12926.

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions for generating randomized benchmarking circuits."""
 from typing import List, Optional, cast

--- a/mitiq/benchmarks/tests/test_ghz_circuits.py
+++ b/mitiq/benchmarks/tests/test_ghz_circuits.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/benchmarks/tests/test_ghz_circuits.py
+++ b/mitiq/benchmarks/tests/test_ghz_circuits.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for GHZ circuits."""
 

--- a/mitiq/benchmarks/tests/test_mirror_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_circuits.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/benchmarks/tests/test_mirror_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_circuits.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for mirror circuits."""
 

--- a/mitiq/benchmarks/tests/test_quantum_volume_circuits.py
+++ b/mitiq/benchmarks/tests/test_quantum_volume_circuits.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/benchmarks/tests/test_quantum_volume_circuits.py
+++ b/mitiq/benchmarks/tests/test_quantum_volume_circuits.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for quantum volume circuits. The Cirq functions that do the main work
 are tested here:

--- a/mitiq/benchmarks/tests/test_randomized_benchmarking.py
+++ b/mitiq/benchmarks/tests/test_randomized_benchmarking.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/benchmarks/tests/test_randomized_benchmarking.py
+++ b/mitiq/benchmarks/tests/test_randomized_benchmarking.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for randomized benchmarking circuits."""
 

--- a/mitiq/calibration/__init__.py
+++ b/mitiq/calibration/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/calibration/__init__.py
+++ b/mitiq/calibration/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.calibration.calibrator import Calibrator, execute_with_mitigation
 from mitiq.calibration.settings import Settings, ZNESettings

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Callable, Dict, Optional, Union, cast
 import warnings

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass, asdict
 from functools import partial

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for the Clifford data regression top-level API."""
 from functools import partial

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 import pytest
 import json
 

--- a/mitiq/cdr/__init__.py
+++ b/mitiq/cdr/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Clifford data regression method for error mitigation as introduced in:
 

--- a/mitiq/cdr/__init__.py
+++ b/mitiq/cdr/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/cdr/_testing.py
+++ b/mitiq/cdr/_testing.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/cdr/_testing.py
+++ b/mitiq/cdr/_testing.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 import numpy as np
 import cirq

--- a/mitiq/cdr/cdr.py
+++ b/mitiq/cdr/cdr.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """API for using Clifford Data Regression (CDR) error mitigation."""
 

--- a/mitiq/cdr/cdr.py
+++ b/mitiq/cdr/cdr.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/cdr/clifford_training_data.py
+++ b/mitiq/cdr/clifford_training_data.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/cdr/clifford_training_data.py
+++ b/mitiq/cdr/clifford_training_data.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions for mapping circuits to (near) Clifford circuits."""
 from typing import List, Optional, Sequence, Union, Any, cast

--- a/mitiq/cdr/clifford_utils.py
+++ b/mitiq/cdr/clifford_utils.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions for mapping circuits to (near) Clifford circuits."""
 from typing import List

--- a/mitiq/cdr/clifford_utils.py
+++ b/mitiq/cdr/clifford_utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/cdr/data_regression.py
+++ b/mitiq/cdr/data_regression.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """The data regression portion of Clifford data regression."""
 from typing import Sequence

--- a/mitiq/cdr/data_regression.py
+++ b/mitiq/cdr/data_regression.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/cdr/tests/test_cdr.py
+++ b/mitiq/cdr/tests/test_cdr.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for the Clifford data regression top-level API."""
 import pytest

--- a/mitiq/cdr/tests/test_cdr.py
+++ b/mitiq/cdr/tests/test_cdr.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/cdr/tests/test_clifford_training_data.py
+++ b/mitiq/cdr/tests/test_clifford_training_data.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/cdr/tests/test_clifford_training_data.py
+++ b/mitiq/cdr/tests/test_clifford_training_data.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for generating (near) Clifford circuits."""
 import pytest

--- a/mitiq/cdr/tests/test_clifford_utils.py
+++ b/mitiq/cdr/tests/test_clifford_utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/cdr/tests/test_clifford_utils.py
+++ b/mitiq/cdr/tests/test_clifford_utils.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for generating (near) Clifford circuits."""
 import pytest

--- a/mitiq/cdr/tests/test_data_regression.py
+++ b/mitiq/cdr/tests/test_data_regression.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/cdr/tests/test_data_regression.py
+++ b/mitiq/cdr/tests/test_data_regression.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for the data regression portion of Clifford data regression."""
 import pytest

--- a/mitiq/ddd/__init__.py
+++ b/mitiq/ddd/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/ddd/__init__.py
+++ b/mitiq/ddd/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Digital dynamical decoupling (DDD) module."""
 

--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """High-level digital dynamical decoupling (DDD) tools."""
 

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tools to determine slack windows in circuits and to insert DDD sequences."""
 from cirq import Circuit, LineQubit, synchronize_terminal_measurements

--- a/mitiq/ddd/rules/__init__.py
+++ b/mitiq/ddd/rules/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/ddd/rules/__init__.py
+++ b/mitiq/ddd/rules/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Built-in rules determining what DDD sequence should be applied in a given slack window."""
 from mitiq.ddd.rules.rules import xx, xyxy, yy, general_rule, repeated_rule

--- a/mitiq/ddd/rules/rules.py
+++ b/mitiq/ddd/rules/rules.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Built-in rules determining what DDD sequence should be applied in a given
 slack window.

--- a/mitiq/ddd/rules/rules.py
+++ b/mitiq/ddd/rules/rules.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/ddd/rules/tests/test_rules.py
+++ b/mitiq/ddd/rules/tests/test_rules.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/ddd/rules/tests/test_rules.py
+++ b/mitiq/ddd/rules/tests/test_rules.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for DDD rules."""
 from mitiq.ddd.rules.rules import general_rule, xx, xyxy, yy, repeated_rule

--- a/mitiq/ddd/tests/test_ddd.py
+++ b/mitiq/ddd/tests/test_ddd.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/ddd/tests/test_ddd.py
+++ b/mitiq/ddd/tests/test_ddd.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for high-level DDD tools."""
 

--- a/mitiq/ddd/tests/test_insertion.py
+++ b/mitiq/ddd/tests/test_insertion.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/ddd/tests/test_insertion.py
+++ b/mitiq/ddd/tests/test_insertion.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for DDD slack windows and DDD insertion tools."""
 

--- a/mitiq/executor/__init__.py
+++ b/mitiq/executor/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/executor/__init__.py
+++ b/mitiq/executor/__init__.py
@@ -1,16 +1,6 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.executor.executor import Executor

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Defines utilities for efficiently running collections of circuits generated
 by error mitigation techniques to compute expectation values."""

--- a/mitiq/executor/tests/test_executor.py
+++ b/mitiq/executor/tests/test_executor.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/executor/tests/test_executor.py
+++ b/mitiq/executor/tests/test_executor.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for Collector."""
 import pytest

--- a/mitiq/interface/__init__.py
+++ b/mitiq/interface/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.interface.conversions import (
     accept_any_qprogram_as_input,

--- a/mitiq/interface/__init__.py
+++ b/mitiq/interface/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions for converting to/from Mitiq's internal circuit representation."""
 from functools import wraps

--- a/mitiq/interface/mitiq_braket/__init__.py
+++ b/mitiq/interface/mitiq_braket/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_braket/__init__.py
+++ b/mitiq/interface/mitiq_braket/__init__.py
@@ -1,16 +1,6 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.interface.mitiq_braket.conversions import from_braket, to_braket

--- a/mitiq/interface/mitiq_braket/conversions.py
+++ b/mitiq/interface/mitiq_braket/conversions.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 from typing import cast, List, Optional, Union
 
 import numpy as np

--- a/mitiq/interface/mitiq_braket/conversions.py
+++ b/mitiq/interface/mitiq_braket/conversions.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
+++ b/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 import pytest
 import numpy as np

--- a/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
+++ b/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_cirq/__init__.py
+++ b/mitiq/interface/mitiq_cirq/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.interface.mitiq_cirq.cirq_utils import (
     sample_bitstrings,

--- a/mitiq/interface/mitiq_cirq/__init__.py
+++ b/mitiq/interface/mitiq_cirq/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 """Cirq utility functions."""
 
 from typing import Tuple

--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 """ Tests for Cirq executors defined in cirq_utils.py"""
 
 import numpy as np

--- a/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_pennylane/__init__.py
+++ b/mitiq/interface/mitiq_pennylane/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_pennylane/__init__.py
+++ b/mitiq/interface/mitiq_pennylane/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.interface.mitiq_pennylane.conversions import (
     from_pennylane,

--- a/mitiq/interface/mitiq_pennylane/conversions.py
+++ b/mitiq/interface/mitiq_pennylane/conversions.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_pennylane/conversions.py
+++ b/mitiq/interface/mitiq_pennylane/conversions.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions to convert between Mitiq's internal circuit representation and
 Pennylane's circuit representation.

--- a/mitiq/interface/mitiq_pennylane/tests/test_conversions_pennylane.py
+++ b/mitiq/interface/mitiq_pennylane/tests/test_conversions_pennylane.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for Pennylane <-> Cirq conversions."""
 

--- a/mitiq/interface/mitiq_pennylane/tests/test_conversions_pennylane.py
+++ b/mitiq/interface/mitiq_pennylane/tests/test_conversions_pennylane.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_pyquil/__init__.py
+++ b/mitiq/interface/mitiq_pyquil/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_pyquil/__init__.py
+++ b/mitiq/interface/mitiq_pyquil/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.interface.mitiq_pyquil.conversions import (
     from_pyquil,

--- a/mitiq/interface/mitiq_pyquil/compiler.py
+++ b/mitiq/interface/mitiq_pyquil/compiler.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Provides a utility basic_compile to allow for running on QCS without
 using quilc, as quilc will optimize away unitary folding.

--- a/mitiq/interface/mitiq_pyquil/compiler.py
+++ b/mitiq/interface/mitiq_pyquil/compiler.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_pyquil/conversions.py
+++ b/mitiq/interface/mitiq_pyquil/conversions.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions to convert between Mitiq's internal circuit representation and
 pyQuil's circuit representation (Quil programs).

--- a/mitiq/interface/mitiq_pyquil/conversions.py
+++ b/mitiq/interface/mitiq_pyquil/conversions.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_pyquil/tests/test_conversions_pyquil.py
+++ b/mitiq/interface/mitiq_pyquil/tests/test_conversions_pyquil.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_pyquil/tests/test_conversions_pyquil.py
+++ b/mitiq/interface/mitiq_pyquil/tests/test_conversions_pyquil.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests conversions to/from pyQuil circuits."""
 import numpy as np

--- a/mitiq/interface/mitiq_pyquil/tests/test_pyquil_compiler.py
+++ b/mitiq/interface/mitiq_pyquil/tests/test_pyquil_compiler.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_pyquil/tests/test_pyquil_compiler.py
+++ b/mitiq/interface/mitiq_pyquil/tests/test_pyquil_compiler.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """NB: Copied in large part from rigetti/forest-benchmarking (Apache-2.0)
 and modified to test a larger gateset.

--- a/mitiq/interface/mitiq_pyquil/tests/test_zne_mitiq_pyquil.py
+++ b/mitiq/interface/mitiq_pyquil/tests/test_zne_mitiq_pyquil.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_pyquil/tests/test_zne_mitiq_pyquil.py
+++ b/mitiq/interface/mitiq_pyquil/tests/test_zne_mitiq_pyquil.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for zne.py with PyQuil backend."""
 import numpy as np

--- a/mitiq/interface/mitiq_qiskit/__init__.py
+++ b/mitiq/interface/mitiq_qiskit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_qiskit/__init__.py
+++ b/mitiq/interface/mitiq_qiskit/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.interface.mitiq_qiskit.conversions import (
     from_qasm,

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions to convert between Mitiq's internal circuit representation and
 Qiskit's circuit representation.

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/qiskit_utils.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Qiskit utility functions."""
 from typing import Tuple

--- a/mitiq/interface/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/qiskit_utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for conversions between Mitiq circuits and Qiskit circuits."""
 import copy

--- a/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for qiskit executors (qiskit_utils.py)."""
 import pytest

--- a/mitiq/observable/__init__.py
+++ b/mitiq/observable/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/observable/__init__.py
+++ b/mitiq/observable/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.observable.pauli import PauliString
 from mitiq.observable.observable import Observable

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 import copy
 from typing import Callable, cast, List, Optional, Set

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from collections import Counter
 from typing import (

--- a/mitiq/observable/tests/test_observable.py
+++ b/mitiq/observable/tests/test_observable.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 import functools
 import pytest

--- a/mitiq/observable/tests/test_observable.py
+++ b/mitiq/observable/tests/test_observable.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/observable/tests/test_pauli.py
+++ b/mitiq/observable/tests/test_pauli.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/observable/tests/test_pauli.py
+++ b/mitiq/observable/tests/test_pauli.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from collections import Counter
 import pytest

--- a/mitiq/pec/__init__.py
+++ b/mitiq/pec/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/__init__.py
+++ b/mitiq/pec/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.pec.types import NoisyOperation, OperationRepresentation, NoisyBasis
 from mitiq.pec.sampling import sample_sequence, sample_circuit

--- a/mitiq/pec/channels.py
+++ b/mitiq/pec/channels.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 # TODO: Functions which don't fit in pec.py and sampling.py are placed here.
 #  Some of them could be moved in future new sub-modules of PEC

--- a/mitiq/pec/channels.py
+++ b/mitiq/pec/channels.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """High-level probabilistic error cancellation tools."""
 

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/representations/__init__.py
+++ b/mitiq/pec/representations/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 
 from mitiq.pec.representations.depolarizing import (

--- a/mitiq/pec/representations/__init__.py
+++ b/mitiq/pec/representations/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 """Function to generate representations with biased noise."""
 import copy
 from typing import List

--- a/mitiq/pec/representations/damping.py
+++ b/mitiq/pec/representations/damping.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 """Functions related to representations with amplitude damping noise."""
 
 from typing import List

--- a/mitiq/pec/representations/damping.py
+++ b/mitiq/pec/representations/damping.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/representations/depolarizing.py
+++ b/mitiq/pec/representations/depolarizing.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/representations/depolarizing.py
+++ b/mitiq/pec/representations/depolarizing.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 """Functions related to representations with depolarizing noise."""
 
 import copy

--- a/mitiq/pec/representations/learning.py
+++ b/mitiq/pec/representations/learning.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/representations/learning.py
+++ b/mitiq/pec/representations/learning.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 """Functions to calculate parameters for depolarizing noise and biased noise
 models via a learning-based technique."""
 

--- a/mitiq/pec/representations/optimal.py
+++ b/mitiq/pec/representations/optimal.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions for finding optimal representations given a noisy basis."""
 

--- a/mitiq/pec/representations/optimal.py
+++ b/mitiq/pec/representations/optimal.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/representations/tests/test_biased_noise.py
+++ b/mitiq/pec/representations/tests/test_biased_noise.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 import numpy as np
 import pytest

--- a/mitiq/pec/representations/tests/test_biased_noise.py
+++ b/mitiq/pec/representations/tests/test_biased_noise.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/representations/tests/test_damping.py
+++ b/mitiq/pec/representations/tests/test_damping.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 import numpy as np
 import pytest

--- a/mitiq/pec/representations/tests/test_damping.py
+++ b/mitiq/pec/representations/tests/test_damping.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/representations/tests/test_depolarizing.py
+++ b/mitiq/pec/representations/tests/test_depolarizing.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 import numpy as np
 import pytest

--- a/mitiq/pec/representations/tests/test_depolarizing.py
+++ b/mitiq/pec/representations/tests/test_depolarizing.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/representations/tests/test_learning.py
+++ b/mitiq/pec/representations/tests/test_learning.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/representations/tests/test_learning.py
+++ b/mitiq/pec/representations/tests/test_learning.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 import os
 import numpy as np

--- a/mitiq/pec/representations/tests/test_optimal.py
+++ b/mitiq/pec/representations/tests/test_optimal.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from pytest import mark, raises
 import numpy as np

--- a/mitiq/pec/representations/tests/test_optimal.py
+++ b/mitiq/pec/representations/tests/test_optimal.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/sampling.py
+++ b/mitiq/pec/sampling.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/sampling.py
+++ b/mitiq/pec/sampling.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tools for sampling from the noisy representations of ideal operations."""
 

--- a/mitiq/pec/tests/test_channels.py
+++ b/mitiq/pec/tests/test_channels.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/tests/test_channels.py
+++ b/mitiq/pec/tests/test_channels.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests related to the functions contained in `mitiq.pec.channels`."""
 

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for PEC."""
 import warnings

--- a/mitiq/pec/tests/test_pec_sampling.py
+++ b/mitiq/pec/tests/test_pec_sampling.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/tests/test_pec_sampling.py
+++ b/mitiq/pec/tests/test_pec_sampling.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for mitiq.pec.sampling functions."""
 

--- a/mitiq/pec/types/__init__.py
+++ b/mitiq/pec/types/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/types/__init__.py
+++ b/mitiq/pec/types/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.pec.types.types import (
     NoisyOperation,

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 import numpy as np
 import pytest

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/pec/types/types.py
+++ b/mitiq/pec/types/types.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Types used in probabilistic error cancellation."""
 from copy import deepcopy

--- a/mitiq/pec/types/types.py
+++ b/mitiq/pec/types/types.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/raw/__init__.py
+++ b/mitiq/raw/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/raw/__init__.py
+++ b/mitiq/raw/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Run experiments without error mitigation using the same interface as error
 mitigation."""

--- a/mitiq/raw/raw.py
+++ b/mitiq/raw/raw.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Run experiments without error mitigation."""
 from typing import Callable, Optional, Union

--- a/mitiq/raw/raw.py
+++ b/mitiq/raw/raw.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/raw/tests/test_raw.py
+++ b/mitiq/raw/tests/test_raw.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for RAW (no error mitigation)."""
 

--- a/mitiq/raw/tests/test_raw.py
+++ b/mitiq/raw/tests/test_raw.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/rem/__init__.py
+++ b/mitiq/rem/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Readout error mitigation (REM) techniques."""
 

--- a/mitiq/rem/__init__.py
+++ b/mitiq/rem/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/rem/inverse_confusion_matrix.py
+++ b/mitiq/rem/inverse_confusion_matrix.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/rem/inverse_confusion_matrix.py
+++ b/mitiq/rem/inverse_confusion_matrix.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from functools import reduce
 from typing import List, Sequence

--- a/mitiq/rem/post_select.py
+++ b/mitiq/rem/post_select.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Callable
 

--- a/mitiq/rem/post_select.py
+++ b/mitiq/rem/post_select.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/rem/rem.py
+++ b/mitiq/rem/rem.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Readout Confusion Inversion."""
 

--- a/mitiq/rem/rem.py
+++ b/mitiq/rem/rem.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/rem/tests/test_inverse_confusion_matrix.py
+++ b/mitiq/rem/tests/test_inverse_confusion_matrix.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/rem/tests/test_inverse_confusion_matrix.py
+++ b/mitiq/rem/tests/test_inverse_confusion_matrix.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for inverse confusion matrix helper functions."""
 

--- a/mitiq/rem/tests/test_post_select.py
+++ b/mitiq/rem/tests/test_post_select.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for postselection of measurement results."""
 import pytest

--- a/mitiq/rem/tests/test_post_select.py
+++ b/mitiq/rem/tests/test_post_select.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/rem/tests/test_rem.py
+++ b/mitiq/rem/tests/test_rem.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for readout confusion inversion."""
 from typing import List

--- a/mitiq/rem/tests/test_rem.py
+++ b/mitiq/rem/tests/test_rem.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/tests/test_conversions.py
+++ b/mitiq/tests/test_conversions.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/tests/test_conversions.py
+++ b/mitiq/tests/test_conversions.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for circuit conversions."""
 

--- a/mitiq/tests/test_measurement_result.py
+++ b/mitiq/tests/test_measurement_result.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for measurement results."""
 import pytest

--- a/mitiq/tests/test_measurement_result.py
+++ b/mitiq/tests/test_measurement_result.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/tests/test_utils.py
+++ b/mitiq/tests/test_utils.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for utility functions."""
 from copy import deepcopy

--- a/mitiq/tests/test_utils.py
+++ b/mitiq/tests/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/tests/test_without_third_party_packages.py
+++ b/mitiq/tests/test_without_third_party_packages.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/tests/test_without_third_party_packages.py
+++ b/mitiq/tests/test_without_third_party_packages.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests to make sure Mitiq works without optional packages like Qiskit,
 pyQuil, etc.

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Defines input / output types for a quantum computer (simulator):
 

--- a/mitiq/utils.py
+++ b/mitiq/utils.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Utility functions."""
 from copy import deepcopy

--- a/mitiq/utils.py
+++ b/mitiq/utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/zne/__init__.py
+++ b/mitiq/zne/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/zne/__init__.py
+++ b/mitiq/zne/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.zne.zne import execute_with_zne, mitigate_executor, zne_decorator
 from mitiq.zne import scaling

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Classes corresponding to different zero-noise extrapolation methods."""
 from abc import ABC, abstractmethod

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/zne/scaling/__init__.py
+++ b/mitiq/zne/scaling/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/zne/scaling/__init__.py
+++ b/mitiq/zne/scaling/__init__.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Methods for scaling noise in circuits by adding or modifying gates."""
 from mitiq.zne.scaling.folding import (

--- a/mitiq/zne/scaling/folding.py
+++ b/mitiq/zne/scaling/folding.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/zne/scaling/folding.py
+++ b/mitiq/zne/scaling/folding.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions for local and global unitary folding on supported circuits."""
 from copy import deepcopy

--- a/mitiq/zne/scaling/identity_insertion.py
+++ b/mitiq/zne/scaling/identity_insertion.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 """Functions for scaling supported circuits by inserting layers of identity
 gates."""
 

--- a/mitiq/zne/scaling/identity_insertion.py
+++ b/mitiq/zne/scaling/identity_insertion.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/zne/scaling/parameter.py
+++ b/mitiq/zne/scaling/parameter.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/zne/scaling/parameter.py
+++ b/mitiq/zne/scaling/parameter.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Optional, Callable, List, cast
 import numpy as np

--- a/mitiq/zne/scaling/tests/test_folding.py
+++ b/mitiq/zne/scaling/tests/test_folding.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/zne/scaling/tests/test_folding.py
+++ b/mitiq/zne/scaling/tests/test_folding.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for scaling noise by unitary folding."""
 import numpy as np

--- a/mitiq/zne/scaling/tests/test_identity_insertion.py
+++ b/mitiq/zne/scaling/tests/test_identity_insertion.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/zne/scaling/tests/test_identity_insertion.py
+++ b/mitiq/zne/scaling/tests/test_identity_insertion.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2022 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for scaling noise by inserting identity layers."""
 import pytest

--- a/mitiq/zne/scaling/tests/test_parameter.py
+++ b/mitiq/zne/scaling/tests/test_parameter.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for parameter scaling."""
 from copy import deepcopy

--- a/mitiq/zne/scaling/tests/test_parameter.py
+++ b/mitiq/zne/scaling/tests/test_parameter.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for zero-noise inference and extrapolation methods (factories) with
 classically generated data.

--- a/mitiq/zne/tests/test_zne.py
+++ b/mitiq/zne/tests/test_zne.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/zne/tests/test_zne.py
+++ b/mitiq/zne/tests/test_zne.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for zero-noise extrapolation."""
 from typing import List

--- a/mitiq/zne/zne.py
+++ b/mitiq/zne/zne.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/zne/zne.py
+++ b/mitiq/zne/zne.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """High-level zero-noise extrapolation tools."""
 from typing import Callable, Optional, Union, List

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright Contributors to the Mitiq project.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from setuptools import setup, find_packages
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Mitiq project.
+# Copyright (C) Unitary Fund
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
## Description

Updates the copyright notice across Python files. This change both removes the copyright symbol `(C)`, the year, and modifies the copyright to be for contributors.

### Motivation

There are two main reasons for suggesting this change.

1. Copyright notice years are out of date, and 
2. our [`CONTRIBUTING.md`](https://github.com/unitaryfund/mitiq/blob/862155c1f1f562305d953125beecbe81bac0dc9b/CONTRIBUTING.md) file does not indicate that contributions from external contributors are transferred to Unitary Fund ownership.

Initially I planned to simply update the years, but after doing some reading (https://hynek.me/til/copyright-years/ and the links therein), updating these dates seems to be unnecessary. The change I've suggested follows the [Linux Foundation's guidelines](https://www.linuxfoundation.org/blog/blog/copyright-notices-in-open-source-software-projects), along with a shorter copyright description as used in many of the linked projects from the article above.

I believe this brings us in line with community best-practices. **No changes to the underlying license are made.**

cc @nathanshammah 