### PR TITLE
 Consider id as slack in ddd circuit mask

### DIFF
--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -151,11 +151,13 @@ def _insert_ddd_sequences(
                     {LineQubit(0): qubits[row_index]}
                 )
                 for idx, op in enumerate(ddd_sequence.all_operations()):
-                    circuit_with_ddd._moments[
-                        moment_idx + idx
-                    ] = circuit_with_ddd._moments[
-                        moment_idx + idx
-                    ].with_operations(
+                    moment = circuit_with_ddd[moment_idx + idx]
+                    op_to_replace = moment.operation_at(*op.qubits)
+
+                    if op_to_replace and op_to_replace.gate == I:
+                        moment = moment.without_operations_touching(op.qubits)
+
+                    circuit_with_ddd[moment_idx + idx] = moment.with_operation(
                         op
                     )
     return circuit_with_ddd

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Tools to determine slack windows in circuits and to insert DDD sequences."""
-from cirq import Circuit, LineQubit, synchronize_terminal_measurements
+from cirq import Circuit, LineQubit, synchronize_terminal_measurements, I
 import numpy as np
 import numpy.typing as npt
 from typing import Callable
@@ -25,8 +25,8 @@ from mitiq import QPROGRAM
 def _get_circuit_mask(circuit: Circuit) -> npt.NDArray[np.int64]:
     """Given a circuit with n qubits and d moments returns a matrix
     :math:`A` with n rows and d columns. The matrix elements are
-    :math:`A_{i,j} = 1` if there is a gate acting on qubit :math:`i` at moment
-    :math:`j`, while :math:`A_{i,j} = 0` otherwise.
+    :math:`A_{i,j} = 1` if there is a non-identity gate acting on qubit
+    :math:`i` at moment :math:`j`, while :math:`A_{i,j} = 0` otherwise.
 
     Args:
         circuit: Input circuit to mask with n qubits and d moments
@@ -40,7 +40,9 @@ def _get_circuit_mask(circuit: Circuit) -> npt.NDArray[np.int64]:
     for moment_index, moment in enumerate(circuit):
         for op in moment:
             qubit_indices = [
-                qubit[0] for qubit in indexed_qubits if qubit[1] in op.qubits
+                qubit[0]
+                for qubit in indexed_qubits
+                if qubit[1] in op.qubits and op.gate != I
             ]
             for qubit_index in qubit_indices:
                 mask_matrix[qubit_index, moment_index] = 1

--- a/mitiq/ddd/tests/test_insertion.py
+++ b/mitiq/ddd/tests/test_insertion.py
@@ -280,3 +280,23 @@ def test_pyquil_midcircuit_measurement_raises_error():
 
     with pytest.raises(ValueError, match="midcircuit measurements"):
         insert_ddd_sequences(p, xx)
+
+
+def test_insert_sequence_over_identity_gates():
+    qubits = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.ops.H.on_each(*qubits),
+        cirq.ops.I.on_each(*qubits),
+        cirq.ops.I.on_each(*qubits),
+        cirq.ops.H.on_each(*qubits),
+    )
+    circuit_expected = cirq.Circuit(
+        cirq.ops.H.on_each(*qubits),
+        cirq.ops.X.on_each(*qubits),
+        cirq.ops.X.on_each(*qubits),
+        cirq.ops.H.on_each(*qubits),
+    )
+
+    ddd_circuit = insert_ddd_sequences(circuit, rule=xx)
+
+    assert ddd_circuit == circuit_expected


### PR DESCRIPTION
## Description

Fixes #1708.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file