### PR TITLE
Quantum Phase Estimation Benchmarking Circuit

### DIFF
--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -744,6 +744,15 @@
   doi       = {10.1103/PhysRevA.94.052325},
   url       = {https://link.aps.org/doi/10.1103/PhysRevA.94.052325},
 }
+
+@book{Wong_2022,
+  title     = {Introduction to Classical and Quantum Computing},
+  author    = {Wong, Thomas G.},
+  isbn      = {9798985593105},
+  lccn      = {2022900358},
+  year      = {2022},
+  publisher = {Rooted Grove},
+}
 # Letter X
 # Letter Y
 # Letter Z

--- a/mitiq/benchmarks/__init__.py
+++ b/mitiq/benchmarks/__init__.py
@@ -20,3 +20,4 @@ from mitiq.benchmarks.quantum_volume_circuits import (
     generate_quantum_volume_circuit,
 )
 from mitiq.benchmarks.w_state_circuits import generate_w_circuit
+from mitiq.benchmarks.qpe_circuits import generate_qpe_circuit

--- a/mitiq/benchmarks/qpe_circuits.py
+++ b/mitiq/benchmarks/qpe_circuits.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright (C) 2023 Unitary Fund
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,11 +12,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-from mitiq.benchmarks.randomized_benchmarking import generate_rb_circuits
-from mitiq.benchmarks.mirror_circuits import generate_mirror_circuit
-from mitiq.benchmarks.ghz_circuits import generate_ghz_circuit
-from mitiq.benchmarks.quantum_volume_circuits import (
-    generate_quantum_volume_circuit,
-)
-from mitiq.benchmarks.w_state_circuits import generate_w_circuit

