### PR TITLE
[Draft] Adding Subspace Expansion error mitigation technique

### DIFF
--- a/mitiq/subspace_expansion/__init__.py
+++ b/mitiq/subspace_expansion/__init__.py
@@ -13,9 +13,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Clifford data regression method for error mitigation as introduced in:...
-.......
-....
+"""Subspace Expansion method for error mitigation as introduced in:
+
+[1] McClean, J.R., Jiang, Z., Rubin, N.C., Babbush, R. and Neven, H., 2020.
+    "Decoding quantum errors with subspace expansions". 
+    (https://arxiv.org/abs/1903.05786)
+[2] Yoshioka, N., Hakoshima, H., Matsuzaki, Y., Tokunaga, Y., Suzuki, Y. and Endo, S., 2022.
+    "Generalized quantum subspace expansion".
+    (https://arxiv.org/abs/2107.02611)
 
 """
 

--- a/mitiq/subspace_expansion/__init__.py
+++ b/mitiq/subspace_expansion/__init__.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Clifford data regression method for error mitigation as introduced in:...
+.......
+....
+
+"""
+
+from mitiq.subspace_expansion.subspace_expansion import (
+    execute_with_subspace_expansion,
+)
+
+from mitiq.subspace_expansion.utils import (
+    convert_from_Mitiq_Observable_to_cirq_PauliSum,
+    convert_from_cirq_PauliSum_to_Mitiq_Observable,
+    convert_from_cirq_PauliString_to_Mitiq_PauliString,
+)

--- a/mitiq/subspace_expansion/subspace_expansion.py
+++ b/mitiq/subspace_expansion/subspace_expansion.py
@@ -1,22 +1,15 @@
-"""API for using Clifford Data Regression (CDR) error mitigation."""
+"""API for using Subspace Expansion error mitigation."""
 
-from typing import Any, Callable, Optional, Sequence, Union, List
-from functools import wraps
+from typing import Callable, Sequence, Union
 from mitiq import Executor, Observable, QPROGRAM, QuantumResult, PauliString
 import cirq
-import sympy as sp
-import numpy as np
 from scipy.linalg import eig
-from scipy.sparse.linalg import eigs
 
-from typing import Union
 from mitiq.subspace_expansion.utils import (
     convert_from_cirq_PauliString_to_Mitiq_PauliString,
     convert_from_Mitiq_Observable_to_cirq_PauliSum,
 )
 
-
-# TODO: move this to a singeleton
 
 cache = {}  # tuple of pauli mask: expectation value
 
@@ -24,31 +17,32 @@ cache = {}  # tuple of pauli mask: expectation value
 def execute_with_subspace_expansion(
     circuit: QPROGRAM,
     executor: Union[Executor, Callable[[QPROGRAM], QuantumResult]],
-    Ms: list[cirq.PauliString],
-    Hc: Observable,
+    check_operators: Sequence[PauliString],
+    code_hamiltonian: Observable,
     observable: Observable,
-    **kwargs: Any,
 ) -> QuantumResult:
     """Function for the calculation of an observable from some circuit of
         interest to be mitigated with Subspace Expansion
     Args:
         circuit: Quantum program to execute with error mitigation.
         executor: Executes a circuit and returns a `QuantumResult`.
