### PR TITLE
Set default force_run_all as True in PEC

### DIFF
--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -271,14 +271,12 @@ class Executor:
                 batch = to_run[i * step : (i + 1) * step]
                 self._call_executor(batch, **kwargs)
 
-        these_results = self._quantum_results[start_result_index:]
+        results = self._quantum_results[start_result_index:]
 
-        if force_run_all:
-            return these_results
-
-        # Expand computed results to all results using counts.
-        results_dict = dict(zip(collection.keys(), these_results))
-        results = [results_dict[key] for key in hashable_circuits]
+        if not force_run_all:
+            # Expand computed results to all results using counts.
+            results_dict = dict(zip(collection.keys(), results))
+            results = [results_dict[key] for key in hashable_circuits]
 
         return self._post_run(results)
 

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -120,7 +120,7 @@ class Executor:
         self,
         circuits: Union[QPROGRAM, List[QPROGRAM]],
         observable: Optional[Observable] = None,
-        force_run_all: bool = False,
+        force_run_all: bool = True,
         **kwargs: Any,
     ) -> List[float]:
         """Returns the expectation value Tr[ρ O] for each circuit in
@@ -224,7 +224,7 @@ class Executor:
     def run(
         self,
         circuits: Sequence[QPROGRAM],
-        force_run_all: bool = False,
+        force_run_all: bool = True,
         **kwargs: Any,
     ) -> Sequence[QuantumResult]:
         """Runs all input circuits using the least number of possible calls to

--- a/mitiq/executor/tests/test_executor.py
+++ b/mitiq/executor/tests/test_executor.py
@@ -117,7 +117,7 @@ def test_executor_non_hermitian_observable():
 def test_run_executor_identical_circuits_batched(ncircuits, executor):
     collector = Executor(executor=executor, max_batch_size=10)
     circuits = [cirq.Circuit(cirq.H(cirq.LineQubit(0)))] * ncircuits
-    results = collector.run(circuits)
+    results = collector.run(circuits, force_run_all=False)
 
     assert np.allclose(results, np.zeros(ncircuits))
     assert collector.calls_to_executor == 1
@@ -134,7 +134,7 @@ def test_run_executor_nonidentical_pyquil_programs(batch_size):
         pyquil.Program(pyquil.gates.X(0)),
         pyquil.Program(pyquil.gates.H(0)),
     ] * 10
-    results = collector.run(circuits)
+    results = collector.run(circuits, force_run_all=False)
 
     assert np.allclose(results, np.zeros(len(circuits)))
     if batch_size == 1:

--- a/mitiq/rem/rem.py
+++ b/mitiq/rem/rem.py
@@ -87,7 +87,7 @@ def mitigate_executor(
         executor_obj = deepcopy(executor)
 
     def post_run(
-        self: MeasurementResult,
+        self: Executor,
         results: Sequence[MeasurementResult],
     ) -> Sequence[MeasurementResult]:
         return [


### PR DESCRIPTION
Set default force_run_all as True in PEC.
This is safer because the procedure used when `force_run_all = False` is too unreliable (due to conversions) and statistically questionable since it would require scaling the number of shots proportionally to the counts of equal circuits.



### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.