### PR TITLE
Make the Calibrator multi-platform

### DIFF
--- a/docs/source/guide/calibrators.md
+++ b/docs/source/guide/calibrators.md
@@ -53,7 +53,7 @@ Before running any experiments, we can call the `get_cost` function to ensure th
 Once instantiated, we call the `run` method to run the set of experiments, and the results of such experiments are stored internal to the class in `cal.results`.
 
 ```{code-cell} ipython3
-cal = Calibrator(execute, ZNESettings)
+cal = Calibrator(execute, ZNESettings, frontend="cirq")
 print(cal.get_cost())
 cal.run()
 ```

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -16,7 +16,6 @@
 from typing import Callable, Dict, Optional, Union, cast
 import warnings
 
-import cirq
 import numpy as np
 import numpy.typing as npt
 
@@ -234,7 +233,7 @@ def convert_to_expval_executor(executor: Executor, bitstring: str) -> Executor:
         the most likely bitstring, according to the passed ``distribution``
     """
 
-    def expval_executor(circuit: cirq.Circuit) -> float:
+    def expval_executor(circuit: QPROGRAM) -> float:
         raw = cast(MeasurementResult, executor.run([circuit])[0])
         distribution = raw.prob_distribution()
         return distribution.get(bitstring, 0.0)

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -15,11 +15,10 @@
 
 from typing import Callable, Dict, Optional, Union, cast, Sequence
 import warnings
-
 import numpy as np
 import numpy.typing as npt
-
 import cirq
+
 from mitiq import (
     QPROGRAM,
     Executor,

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -92,7 +92,6 @@ class BenchmarkProblem:
         Returns:
             The converted circuit with final measurements.
         """
-        # TODO: check circuit_type with SUPPORTED_PROGRAM_TYPES
         circuit = self.circuit.copy()
         circuit.append(cirq.measure(circuit.all_qubits()))
         return convert_from_mitiq(circuit, circuit_type)

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -21,13 +21,14 @@ from enum import Enum, auto
 import networkx as nx
 import cirq
 
+from mitiq import QPROGRAM
+from mitiq.interface import convert_from_mitiq
 from mitiq.benchmarks import (
     generate_ghz_circuit,
     generate_mirror_circuit,
     generate_quantum_volume_circuit,
     generate_rb_circuits,
 )
-
 from mitiq.pec import execute_with_pec
 from mitiq.raw import execute
 from mitiq.zne import execute_with_zne
@@ -80,6 +81,21 @@ class BenchmarkProblem:
 
     def largest_probability(self) -> float:
         return max(self.ideal_distribution.values())
+
+    def converted_circuit(self, circuit_type: str) -> QPROGRAM:
+        """Adds measurements to all qubits and convert
+        to the input frontend type.
+
+        Args:
+            circuit_type: The circuit type as a string.
+                For supported circuit types see mitiq.SUPPORTED_PROGRAM_TYPES.
+        Returns:
+            The converted circuit with final measurements.
+        """
+        # TODO: check circuit_type with SUPPORTED_PROGRAM_TYPES
+        circuit = self.circuit.copy()
+        circuit.append(cirq.measure(circuit.all_qubits()))
+        return convert_from_mitiq(circuit, circuit_type)
 
     @property
     def num_qubits(self) -> int:

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -237,7 +237,7 @@ class Settings:
                 circuit = generate_rb_circuits(num_qubits, depth)[0]
                 ideal = {"0" * num_qubits: 1.0}
             elif circuit_type == "mirror":
-                seed = benchmark["circuit_seed"]
+                seed = benchmark.get("circuit_seed", None)
                 circuit, bitstring_list = generate_mirror_circuit(
                     nlayers=depth,
                     two_qubit_gate_prob=1.0,

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -118,7 +118,7 @@ def non_cirq_execute(circuit):
 
 
 def test_ZNE_workflow():
-    cal = Calibrator(execute, ZNESettings)
+    cal = Calibrator(execute, ZNESettings, frontend="cirq")
     cost = cal.get_cost()
     assert cost == {"noisy_executions": 24, "ideal_executions": 0}
 
@@ -140,7 +140,7 @@ def test_ZNE_workflow_multi_platform(circuit_type):
     cal = Calibrator(
         non_cirq_execute,
         light_settings,
-        frontend_type=circuit_type,
+        frontend=circuit_type,
     )
     cost = cal.get_cost()
     assert cost == {"noisy_executions": 2, "ideal_executions": 0}
@@ -153,7 +153,7 @@ def test_ZNE_workflow_multi_platform(circuit_type):
 
 
 def test_get_cost():
-    cal = Calibrator(execute, settings)
+    cal = Calibrator(execute, settings, frontend="cirq")
     cost = cal.get_cost()
     expected_cost = 2 * 4  # circuits * num_experiments
     assert cost["noisy_executions"] == expected_cost
@@ -195,7 +195,7 @@ def test_best_strategy():
         ],
     )
 