-        observable: Observable to compute the expectation value of.
-            If None, the `executor` must return an expectation value. Otherwise
-            the `QuantumResult` returned by `executor` is used to compute the
-            expectation of the observable.
-        simulator: Executes a circuit without noise and returns a
-            `QuantumResult`. For CDR to be efficient, the simulator must
-            be able to efficiently simulate near-Clifford circuits.
+        check_operators: List of check operators that define the stabilizer code space.
+        code_hamiltonian: Hamiltonian of the code space.
+        observable: Observable to compute the mitigated expectation value of.
     """
     cache.clear()
-    Ms_cirq = [M._pauli for M in Ms]
-    Hc_cirq = convert_from_Mitiq_Observable_to_cirq_PauliSum(Hc)
+    check_operators_cirq = [
+        check_operator._pauli for check_operator in check_operators
+    ]
+    code_hamiltonian_cirq = convert_from_Mitiq_Observable_to_cirq_PauliSum(
+        code_hamiltonian
+    )
     observable_cirq = convert_from_Mitiq_Observable_to_cirq_PauliSum(
         observable
     )
-    P = get_projector(circuit, executor, Ms_cirq, Hc_cirq)
+    P = get_projector(
+        circuit, executor, check_operators_cirq, code_hamiltonian_cirq
+    )
     pop = get_expectation_value_for_observable(
         circuit, executor, P * observable_cirq * P
     )
@@ -59,7 +53,7 @@ def execute_with_subspace_expansion(
 def get_expectation_value_for_observable(
     qc: QPROGRAM,
     executor: Union[Executor, Callable[[QPROGRAM], QuantumResult]],
-    observable,
+    observable: Union[cirq.PauliString, cirq.PauliSum],
 ):
     def get_expectation_value_for_one_pauli(pauli_string: cirq.PauliString):
         cache_key = tuple(pauli_string.gate.pauli_mask.tolist())
@@ -67,69 +61,76 @@ def get_expectation_value_for_observable(
             return 1 * pauli_string.coefficient
         if cache_key in cache:
             return cache[cache_key] * pauli_string.coefficient
-        a = convert_from_cirq_PauliString_to_Mitiq_PauliString(pauli_string)
-        return Observable(a).expectation(qc, executor)
+        mitiq_pauli_string = (
+            convert_from_cirq_PauliString_to_Mitiq_PauliString(pauli_string)
+        )
+        return Observable(mitiq_pauli_string).expectation(qc, executor)
 
-    if type(observable) != list:
-        observable = [observable]
     total_expectation_value_for_observable = 0
-    for pauli_string_or_pauli_sum in observable:
-        if type(pauli_string_or_pauli_sum) == cirq.PauliString:
-            pauli_string = pauli_string_or_pauli_sum
+
+    if type(observable) == cirq.PauliString:
+        pauli_string = observable
+        total_expectation_value_for_observable += (
+            get_expectation_value_for_one_pauli(pauli_string)
+        )
+    elif type(observable) == cirq.PauliSum:
+        pauli_sum = observable
+        for pauli_string in pauli_sum:
             total_expectation_value_for_observable += (
                 get_expectation_value_for_one_pauli(pauli_string)
             )
-        elif type(pauli_string_or_pauli_sum) == cirq.PauliSum:
-            pauli_sum = pauli_string_or_pauli_sum
-            for pauli_string in pauli_sum:
-                total_expectation_value_for_observable += (
-                    get_expectation_value_for_one_pauli(pauli_string)
-                )
     return total_expectation_value_for_observable
 
 
-def get_Sij(qc: QPROGRAM, executor, Ms: list[cirq.PauliString]):
-    Sij = []
-    # Sij = <Ψ|Mi† Mj|Ψ>
-    for i in range(len(Ms)):
-        Sij.append([])
-        for j in range(len(Ms)):
-            paulis_and_weights = [Ms[i] * Ms[j]]
+def get_projector(qc: QPROGRAM, executor, check_operators, code_hamiltonian):
+    S = compute_overlap_matrix(qc, executor, check_operators)
+    H = compute_code_hamiltonian_overlap_matrix(qc, executor, check_operators, code_hamiltonian)
+    E, C = eig(H, S)
+    minpos = list(E).index(min(E))
+    Cs = C[:, minpos]
+
+    projector_formed_out_of_check_operators_and_Cs = sum(
+        [check_operators[i] * Cs[i] for i in range(len(check_operators))]
+    )
+
+    return projector_formed_out_of_check_operators_and_Cs
+
+
+def compute_overlap_matrix(
+    qc: QPROGRAM,
+    executor: Union[Executor, Callable[[QPROGRAM], QuantumResult]],
+    check_operators: Sequence[cirq.PauliString],
+):
+    S = []
+    # S_ij = <Ψ|Mi† Mj|Ψ>
+    for i in range(len(check_operators)):
+        S.append([])
+        for j in range(len(check_operators)):
+            paulis_and_weights = check_operators[i] * check_operators[j]
             sij = get_expectation_value_for_observable(
                 qc, executor, paulis_and_weights
             )
-            Sij[-1].append(sij)
-    return Sij
+            S[-1].append(sij)
+    return S
 
 
-def get_Hij(
-    qc: QPROGRAM, executor, Ms: list[cirq.PauliString], Hc
-):  # takes 40 minutes
-    Hij = []
-    # Hij = <Ψ|Mi† H Mj|Ψ>
-    for i in range(len(Ms)):
-        Hij.append([])
-        for j in range(len(Ms)):
-            paulis_and_weights = [Ms[i] * Hc * Ms[j]]
-            Hij[-1].append(
+def compute_code_hamiltonian_overlap_matrix(
+    qc: QPROGRAM,
+    executor: Union[Executor, Callable[[QPROGRAM], QuantumResult]],
+    check_operators: Sequence[cirq.PauliString],
+    code_hamiltonian,
+):
+    H = []
+    # H_ij = <Ψ|Mi† H Mj|Ψ>
+    for i in range(len(check_operators)):
+        H.append([])
+        for j in range(len(check_operators)):
+            paulis_and_weights = (
+                check_operators[i] * code_hamiltonian * check_operators[j]
+            )
+            H[-1].append(
                 get_expectation_value_for_observable(
                     qc, executor, paulis_and_weights
                 )
             )
-    return Hij
-
-
-def get_projector(qc: QPROGRAM, executor, Ms, Hc):
-    Sij = get_Sij(qc, executor, Ms)
-    Hij = get_Hij(qc, executor, Ms, Hc)
-    E, C = eig(Hij, Sij)
-    print("E=", E)
-    minpos = list(E).index(min(E))
-    print(minpos)
-    Cs = C[:, minpos]
-
-    projector_formed_out_of_Ms_and_Cs = sum(
-        [Ms[i] * Cs[i] for i in range(len(Ms))]
-    )
-
-    return projector_formed_out_of_Ms_and_Cs
+    return H

--- a/mitiq/subspace_expansion/subspace_expansion.py
+++ b/mitiq/subspace_expansion/subspace_expansion.py
@@ -1,0 +1,135 @@
+"""API for using Clifford Data Regression (CDR) error mitigation."""
+
+from typing import Any, Callable, Optional, Sequence, Union, List
+from functools import wraps
+from mitiq import Executor, Observable, QPROGRAM, QuantumResult, PauliString
+import cirq
+import sympy as sp
+import numpy as np
+from scipy.linalg import eig
+from scipy.sparse.linalg import eigs
+
+from typing import Union
+from mitiq.subspace_expansion.utils import (
+    convert_from_cirq_PauliString_to_Mitiq_PauliString,
+    convert_from_Mitiq_Observable_to_cirq_PauliSum,
+)
+
+
+# TODO: move this to a singeleton
+
+cache = {}  # tuple of pauli mask: expectation value
+
+
+def execute_with_subspace_expansion(
+    circuit: QPROGRAM,
+    executor: Union[Executor, Callable[[QPROGRAM], QuantumResult]],
+    Ms: list[cirq.PauliString],
+    Hc: Observable,
+    observable: Observable,
+    **kwargs: Any,
+) -> QuantumResult:
+    """Function for the calculation of an observable from some circuit of
+        interest to be mitigated with Subspace Expansion
+    Args:
+        circuit: Quantum program to execute with error mitigation.
+        executor: Executes a circuit and returns a `QuantumResult`.
+        observable: Observable to compute the expectation value of.
+            If None, the `executor` must return an expectation value. Otherwise
+            the `QuantumResult` returned by `executor` is used to compute the
+            expectation of the observable.
+        simulator: Executes a circuit without noise and returns a
+            `QuantumResult`. For CDR to be efficient, the simulator must
+            be able to efficiently simulate near-Clifford circuits.
+    """
+    cache.clear()
+    Ms_cirq = [M._pauli for M in Ms]
+    Hc_cirq = convert_from_Mitiq_Observable_to_cirq_PauliSum(Hc)
+    observable_cirq = convert_from_Mitiq_Observable_to_cirq_PauliSum(
+        observable
+    )
+    P = get_projector(circuit, executor, Ms_cirq, Hc_cirq)
+    pop = get_expectation_value_for_observable(
+        circuit, executor, P * observable_cirq * P
+    )
+    pp = get_expectation_value_for_observable(circuit, executor, P * P)
+    return pop / pp
+
+
+def get_expectation_value_for_observable(
+    qc: QPROGRAM,
+    executor: Union[Executor, Callable[[QPROGRAM], QuantumResult]],
+    observable,
+):
+    def get_expectation_value_for_one_pauli(pauli_string: cirq.PauliString):
+        cache_key = tuple(pauli_string.gate.pauli_mask.tolist())
+        if cache_key == ():  # if all I's
+            return 1 * pauli_string.coefficient
+        if cache_key in cache:
+            return cache[cache_key] * pauli_string.coefficient
+        a = convert_from_cirq_PauliString_to_Mitiq_PauliString(pauli_string)
+        return Observable(a).expectation(qc, executor)
+
+    if type(observable) != list:
+        observable = [observable]
+    total_expectation_value_for_observable = 0
+    for pauli_string_or_pauli_sum in observable:
+        if type(pauli_string_or_pauli_sum) == cirq.PauliString:
+            pauli_string = pauli_string_or_pauli_sum
+            total_expectation_value_for_observable += (
+                get_expectation_value_for_one_pauli(pauli_string)
+            )
+        elif type(pauli_string_or_pauli_sum) == cirq.PauliSum:
+            pauli_sum = pauli_string_or_pauli_sum
+            for pauli_string in pauli_sum:
+                total_expectation_value_for_observable += (
+                    get_expectation_value_for_one_pauli(pauli_string)
+                )
+    return total_expectation_value_for_observable
+
+
+def get_Sij(qc: QPROGRAM, executor, Ms: list[cirq.PauliString]):
+    Sij = []
+    # Sij = <Ψ|Mi† Mj|Ψ>
+    for i in range(len(Ms)):
+        Sij.append([])
+        for j in range(len(Ms)):
+            paulis_and_weights = [Ms[i] * Ms[j]]
+            sij = get_expectation_value_for_observable(
+                qc, executor, paulis_and_weights
+            )
+            Sij[-1].append(sij)
+    return Sij
+
+
+def get_Hij(
+    qc: QPROGRAM, executor, Ms: list[cirq.PauliString], Hc
+):  # takes 40 minutes
+    Hij = []
+    # Hij = <Ψ|Mi† H Mj|Ψ>
+    for i in range(len(Ms)):
+        Hij.append([])
+        for j in range(len(Ms)):
+            paulis_and_weights = [Ms[i] * Hc * Ms[j]]
+            Hij[-1].append(
+                get_expectation_value_for_observable(
+                    qc, executor, paulis_and_weights
+                )
+            )
+    return Hij
+
+
+def get_projector(qc: QPROGRAM, executor, Ms, Hc):
+    Sij = get_Sij(qc, executor, Ms)
+    Hij = get_Hij(qc, executor, Ms, Hc)
+    E, C = eig(Hij, Sij)
+    print("E=", E)
+    minpos = list(E).index(min(E))
+    print(minpos)
+    Cs = C[:, minpos]
+
+    projector_formed_out_of_Ms_and_Cs = sum(
+        [Ms[i] * Cs[i] for i in range(len(Ms))]
+    )
+
+    return projector_formed_out_of_Ms_and_Cs

--- a/mitiq/subspace_expansion/tests/test_subspace_expansion.py
+++ b/mitiq/subspace_expansion/tests/test_subspace_expansion.py
@@ -1,0 +1,186 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for the Clifford data regression top-level API."""
+import pytest
+
+from typing import List
+
+import numpy as np
+
+import cirq
+from cirq import X, Y, Z, I
+
+from mitiq import PauliString, Observable, QPROGRAM
+from mitiq._typing import SUPPORTED_PROGRAM_TYPES
+
+from mitiq.subspace_expansion import (
+    execute_with_subspace_expansion,
+)
+from mitiq.subspace_expansion.utils import (
+    convert_from_cirq_PauliString_to_Mitiq_PauliString,
+    convert_from_Mitiq_Observable_to_cirq_PauliSum,
+    convert_from_cirq_PauliSum_to_Mitiq_Observable,
+)
+
+from mitiq.interface import convert_from_mitiq, convert_to_mitiq
+
+from mitiq.interface.mitiq_cirq import compute_density_matrix
+
+# Allow execution with any QPROGRAM for testing.
+def execute(circuit: QPROGRAM) -> np.ndarray:
+    return compute_density_matrix(convert_to_mitiq(circuit)[0])
+
+
+def batched_execute(circuits) -> List[np.ndarray]:
+    return [execute(circuit) for circuit in circuits]
+
+
+def simulate(circuit: QPROGRAM) -> np.ndarray:
+    return compute_density_matrix(
+        convert_to_mitiq(circuit)[0], noise_level=(0,)
+    )
+
+
+def test_execute_with_cdr():
+    qc, actual_qubits = prepare_logical_0_state_for_5_1_3_code()
+    Ms, Hc = get_Ms_and_Hc()
+    observable = convert_from_cirq_PauliSum_to_Mitiq_Observable(
+        get_observable_cirq_in_code_space(actual_qubits, [Z, Z, Z, Z, Z])
+    )
+    a = execute_with_subspace_expansion(qc, execute, Ms, Hc, observable)
+    assert abs(a.real - 1) < 0.001
+
+    observable = convert_from_cirq_PauliSum_to_Mitiq_Observable(
+        get_observable_cirq_in_code_space(actual_qubits, [X, X, X, X, X])
+    )
+    a = execute_with_subspace_expansion(qc, execute, Ms, Hc, observable)
+    assert abs(a.real - 0.5) < 0.001
+
+
+def get_observable_cirq_in_code_space(
+    actual_qubits, observable: list[cirq.PauliString]
+):
+    FIVE_I = cirq.PauliString(
+        [I(actual_qubits[i]) for i in range(len(actual_qubits))]
+    )
+    projector_onto_code_space = [
+        [X, Z, Z, X, I],
+        [I, X, Z, Z, X],
+        [X, I, X, Z, Z],
+        [Z, X, I, X, Z],
+    ]
+
+    observable_in_code_space = FIVE_I
+    all_paulis = projector_onto_code_space + [observable]
+    for g in all_paulis:
+        f = cirq.PauliString([(g[i])(actual_qubits[i]) for i in range(len(g))])
+        observable_in_code_space *= 0.5 * (FIVE_I + f)
+    return observable_in_code_space
+
+
+def get_Ms_and_Hc() -> tuple:
+    Ms = [
+        "YIYXX",
+        "ZIZYY",
+        "IXZZX",
+        "ZXIXZ",
+        "YYZIZ",
+        "XYIYX",
+        "YZIZY",
+        "ZZXIX",
+        "XZZXI",
+        "ZYYZI",
+        "IYXXY",
+        "IZYYZ",
+        "YXXYI",
+        "XXYIY",
+        "XIXZZ",
+        "IIIII",
+    ]
+    Ms_as_pauliStrings = [
+        PauliString(M, coeff=1, support=range(5)) for M in Ms
+    ]
+    negative_Ms_as_pauliStrings = [
+        PauliString(M, coeff=-1, support=range(5)) for M in Ms
+    ]
+    Hc = Observable(*negative_Ms_as_pauliStrings)
+    return Ms_as_pauliStrings, Hc
+
+
+def prepare_logical_0_state_for_5_1_3_code():
+    def gram_schmidt(
+        vecs,
+    ):  # input a list of orthogonal vectors, use Gram-Schmidt to generate the rest
+        orthonormalVecs = [
+            vec / np.sqrt(np.vdot(vec, vec)) for vec in vecs
+        ]  # normalize input
+        dim = np.shape(vecs[0])[0]  # get dim of vector space
+        for i in range(dim - len(vecs)):
+            new_vec = np.zeros(dim)
+            new_vec[i] = 1  # construct ith basis vector
+            projs = sum(
+                [
+                    np.vdot(new_vec, cached_vec) * cached_vec
+                    for cached_vec in orthonormalVecs
+                ]
+            )  # sum of projections of new vec with all existing vecs
+            new_vec -= projs
+            orthonormalVecs.append(
+                new_vec / np.sqrt(np.vdot(new_vec, new_vec))
+            )
+        return orthonormalVecs
+
+    v0 = np.zeros(32)
+    for z in ["00000", "10010", "01001", "10100", "01010", "00101"]:
+        v0[int(z, 2)] = 1 / 4
+    for z in [
+        "11011",
+        "00110",
+        "11000",
+        "11101",
+        "00011",
+        "11110",
+        "01111",
+        "10001",
+        "01100",
+        "10111",
+    ]:
+        v0[int(z, 2)] = -1 / 4
+
+    v1 = np.zeros(32)
+    for z in ["11111", "01101", "10110", "01011", "10101", "11010"]:
+        v1[int(z, 2)] = 1 / 4
+    for z in [
+        "00100",
+        "11001",
+        "00111",
+        "00010",
+        "11100",
+        "00001",
+        "10000",
+        "01110",
+        "10011",
+        "01000",
+    ]:
+        v1[int(z, 2)] = -1 / 4
+
+    res = gram_schmidt([v0, v1])
+    mat = np.reshape(res, (32, 32)).T
+    circuit = cirq.Circuit()
+    g = cirq.MatrixGate(mat)
+    actual_qubits = cirq.LineQubit.range(5)
+    circuit.append(g(*actual_qubits))
+    return circuit, actual_qubits