--- a/mitiq/benchmarks/qpe_circuits.py
+++ b/mitiq/benchmarks/qpe_circuits.py
@@ -61,6 +61,7 @@ def generate_qpe_circuit(
     for i in range(evalue_reg):
         hadamard_circuit.append(cirq.H(qreg[i]))
     circuit = circuit + hadamard_circuit
+
     for i in range(total_num_qubits - 1)[::-1]:
         circuit.append(
             [input_gate(qreg[-1]).controlled_by(qreg[i])]

--- a/mitiq/benchmarks/qpe_circuits.py
+++ b/mitiq/benchmarks/qpe_circuits.py
@@ -12,3 +12,79 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+""" Functions to create a QPE circuit"""
+from typing import Optional
+import cirq
+from mitiq import QPROGRAM
+from mitiq.interface import convert_from_mitiq
+
+
+def generate_qpe_circuit(
+    evalue_reg: int,
+    input_gate: cirq.Gate,
+    return_type: Optional[str] = None,
+) -> QPROGRAM:
+    """Returns a circuit to create a Quantum Phase Estimation circuit as
+    defined in https://en.wikipedia.org/wiki/Quantum_phase_estimation_algorithm
+
+    The IQFT circuit defined in this method is taken from taken from Sec 7.7.4
+    of :cite:`Wong_2022`.
+    Args:
+        evalue_reg : Number of qubits in the eigenvalue register
+        input_gate: A quantum gate
+        return_type: Return type of the output circuit.
+    Returns:
+        A Quantum Phase Estimation circuit.
+    """
+    if evalue_reg <= 0:
+        raise ValueError(
+            f"Arg `evalue_reg` must be positive but was {evalue_reg}."
+        )
+    num_qubits_for_gate = input_gate.num_qubits()
+    if num_qubits_for_gate > 1:
+        raise ValueError(
+            "This QPE circuit generation method only works for 1-qubit gates."
+        )
+
+    if evalue_reg < num_qubits_for_gate:
+        raise ValueError(
+            "The eigenvalue register must be larger than the eigenstate reg."
+        )
+
+    total_num_qubits = evalue_reg + num_qubits_for_gate
+    qreg = cirq.LineQubit.range(total_num_qubits)
+    circuit = cirq.Circuit()
+
+    # QFT circuit
+    # apply hadamard and controlled unitary to the qubits in the eigenvalue reg
+    for i in range(evalue_reg):
+        circuit.append(cirq.H(qreg[i]))
+    for i in range(total_num_qubits - 1)[::-1]:
+        circuit.append(
+            [input_gate(qreg[-1]).controlled_by(qreg[i])]
+            * (2 ** (evalue_reg - 1 - i))
+        )
+
+    # IQFT of the eigenvalue register
+    # swap the qubits in the eigenvalue register
+    for i in range(int(evalue_reg / 2)):
+        circuit.append(
+            cirq.SWAP(qreg[i], qreg[evalue_reg - 1 - i]),
+            strategy=cirq.InsertStrategy.NEW,
+        )
+    # apply inverse of hadamard and controlled unitary
+    for i in range(evalue_reg):
+        circuit.append(
+            cirq.H(qreg[i]), strategy=cirq.InsertStrategy.NEW_THEN_INLINE
+        )
+    for i in range(1, evalue_reg):
+        for j in range(evalue_reg):
+            if j < i:
+                circuit.append(
+                    cirq.inverse(input_gate(qreg[i]).controlled_by(qreg[j])),
+                    strategy=cirq.InsertStrategy.NEW,
+                )
+    return_type = "cirq" if not return_type else return_type
+
+    return convert_from_mitiq(circuit, return_type)

--- a/mitiq/benchmarks/qpe_circuits.py
+++ b/mitiq/benchmarks/qpe_circuits.py
@@ -25,14 +25,16 @@ def generate_qpe_circuit(
     input_gate: cirq.Gate,
     return_type: Optional[str] = None,
 ) -> QPROGRAM:
-    """Returns a circuit to create a Quantum Phase Estimation circuit as
+    """Returns a circuit to create a quantum phase estimation (QPE) circuit as
     defined in https://en.wikipedia.org/wiki/Quantum_phase_estimation_algorithm
-
+    
+    The unitary to estimate the phase of corresponds to a
+    single-qubit gate (``input_gate``).
     The IQFT circuit defined in this method is taken from taken from Sec 7.7.4
     of :cite:`Wong_2022`.
     Args:
         evalue_reg : Number of qubits in the eigenvalue register
-        input_gate: A quantum gate
+        input_gate: The unitary to estimate the phase of as a single-qubit Cirq gate.
         return_type: Return type of the output circuit.
     Returns:
         A Quantum Phase Estimation circuit.

--- a/mitiq/benchmarks/qpe_circuits.py
+++ b/mitiq/benchmarks/qpe_circuits.py
@@ -39,7 +39,8 @@ def generate_qpe_circuit(
     """
     if evalue_reg <= 0:
         raise ValueError(
-            f"Arg `evalue_reg` must be positive but was {evalue_reg}."
+            "{} is invalid for the number of eigenvalue register qubits. ",
+            evalue_reg,
         )
     num_qubits_for_gate = input_gate.num_qubits()
     if num_qubits_for_gate > 1:
@@ -47,9 +48,9 @@ def generate_qpe_circuit(
             "This QPE circuit generation method only works for 1-qubit gates."
         )
 
-    if evalue_reg < num_qubits_for_gate:
+    if evalue_reg == num_qubits_for_gate:
         raise ValueError(
-            "The eigenvalue register must be larger than the eigenstate reg."
+            "The eigenvalue register must be larger than the eigenstate register."
         )
 
     total_num_qubits = evalue_reg + num_qubits_for_gate

--- a/mitiq/benchmarks/tests/test_qpe_circuits.py
+++ b/mitiq/benchmarks/tests/test_qpe_circuits.py
@@ -184,6 +184,7 @@ def test_phase_angle_estimation():
     # initialize the eigenstate reg to |+> by using H
     # + add measurements on ereg register
     # expect eigenvalue to be +1
+    # the constant calculated is n in exp(2 pi i n)
     qubits = cirq.LineQubit.range(n_eigstate_reg + 1)
     PauliX_on_0_qft_circuit = (
         cirq.Circuit(cirq.H(qubits[3]))

--- a/mitiq/benchmarks/tests/test_qpe_circuits.py
+++ b/mitiq/benchmarks/tests/test_qpe_circuits.py
@@ -201,6 +201,7 @@ def test_phase_angle_estimation():
     # initialize the eigenstate reg to |-> by using X and H after Pauli X Gate
     # + add measurements on ereg register
     # expect eigenvalue to be -1
+    # the constant calculated is n in exp(2 pi i n)
     qubits = cirq.LineQubit.range(n_eigstate_reg + 1)
     PauliX_on_1_qft_circuit = (
         cirq.Circuit(cirq.X(qubits[3]), cirq.H(qubits[3]))

--- a/mitiq/benchmarks/tests/test_qpe_circuits.py
+++ b/mitiq/benchmarks/tests/test_qpe_circuits.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Unitary Fund
+# Copyright (C) 2023 Unitary Fund
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,11 +12,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-from mitiq.benchmarks.randomized_benchmarking import generate_rb_circuits
-from mitiq.benchmarks.mirror_circuits import generate_mirror_circuit
-from mitiq.benchmarks.ghz_circuits import generate_ghz_circuit
-from mitiq.benchmarks.quantum_volume_circuits import (
-    generate_quantum_volume_circuit,
-)
-from mitiq.benchmarks.w_state_circuits import generate_w_circuit

--- a/mitiq/benchmarks/tests/test_qpe_circuits.py
+++ b/mitiq/benchmarks/tests/test_qpe_circuits.py
@@ -167,11 +167,10 @@ def test_phase_angle_estimation():
         result_string = ""
         for i in range(len(input_array)):
             result_string += str(input_array[i])
-            result = int(result_string, 2)
-        return result
+        return int(result_string, 2)
 
     n_eigstate_reg = 3
-    # initialize the eigenstate reg to |+> by using H after Pauli X Gate
+    # initialize the eigenstate reg to |+> by using H
     # + add measurements on ereg register
     # expect eigenvalue to be +1
     qubits = cirq.LineQubit.range(n_eigstate_reg + 1)

--- a/mitiq/benchmarks/tests/test_qpe_circuits.py
+++ b/mitiq/benchmarks/tests/test_qpe_circuits.py
@@ -12,3 +12,49 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+"""Tests for QPE benchmarking circuits."""
+
+import pytest
+import numpy as np
+import cirq
+from mitiq.utils import _equal
+from mitiq.benchmarks.qpe_circuits import generate_qpe_circuit
+from mitiq import SUPPORTED_PROGRAM_TYPES
+
+
+def test_bad_qubit_number():
+    for n in (-1, 0):
+        with pytest.raises(
+            ValueError,
+            match="{} is invalid for the number of eigenvalue register\
+             qubits.",
+        ):
+            generate_qpe_circuit(n, cirq.T)
+
+
+def test_bad_gate():
+    for g in (cirq.CNOT, cirq.SWAP):
+        with pytest.raises(
+            ValueError,
+            match="This QPE circuit generation method only works for \
+            1-qubit gates.",
+        ):
+            generate_qpe_circuit(4, g)
+
+
+def test_bad_evalue_register():
+    for g in (cirq.X, cirq.T):
+        with pytest.raises(
+            ValueError,
+            match="The eigenvalue register must be larger than the eigenstate\
+             register.",
+        ):
+            generate_qpe_circuit(1, g)
+
+
+@pytest.mark.parametrize("return_type", SUPPORTED_PROGRAM_TYPES.keys())
+def test_conversion(return_type):
+    circuit = generate_qpe_circuit(3, cirq.Y, return_type)
+    assert return_type in circuit.__module__

--- a/mitiq/benchmarks/tests/test_qpe_circuits.py
+++ b/mitiq/benchmarks/tests/test_qpe_circuits.py
@@ -92,17 +92,21 @@ def test_circuit_PauliX():
             ),
             cirq.Moment(
                 cirq.H(qubits[0]),
-                cirq.H(qubits[1]),
-                cirq.H(qubits[2]),
             ),
             cirq.Moment(
                 (cirq.CNOT**-1.0).on(qubits[0], qubits[1]),
+            ),
+            cirq.Moment(
+                cirq.H(qubits[1]),
             ),
             cirq.Moment(
                 (cirq.CNOT**-1.0).on(qubits[0], qubits[2]),
             ),
             cirq.Moment(
                 (cirq.CNOT**-1.0).on(qubits[1], qubits[2]),
+            ),
+            cirq.Moment(
+                cirq.H(qubits[2]),
             ),
         ]
     )
@@ -145,11 +149,12 @@ def test_circuit_QPE_TGate():
             ),
             cirq.Moment(
                 cirq.H(qubits[0]),
-                cirq.H(qubits[1]),
-                cirq.H(qubits[2]),
             ),
             cirq.Moment(
                 (cirq.CZ**-0.25).on(qubits[0], qubits[1]),
+            ),
+            cirq.Moment(
+                cirq.H(qubits[1]),
             ),
             cirq.Moment(
                 (cirq.CZ**-0.25).on(qubits[0], qubits[2]),
@@ -157,9 +162,15 @@ def test_circuit_QPE_TGate():
             cirq.Moment(
                 (cirq.CZ**-0.25).on(qubits[1], qubits[2]),
             ),
+            cirq.Moment(
+                cirq.H(qubits[2]),
+            ),
         ]
     )
     assert _equal(generated_circuit, expected_circuit)
+
+    generated_circuit_check_default_option = generate_qpe_circuit(3)
+    assert _equal(generated_circuit_check_default_option, expected_circuit)
 
 
 def test_phase_angle_estimation():
@@ -183,12 +194,12 @@ def test_phase_angle_estimation():
     result1 = simulator.run(PauliX_on_0_qft_circuit)
     result_array1 = result1.records["q(0),q(1),q(2)"]
     result1 = _binary_to_int(result_array1[0][0])
-    calculated_angle = result1 / 2**n_eigstate_reg
-    assert calculated_angle == 0
+    calculated_constant = result1 / 2**n_eigstate_reg
+    assert calculated_constant == 0
 
     # initialize the eigenstate reg to |-> by using X and H after Pauli X Gate
     # + add measurements on ereg register
-    # expect eigenvalue to be -1 (ignoring complex i)
+    # expect eigenvalue to be -1
     qubits = cirq.LineQubit.range(n_eigstate_reg + 1)
     PauliX_on_1_qft_circuit = (
         cirq.Circuit(cirq.X(qubits[3]), cirq.H(qubits[3]))
@@ -199,5 +210,5 @@ def test_phase_angle_estimation():
     result2 = simulator.run(PauliX_on_1_qft_circuit)
     result_array2 = result2.records["q(0),q(1),q(2)"]
     result2 = _binary_to_int(result_array2[0][0])
-    calculated_angle = result2 / 2**n_eigstate_reg
-    assert calculated_angle == 0.75
+    calculated_constant = result2 / 2**n_eigstate_reg
+    assert calculated_constant == 0.5

--- a/mitiq/benchmarks/tests/test_qpe_circuits.py
+++ b/mitiq/benchmarks/tests/test_qpe_circuits.py
@@ -17,7 +17,6 @@
 """Tests for QPE benchmarking circuits."""
 
 import pytest
-import numpy as np
 import cirq
 from mitiq.utils import _equal
 from mitiq.benchmarks.qpe_circuits import generate_qpe_circuit
@@ -28,8 +27,7 @@ def test_bad_qubit_number():
     for n in (-1, 0):
         with pytest.raises(
             ValueError,
-            match="{} is invalid for the number of eigenvalue register\
-             qubits.",
+            match="{} is invalid for the number of eigenvalue reg qubits.",
         ):
             generate_qpe_circuit(n, cirq.T)
 
@@ -38,8 +36,7 @@ def test_bad_gate():
     for g in (cirq.CNOT, cirq.SWAP):
         with pytest.raises(
             ValueError,
-            match="This QPE circuit generation method only works for \
-            1-qubit gates.",
+            match="This QPE method only works for 1-qubit gates.",
         ):
             generate_qpe_circuit(4, g)
 
@@ -48,8 +45,7 @@ def test_bad_evalue_register():
     for g in (cirq.X, cirq.T):
         with pytest.raises(
             ValueError,
-            match="The eigenvalue register must be larger than the eigenstate\
-             register.",
+            match="The eigenvalue reg must be larger than the eigenstate reg.",
         ):
             generate_qpe_circuit(1, g)
 
@@ -58,3 +54,115 @@ def test_bad_evalue_register():
 def test_conversion(return_type):
     circuit = generate_qpe_circuit(3, cirq.Y, return_type)
     assert return_type in circuit.__module__
+
+
+def test_QPE_PauliX():
+    generated_circuit = generate_qpe_circuit(3, cirq.X)
+    qubits = cirq.LineQubit.range(3 + 1)
+    expected_circuit = cirq.Circuit(
+        [
+            cirq.Moment(
+                cirq.H(qubits[0]),
+                cirq.H(qubits[1]),
+                cirq.H(qubits[2]),
+            ),
+            cirq.Moment(
+                cirq.CNOT(qubits[2], qubits[3]),
+            ),
+            cirq.Moment(
+                cirq.CNOT(qubits[1], qubits[3]),
+            ),
+            cirq.Moment(
+                cirq.CNOT(qubits[1], qubits[3]),
+            ),
+            cirq.Moment(
+                cirq.CNOT(qubits[0], qubits[3]),
+            ),
+            cirq.Moment(
+                cirq.CNOT(qubits[0], qubits[3]),
+            ),
+            cirq.Moment(
+                cirq.CNOT(qubits[0], qubits[3]),
+            ),
+            cirq.Moment(
+                cirq.CNOT(qubits[0], qubits[3]),
+            ),
+            cirq.Moment(
+                cirq.SWAP(qubits[0], qubits[2]),
+            ),
+            cirq.Moment(
+                cirq.H(qubits[0]),
+                cirq.H(qubits[1]),
+                cirq.H(qubits[2]),
+            ),
+            cirq.Moment(
+                (cirq.CNOT**-1.0).on(qubits[0], qubits[1]),
+            ),
+            cirq.Moment(
+                (cirq.CNOT**-1.0).on(qubits[0], qubits[2]),
+            ),
+            cirq.Moment(
+                (cirq.CNOT**-1.0).on(qubits[1], qubits[2]),
+            ),
+        ]
+    )
+    assert _equal(generated_circuit, expected_circuit)
+
+    # initialize the state to +
+
+    # initialize the state to -
+
+
+def test_QPE_TGate():
+    generated_circuit = generate_qpe_circuit(3, cirq.T)
+    qubits = cirq.LineQubit.range(3 + 1)
+    expected_circuit = cirq.Circuit(
+        [
+            cirq.Moment(
+                cirq.H(qubits[0]),
+                cirq.H(qubits[1]),
+                cirq.H(qubits[2]),
+            ),
+            cirq.Moment(
+                (cirq.CZ**0.25).on(qubits[2], qubits[3]),
+            ),
+            cirq.Moment(
+                (cirq.CZ**0.25).on(qubits[1], qubits[3]),
+            ),
+            cirq.Moment(
+                (cirq.CZ**0.25).on(qubits[1], qubits[3]),
+            ),
+            cirq.Moment(
+                (cirq.CZ**0.25).on(qubits[0], qubits[3]),
+            ),
+            cirq.Moment(
+                (cirq.CZ**0.25).on(qubits[0], qubits[3]),
+            ),
+            cirq.Moment(
+                (cirq.CZ**0.25).on(qubits[0], qubits[3]),
+            ),
+            cirq.Moment(
+                (cirq.CZ**0.25).on(qubits[0], qubits[3]),
+            ),
+            cirq.Moment(
+                cirq.SWAP(qubits[0], qubits[2]),
+            ),
+            cirq.Moment(
+                cirq.H(qubits[0]),
+                cirq.H(qubits[1]),
+                cirq.H(qubits[2]),
+            ),
+            cirq.Moment(
+                (cirq.CZ**-0.25).on(qubits[0], qubits[1]),
+            ),
+            cirq.Moment(
+                (cirq.CZ**-0.25).on(qubits[0], qubits[2]),
+            ),
+            cirq.Moment(
+                (cirq.CZ**-0.25).on(qubits[1], qubits[2]),
+            ),
+        ]
+    )
+    assert _equal(generated_circuit, expected_circuit)
+
+    # initialize the state to 1

--- a/mitiq/benchmarks/w_state_circuits.py
+++ b/mitiq/benchmarks/w_state_circuits.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-""" Functions for creating 2 W-state benchmarking circuits as defined in
+""" Functions for creating a linear complexity W-state benchmarking circuit as defined in
 :cite:`Cruz_2019_Efficient`"""
 
 from typing import Optional

--- a/mitiq/benchmarks/w_state_circuits.py
+++ b/mitiq/benchmarks/w_state_circuits.py
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-""" Functions for creating a linear complexity W-state benchmarking circuit as defined in
-:cite:`Cruz_2019_Efficient`"""
+""" Functions for creating a linear complexity W-state benchmarking circuit
+as defined in :cite:`Cruz_2019_Efficient`"""
 
 from typing import Optional
 import numpy as np


### PR DESCRIPTION
Fixes #1597 

Function tested locally i.e. it works. 

Need to add tests in `test_qpe_circuits.py`. For this reason, Github workflows will fail. 

List of tests to add: 

- [x] Bad eigenvalue register size
- [x] Input qubit gate acts on more than 1 qubit
- [x] Bad eigenvalue register size in comparison with the eigenstate register size
- [x] Compare the circuit for known single qubit gates
- [x] Same test as above but get the eigenvalue by inserting measurements on the eigenvalue reg
- [x] Test return type of the circuit