-    cal = Calibrator(execute, test_strategy_settings)
+    cal = Calibrator(execute, test_strategy_settings, frontend="cirq")
     cal.run()
     assert not np.isnan(cal.results.mitigated).all()
 
@@ -216,7 +216,7 @@ def test_convert_to_expval_executor():
 
 
 def test_execute_with_mitigation(monkeypatch):
-    cal = Calibrator(execute, ZNESettings)
+    cal = Calibrator(execute, ZNESettings, frontend="cirq")
 
     expval_executor = convert_to_expval_executor(
         Executor(execute), bitstring="00"
@@ -234,7 +234,7 @@ def test_execute_with_mitigation(monkeypatch):
 
 
 def test_double_run():
-    cal = Calibrator(execute, ZNESettings)
+    cal = Calibrator(execute, ZNESettings, frontend="cirq")
     cal.run()
     cal.run()
 
@@ -273,7 +273,7 @@ def test_ExtrapolationResults_best_strategy():
 
 
 def test_logging(capfd):
-    cal = Calibrator(execute, ZNESettings)
+    cal = Calibrator(execute, ZNESettings, frontend="cirq")
     cal.run(log=True)
 
     captured = capfd.readouterr()

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -14,9 +14,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import pytest
 import json
+import cirq
+import qiskit
 
+from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES
 from mitiq.calibration import ZNESettings, Settings
-from mitiq.calibration.settings import MitigationTechnique
+from mitiq.calibration.settings import MitigationTechnique, BenchmarkProblem
 from mitiq.raw import execute
 from mitiq.pec import execute_with_pec
 from mitiq.zne.scaling import fold_global
@@ -144,3 +147,27 @@ def test_ZNESettings():
 
     assert len(circuits) == 3
     assert len(strategies) == 2 * 2 * 2
+
+
+@pytest.mark.parametrize("circuit_type", SUPPORTED_PROGRAM_TYPES.keys())
+def test_benchmark_problem_class(circuit_type):
+    qubit = cirq.LineQubit(0)
+    circuit = cirq.Circuit(cirq.X(qubit))
+    circuit_with_measurements = circuit.copy()
+    circuit_with_measurements.append(cirq.measure(qubit))
+    problem = BenchmarkProblem(
+        id=7,
+        circuit=circuit,
+        type="",
+        ideal_distribution={},
+    )
+    assert problem.circuit == circuit
+    conv_circ = problem.converted_circuit(circuit_type)
+    assert isinstance(conv_circ, QPROGRAM)
+    if circuit_type == "qiskit":
+        qreg = qiskit.QuantumRegister(1, name="q")
+        creg = qiskit.ClassicalRegister(1, name="m0")
+        expected = qiskit.QuantumCircuit(qreg, creg)
+        expected.x(0)
+        expected.measure(0, 0)
+        assert conv_circ == expected

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -163,7 +163,8 @@ def test_benchmark_problem_class(circuit_type):
     )
     assert problem.circuit == circuit
     conv_circ = problem.converted_circuit(circuit_type)
-    assert isinstance(conv_circ, QPROGRAM)
+    assert any([isinstance(conv_circ, q) for q in QPROGRAM.__args__])
+    # For at least one case, test the circuit is correct and has measurements
     if circuit_type == "qiskit":
         qreg = qiskit.QuantumRegister(1, name="q")
         creg = qiskit.ClassicalRegister(1, name="m0")

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -224,7 +224,7 @@ class Executor:
     def run(
         self,
         circuits: Sequence[QPROGRAM],
-        force_run_all: bool = False,
+        force_run_all: bool = True,
         **kwargs: Any,
     ) -> Sequence[QuantumResult]:
         """Runs all input circuits using the least number of possible calls to

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -224,7 +224,7 @@ class Executor:
     def run(
         self,
         circuits: Sequence[QPROGRAM],
-        force_run_all: bool = True,
+        force_run_all: bool = False,
         **kwargs: Any,
     ) -> Sequence[QuantumResult]:
         """Runs all input circuits using the least number of possible calls to

--- a/mitiq/interface/mitiq_braket/conversions.py
+++ b/mitiq/interface/mitiq_braket/conversions.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from typing import cast, List, Optional, Union
+from warnings import warn
 
 import numpy as np
 import numpy.typing as npt
@@ -122,6 +123,11 @@ def _translate_cirq_operation_to_braket_instruction(
     Raises:
         ValueError: If the operation cannot be converted to Braket.
     """
+    # Measurement gates do not exist in Braket.
+    if isinstance(op.gate, cirq_ops.MeasurementGate):
+        warn("Measurement gate removed when converting from Cirq to Braket.")
+        return []
+
     nqubits = protocols.num_qubits(op)
 
     if nqubits == 1:


### PR DESCRIPTION
## Description

This is a possible solution to fix #1746. Me and @Misty-W drafted this in a live coding call :rocket: !

Tests are missing.
Design could be changed. E.g. I am not sure what is the best place to ask the user for  `frontend_type`. Now this is an argument of `Calibrator`.

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