--- a/mitiq/subspace_expansion/utils.py
+++ b/mitiq/subspace_expansion/utils.py
@@ -16,16 +16,20 @@ def convert_from_cirq_PauliString_to_Mitiq_PauliString(cirq_PauliString):
 
 def convert_from_cirq_PauliSum_to_Mitiq_Observable(cirq_PauliSum):
     mitiq_pauli_strings = []
-    l = list(cirq_PauliSum)
-    for i in range(len(l)):
+    pauli_sum_list = list(cirq_PauliSum)  # convert to list so we can index
+    for i in range(len(pauli_sum_list)):
         mitiq_pauli_string = (
-            convert_from_cirq_PauliString_to_Mitiq_PauliString(l[i])
+            convert_from_cirq_PauliString_to_Mitiq_PauliString(
+                pauli_sum_list[i]
+            )
         )
         mitiq_pauli_strings.append(mitiq_pauli_string)
     return Observable(*mitiq_pauli_strings)
 
 
 def convert_from_Mitiq_Observable_to_cirq_PauliSum(mitiq_Observable):
-    l = [g.elements for g in mitiq_Observable.groups]
-    l = [item for sublist in l for item in sublist]
-    return sum([x._pauli for x in l])
+    observable_group_elements = [g.elements for g in mitiq_Observable.groups]
+    flattened_list = [
+        item for sublist in observable_group_elements for item in sublist
+    ]
+    return sum([pauli_string._pauli for pauli_string in flattened_list])

--- a/mitiq/subspace_expansion/utils.py
+++ b/mitiq/subspace_expansion/utils.py
@@ -1,0 +1,31 @@
+import cirq
+from mitiq import PauliString, Observable
+
+
+def convert_from_cirq_PauliString_to_Mitiq_PauliString(cirq_PauliString):
+    map = {cirq.X: "X", cirq.Y: "Y", cirq.Z: "Z", cirq.I: "I"}
+    N = 5
+    new_value = ["I"] * N
+    for v in cirq_PauliString.items():
+        new_value[v[0].x] = map[v[1]]
+    mitiq_pauli_string = PauliString(
+        "".join(new_value), cirq_PauliString.coefficient, range(N)
+    )
+    return mitiq_pauli_string
+
+
+def convert_from_cirq_PauliSum_to_Mitiq_Observable(cirq_PauliSum):
+    mitiq_pauli_strings = []
+    l = list(cirq_PauliSum)
+    for i in range(len(l)):
+        mitiq_pauli_string = (
+            convert_from_cirq_PauliString_to_Mitiq_PauliString(l[i])
+        )
+        mitiq_pauli_strings.append(mitiq_pauli_string)
+    return Observable(*mitiq_pauli_strings)
+
+
+def convert_from_Mitiq_Observable_to_cirq_PauliSum(mitiq_Observable):
+    l = [g.elements for g in mitiq_Observable.groups]
+    l = [item for sublist in l for item in sublist]
+    return sum([x._pauli for x in l])


### PR DESCRIPTION
Authors: Ammar Jahin (amar.jahin@gmail.com), Dariel Mok (darielmok@caltech.edu), Preksha Naik(pnaik@caltech.edu), Abdulrahman Sahmoud (ahssahmoud@gmail.com)

Closes https://github.com/unitaryfund/mitiq/issues/818
[Request For Comments (RFC) — Error Mitigation by Subspace Expansion](https://docs.google.com/document/d/1JyQAwiw8BRT_oucZ6tQv0id6UhSdd3df1mNSPpOvu1I/edit)

## Description
This implementation features the Subspace Expansion error mitigation method. The purpose of this Pull Request is to support the associated RFC during the review process. If approved, we anticipate further modifications to the PR.

## Issues with PR
Our code relies on being able to multiply PauliStrings, which doesn't seem to be supported in Mitiq's PauliString class. We couldn't find examples in the code of doing this, so we chose to access the private API to convert Mitiq's PauliStrings into Cirq's PauliStrings to do the multiplication operations. We instead propose to update the PauliString class to support multiplication if the PR/RFC is approved.

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [X] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [X] Added myself / the copyright holder to the AUTHORS file