### PR TITLE
CNOT twirling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ requirements: requirements.txt
 test:
 	pytest -n auto -v --cov=mitiq --cov-report=term --cov-report=xml --ignore=mitiq/interface/mitiq_pyquil
 
+.PHONY: test-%
+test-%:
+	pytest -n auto -v --cov=mitiq --cov-report=term --cov-report=xml */$(*)/*
+
 .PHONY: test-pyquil
 test-pyquil:
 	pytest -v --cov=mitiq --cov-report=term --cov-report=xml mitiq/interface/mitiq_pyquil

--- a/docs/source/apidoc.md
+++ b/docs/source/apidoc.md
@@ -268,6 +268,12 @@ See Ref. :cite:`Czarnik_2021_Quantum` for more details on these methods.
    :members:
 ```
 
+## Pauli Twirling
+```{eval-rst}
+.. automodule:: mitiq.pt.pt
+   :members:
+```
+
 ## Calibration
 
 ```{eval-rst}

--- a/mitiq/pt/__init__.py
+++ b/mitiq/pt/__init__.py
@@ -5,5 +5,6 @@
 
 from mitiq.pt.pt import (
     execute_with_pauli_twirling,
-    sample_paulis,
+    twirl_CNOT_gates,
+    twirl_CZ_gates,
 )

--- a/mitiq/pt/__init__.py
+++ b/mitiq/pt/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) Unitary Fund
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+from mitiq.pt.pt import execute_with_pauli_twirling

--- a/mitiq/pt/__init__.py
+++ b/mitiq/pt/__init__.py
@@ -5,6 +5,5 @@
 
 from mitiq.pt.pt import (
     execute_with_pauli_twirling,
-    _generate_lookup_table,
     sample_paulis,
 )

--- a/mitiq/pt/__init__.py
+++ b/mitiq/pt/__init__.py
@@ -3,4 +3,4 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-from mitiq.pt.pt import execute_with_pauli_twirling
+from mitiq.pt.pt import execute_with_pauli_twirling, _generate_lookup_table, sample_paulis

--- a/mitiq/pt/__init__.py
+++ b/mitiq/pt/__init__.py
@@ -3,4 +3,8 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-from mitiq.pt.pt import execute_with_pauli_twirling, _generate_lookup_table, sample_paulis
+from mitiq.pt.pt import (
+    execute_with_pauli_twirling,
+    _generate_lookup_table,
+    sample_paulis,
+)

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -77,7 +77,10 @@ def execute_with_pauli_twirling(
     executor = (
         executor if isinstance(executor, Executor) else Executor(executor)
     )
-    twirled_circuits = twirl_CNOT_gates(circuit, num_circuits)
+    CNOT_twirled_circuits = twirl_CNOT_gates(circuit, num_circuits)
+    twirled_circuits = [
+        twirl_CZ_gates(c, num_circuits=1)[0] for c in CNOT_twirled_circuits
+    ]
     expvals = executor.evaluate(twirled_circuits, observable)
     return cast(float, np.average(expvals))
 

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -58,7 +58,8 @@ def execute_with_pauli_twirling(
     *,
     num_circuits: int = 10,
 ) -> float:
-    """Estimates the expecation value by averaging pauli twirled circuits.
+    """Estimates the expectation value of the input circuit by averaging
+    expectation values obtained from Pauli twirled circuits.
 
     Args:
         circuit: The input circuit to execute with twirling.
@@ -112,8 +113,8 @@ def _twirl_CZ_qprogram(circuit: cirq.Circuit) -> cirq.Circuit:
 
 
 def _twirl_single_CNOT_gate(op: cirq.Operation) -> cirq.OP_TREE:
-    """Function which converts a CNOT to a logical equivalent. That is, it
-    converts CNOT operations into the following, leaving all other cirq
+    """Function which converts a CNOT gate to a logical equivalent. That is,
+    it converts CNOT operations into the following, leaving all other cirq
     operations alone.
 
         --P---⏺---R--
@@ -138,8 +139,8 @@ def _twirl_single_CNOT_gate(op: cirq.Operation) -> cirq.OP_TREE:
 
 
 def _twirl_single_CZ_gate(op: cirq.Operation) -> cirq.OP_TREE:
-    """Function which converts a CNOT to a logical equivalent. That is, it
-    converts CNOT operations into the following, leaving all other cirq
+    """Function which converts a CZ gate to a logical equivalent. That is, it
+    converts CZ operations into the following, leaving all other cirq
     operations alone.
 
         --P---⏺---R--

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -31,23 +31,22 @@ CNOT_twirling_gates = [
     (cirq.Z, cirq.Y, cirq.I, cirq.Y),
     (cirq.Z, cirq.Z, cirq.I, cirq.Z),
 ]
-# TODO: check the CZ gates. should be in PQRS order
 CZ_twirling_gates = [
     (cirq.I, cirq.I, cirq.I, cirq.I),
-    (cirq.X, cirq.I, cirq.I, cirq.X),
-    (cirq.Y, cirq.I, cirq.I, cirq.Y),
-    (cirq.Z, cirq.I, cirq.I, cirq.Z),
-    (cirq.I, cirq.Z, cirq.Z, cirq.I),
-    (cirq.X, cirq.Z, cirq.Z, cirq.X),
-    (cirq.Y, cirq.Z, cirq.Z, cirq.Y),
-    (cirq.Z, cirq.Z, cirq.Z, cirq.Z),
-    (cirq.I, cirq.Y, cirq.Y, cirq.I),
+    (cirq.I, cirq.X, cirq.Z, cirq.X),
+    (cirq.I, cirq.Y, cirq.Z, cirq.Y),
+    (cirq.I, cirq.Z, cirq.I, cirq.Z),
+    (cirq.X, cirq.I, cirq.X, cirq.Z),
+    (cirq.X, cirq.X, cirq.Y, cirq.Y),
     (cirq.X, cirq.Y, cirq.Y, cirq.X),
-    (cirq.Y, cirq.Y, cirq.Y, cirq.Y),
-    (cirq.Z, cirq.Y, cirq.Y, cirq.Z),
-    (cirq.I, cirq.Z, cirq.Z, cirq.I),
-    (cirq.X, cirq.Z, cirq.Z, cirq.X),
-    (cirq.Y, cirq.Z, cirq.Z, cirq.Y),
+    (cirq.X, cirq.Z, cirq.X, cirq.I),
+    (cirq.Y, cirq.I, cirq.Y, cirq.Z),
+    (cirq.Y, cirq.X, cirq.X, cirq.Y),
+    (cirq.Y, cirq.Y, cirq.X, cirq.X),
+    (cirq.Y, cirq.Z, cirq.Y, cirq.I),
+    (cirq.Z, cirq.I, cirq.Z, cirq.I),
+    (cirq.Z, cirq.X, cirq.I, cirq.X),
+    (cirq.Z, cirq.Y, cirq.I, cirq.Y),
     (cirq.Z, cirq.Z, cirq.Z, cirq.Z),
 ]
 
@@ -104,9 +103,7 @@ def twirl_CZ_gates(circuit: QPROGRAM, num_circuits: int) -> List[QPROGRAM]:
         circuit: The circuit to generate twirled versions of
         num_circuits: The number of sampled circuits to return
     """
-    return [
-        _twirl_CZ_qprogram(circuit, num_circuits) for _ in range(num_circuits)
-    ]
+    return [_twirl_CZ_qprogram(circuit) for _ in range(num_circuits)]
 
 
 @noise_scaling_converter

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -1,0 +1,61 @@
+# Copyright (C) Unitary Fund
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Callable, List, Optional, Tuple, Union
+
+import cirq
+import numpy as np
+
+from mitiq import QPROGRAM, Executor, Observable, QuantumResult
+from mitiq.interface import atomic_converter
+
+
+def execute_with_pauli_twirling(
+    circuit: QPROGRAM,
+    executor: Union[Executor, Callable[[QPROGRAM], QuantumResult]],
+    observable: Optional[Observable] = None,
+    *,
+    num_circuits: int = 100,
+) -> float:
+    executor = (
+        executor if isinstance(executor, Executor) else Executor(executor)
+    )
+    twirled_circuits = pauli_twirled_circuits(circuit, num_circuits)
+    expvals = executor.evaluate(twirled_circuits, observable)
+    return np.average(expvals)
+
+
+def pauli_twirled_circuits(
+    circuit: QPROGRAM, num_circuits: int
+) -> List[QPROGRAM]:
+    return [add_paulis(circuit) for _ in range(num_circuits)]
+
+
+Paulis = Union[cirq.IdentityGate, cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate]
+
+
+def sample_paulis() -> Tuple[Paulis, Paulis, Paulis, Paulis]:
+    # P, Q, R, S
+    return cirq.ops.X, cirq.ops.I, cirq.ops.X, cirq.ops.X
+
+
+@atomic_converter
+def add_paulis(circuit: cirq.Circuit) -> cirq.Circuit:
+    return circuit.map_operations(twirl_CNOT)
+
+
+def twirl_CNOT(op: cirq.Operation) -> cirq.OP_TREE:
+    if op.gate != cirq.CNOT:
+        return op
+
+    P, Q, R, S = sample_paulis()
+    control_qubit, target_qubit = op.qubits
+    return [
+        P.on(control_qubit),
+        Q.on(target_qubit),
+        op,
+        R.on(control_qubit),
+        S.on(target_qubit),
+    ]

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -84,10 +84,10 @@ def sample_paulis(
 
 @atomic_converter
 def add_paulis(circuit: cirq.Circuit) -> cirq.Circuit:
-    return circuit.map_operations(twirl_CNOT)
+    return circuit.map_operations(twirl_two_qubit_gate)
 
 
-def twirl_CNOT(op: cirq.Operation) -> cirq.OP_TREE:
+def twirl_two_qubit_gate(op: cirq.Operation) -> cirq.OP_TREE:
     if op.gate not in [cirq.CNOT, cirq.CZ]:
         return op
 

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -69,7 +69,7 @@ def execute_with_pauli_twirling(
             ``None``, the ``executor`` must return an expectation value
             (float). Otherwise, the ``QuantumResult`` returned by ``executor``
             is used to compute the expectation of the observable.
-        num_circuits: Number of circuits to be randomly twirled, and averaged.
+        num_circuits: Number of circuits to be twirled, and averaged.
 
     Returns:
         The expectation value estimated with Pauli twirling.

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -12,7 +12,7 @@ import numpy as np
 from mitiq import QPROGRAM, Executor, Observable, QuantumResult
 from mitiq.interface import atomic_converter
 
-Paulis = Union[cirq.IdentityGate, cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate]
+# Paulis = Union[cirq.IdentityGate, cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate]
 
 
 def _generate_lookup_table(

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -10,7 +10,7 @@ import cirq
 import numpy as np
 
 from mitiq import QPROGRAM, Executor, Observable, QuantumResult
-from mitiq.interface import atomic_converter
+from mitiq.interface import noise_scaling_converter
 
 # P, Q, R, S from https://arxiv.org/pdf/2301.02690.pdf
 CNOT_twirling_gates = [
@@ -68,17 +68,23 @@ def execute_with_pauli_twirling(
 
 
 def twirl_CNOT_gates(circuit: QPROGRAM, num_circuits: int) -> List[QPROGRAM]:
-    twirl_qprogram = atomic_converter(
-        lambda circuit: circuit.map_operations(_twirl_single_CNOT_gate)
-    )
-    return [twirl_qprogram(circuit) for _ in range(num_circuits)]
+    return [_twirl_CNOT_qprogram(circuit) for _ in range(num_circuits)]
+
+
+@noise_scaling_converter
+def _twirl_CNOT_qprogram(circuit: cirq.Circuit) -> List[cirq.Circuit]:
+    return circuit.map_operations(_twirl_single_CNOT_gate)
 
 
 def twirl_CZ_gates(circuit: QPROGRAM, num_circuits: int) -> List[QPROGRAM]:
-    twirl_qprogram = atomic_converter(
-        lambda circuit: circuit.map_operations(_twirl_single_CZ_gate)
-    )
-    return [twirl_qprogram(circuit) for _ in range(num_circuits)]
+    return [
+        _twirl_CZ_qprogram(circuit, num_circuits) for _ in range(num_circuits)
+    ]
+
+
+@noise_scaling_converter
+def _twirl_CZ_qprogram(circuit: cirq.Circuit) -> List[cirq.Circuit]:
+    return circuit.map_operations(_twirl_single_CZ_gate)
 
 
 def _twirl_single_CNOT_gate(op: cirq.Operation) -> cirq.OP_TREE:

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -72,7 +72,7 @@ def pauli_twirled_circuits(
 def sample_paulis(
     two_qubit_gate: cirq.Gate,
 ) -> Tuple[cirq.Gate, cirq.Gate, cirq.Gate, cirq.Gate]:
-    if two_qubit_gate not in ["CNOT", "CZ"]:
+    if two_qubit_gate not in [cirq.CNOT, cirq.CZ]:
         raise ValueError("Invalid two-qubit gate. Supported gates: CNOT, CZ")
 
     lookup_table = (

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -59,6 +59,21 @@ def execute_with_pauli_twirling(
     *,
     num_circuits: int = 10,
 ) -> float:
+    """Estimates the expecation value by averaging pauli twirled circuits.
+
+    Args:
+        circuit: The input circuit to execute with twirling.
+        executor: A Mitiq executor that executes a circuit and returns the
+            unmitigated ``QuantumResult`` (e.g. an expectation value).
+        observable: Observable to compute the expectation value of. If
+            ``None``, the ``executor`` must return an expectation value
+            (float). Otherwise, the ``QuantumResult`` returned by ``executor``
+            is used to compute the expectation of the observable.
+        num_circuits: Number of circuits to be randomly twirled, and averaged.
+
+    Returns:
+        The expectation value estimated with Pauli twirling.
+    """
     executor = (
         executor if isinstance(executor, Executor) else Executor(executor)
     )
@@ -68,6 +83,12 @@ def execute_with_pauli_twirling(
 
 
 def twirl_CNOT_gates(circuit: QPROGRAM, num_circuits: int) -> List[QPROGRAM]:
+    """Generate a list of circuits using Pauli twirling on CNOT gates.
+
+    Args:
+        circuit: The circuit to generate twirled versions of
+        num_circuits: The number of sampled circuits to return
+    """
     return [_twirl_CNOT_qprogram(circuit) for _ in range(num_circuits)]
 
 
@@ -77,6 +98,12 @@ def _twirl_CNOT_qprogram(circuit: cirq.Circuit) -> List[cirq.Circuit]:
 
 
 def twirl_CZ_gates(circuit: QPROGRAM, num_circuits: int) -> List[QPROGRAM]:
+    """Generate a list of circuits using Pauli twirling on CZ gates.
+
+    Args:
+        circuit: The circuit to generate twirled versions of
+        num_circuits: The number of sampled circuits to return
+    """
     return [
         _twirl_CZ_qprogram(circuit, num_circuits) for _ in range(num_circuits)
     ]
@@ -88,6 +115,17 @@ def _twirl_CZ_qprogram(circuit: cirq.Circuit) -> List[cirq.Circuit]:
 
 
 def _twirl_single_CNOT_gate(op: cirq.Operation) -> cirq.OP_TREE:
+    """Function which converts a CNOT to a logical equivalent. That is, it
+    converts CNOT operations into the following, leaving all other cirq
+    operations alone.
+
+        --P---⏺---R--
+              |
+        --Q---⊕---S--
+
+    Where P, Q, R, and S are Pauli operators sampled so as to not effect
+    change on the underlying unitary.
+    """
     if op.gate != cirq.CNOT:
         return op
 
@@ -103,6 +141,17 @@ def _twirl_single_CNOT_gate(op: cirq.Operation) -> cirq.OP_TREE:
 
 
 def _twirl_single_CZ_gate(op: cirq.Operation) -> cirq.OP_TREE:
+    """Function which converts a CNOT to a logical equivalent. That is, it
+    converts CNOT operations into the following, leaving all other cirq
+    operations alone.
+
+        --P---⏺---R--
+              |
+        --Q---⏺---S--
+
+    Where P, Q, R, and S are Pauli operators sampled so as to not effect
+    change on the underlying unitary.
+    """
     if op.gate != cirq.CZ:
         return op
 

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -92,7 +92,7 @@ def twirl_CNOT_gates(circuit: QPROGRAM, num_circuits: int) -> List[QPROGRAM]:
 
 
 @noise_scaling_converter
-def _twirl_CNOT_qprogram(circuit: cirq.Circuit) -> List[cirq.Circuit]:
+def _twirl_CNOT_qprogram(circuit: cirq.Circuit) -> cirq.Circuit:
     return circuit.map_operations(_twirl_single_CNOT_gate)
 
 
@@ -107,7 +107,7 @@ def twirl_CZ_gates(circuit: QPROGRAM, num_circuits: int) -> List[QPROGRAM]:
 
 
 @noise_scaling_converter
-def _twirl_CZ_qprogram(circuit: cirq.Circuit) -> List[cirq.Circuit]:
+def _twirl_CZ_qprogram(circuit: cirq.Circuit) -> cirq.Circuit:
     return circuit.map_operations(_twirl_single_CZ_gate)
 
 

--- a/mitiq/pt/tests/test_pt.py
+++ b/mitiq/pt/tests/test_pt.py
@@ -43,9 +43,9 @@ def test_generate_lookup_table():
     "gate, seed_val, expected_tuple",
     [
         (cirq.CNOT, 0, (cirq.I, cirq.Z, cirq.Z, cirq.I)),
-        (cirq.CZ, 2, (cirq.Z, cirq.I, cirq.X, cirq.Z)),
+        (cirq.CZ, 2, (cirq.X, cirq.I, cirq.I, cirq.X)),
         (cirq.CNOT, 3, (cirq.Z, cirq.X, cirq.X, cirq.Z)),
-        (cirq.CZ, 4, (cirq.Z, cirq.I, cirq.I, cirq.Z)),
+        (cirq.CZ, 4, (cirq.Z, cirq.Z, cirq.Z, cirq.Z)),
     ],
 )
 def test_sample_paulis(gate, seed_val, expected_tuple):

--- a/mitiq/pt/tests/test_pt.py
+++ b/mitiq/pt/tests/test_pt.py
@@ -1,0 +1,24 @@
+# Copyright (C) Unitary Fund
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+from mitiq.pt.pt import add_paulis
+import cirq
+
+num_qubits = 2
+qubits = cirq.LineQubit.range(num_qubits)
+circuit = cirq.Circuit()
+circuit.append(cirq.CNOT.on_each(zip(qubits, qubits[1:])))
+
+
+def test_add_paulis():
+    twirled = add_paulis(circuit)
+    twirled_circuit = cirq.Circuit(
+        cirq.X.on(qubits[0]),
+        cirq.I.on(qubits[1]),
+        cirq.CNOT.on(*qubits),
+        cirq.X.on_each(*qubits),
+    )
+
+    assert twirled == twirled_circuit

--- a/mitiq/pt/tests/test_pt.py
+++ b/mitiq/pt/tests/test_pt.py
@@ -23,7 +23,8 @@ from mitiq.benchmarks import generate_mirror_circuit
 num_qubits = 2
 qubits = cirq.LineQubit.range(num_qubits)
 circuit = cirq.Circuit()
-circuit.append(cirq.CNOT.on_each(zip(qubits, qubits[1:])))
+circuit.append(cirq.CNOT(*qubits))
+circuit.append(cirq.CZ(*qubits))
 
 
 def amp_damp_executor(circuit: cirq.Circuit, noise: float = 0.005) -> float:

--- a/mitiq/pt/tests/test_pt.py
+++ b/mitiq/pt/tests/test_pt.py
@@ -34,21 +34,26 @@ def test_generate_lookup_table():
         with pytest.raises(ValueError):
             _generate_lookup_table(gate)
 
-    _test_generate_lookup_table('CNOT', 16)
-    _test_generate_lookup_table('CZ', 16)
-    _test_generate_lookup_table_exception('INVALID_GATE')
+    _test_generate_lookup_table("CNOT", 16)
+    _test_generate_lookup_table("CZ", 16)
+    _test_generate_lookup_table_exception("INVALID_GATE")
 
-@pytest.mark.parametrize("gate, seed_val, expected_tuple", [
-    ('CNOT', 0, (cirq.Y, cirq.X, cirq.X, cirq.Y)),
-    ('CZ', 0, (cirq.Y, cirq.Z, cirq.Z, cirq.Y)),
-    ('CNOT', 1, (cirq.I, cirq.X, cirq.X, cirq.I)),
-    ('CZ', 1, (cirq.Z, cirq.I, cirq.I, cirq.Z))
-])
+
+@pytest.mark.parametrize(
+    "gate, seed_val, expected_tuple",
+    [
+        ("CNOT", 0, (cirq.Y, cirq.X, cirq.X, cirq.Y)),
+        ("CZ", 0, (cirq.Y, cirq.Z, cirq.Z, cirq.Y)),
+        ("CNOT", 1, (cirq.I, cirq.X, cirq.X, cirq.I)),
+        ("CZ", 1, (cirq.Z, cirq.I, cirq.I, cirq.Z)),
+    ],
+)
 def test_sample_paulis(gate, seed_val, expected_tuple):
     seed(seed_val)  # Fix random seed for reproducibility
     P1, P2, R1, R2 = sample_paulis(gate)
     assert (P1, P2, R1, R2) == expected_tuple
 
-def test_sample_paulis():
+
+def test_sample_paulis_exception():
     with pytest.raises(ValueError):
-        sample_paulis('INVALID_GATE')
+        sample_paulis("INVALID_GATE")

--- a/mitiq/pt/tests/test_pt.py
+++ b/mitiq/pt/tests/test_pt.py
@@ -3,8 +3,10 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-from mitiq.pt.pt import add_paulis
+from mitiq.pt.pt import add_paulis, sample_paulis, _generate_lookup_table
 import cirq
+import pytest
+from random import seed
 
 num_qubits = 2
 qubits = cirq.LineQubit.range(num_qubits)
@@ -22,3 +24,31 @@ def test_add_paulis():
     )
 
     assert twirled == twirled_circuit
+
+
+def test_generate_lookup_table():
+    def _test_generate_lookup_table(gate, expected_length):
+        assert len(_generate_lookup_table(gate)) == expected_length
+
+    def _test_generate_lookup_table_exception(gate):
+        with pytest.raises(ValueError):
+            _generate_lookup_table(gate)
+
+    _test_generate_lookup_table('CNOT', 16)
+    _test_generate_lookup_table('CZ', 16)
+    _test_generate_lookup_table_exception('INVALID_GATE')
+
+@pytest.mark.parametrize("gate, seed_val, expected_tuple", [
+    ('CNOT', 0, (cirq.Y, cirq.X, cirq.X, cirq.Y)),
+    ('CZ', 0, (cirq.Y, cirq.Z, cirq.Z, cirq.Y)),
+    ('CNOT', 1, (cirq.I, cirq.X, cirq.X, cirq.I)),
+    ('CZ', 1, (cirq.Z, cirq.I, cirq.I, cirq.Z))
+])
+def test_sample_paulis(gate, seed_val, expected_tuple):
+    seed(seed_val)  # Fix random seed for reproducibility
+    P1, P2, R1, R2 = sample_paulis(gate)
+    assert (P1, P2, R1, R2) == expected_tuple
+
+def test_sample_paulis():
+    with pytest.raises(ValueError):
+        sample_paulis('INVALID_GATE')

--- a/mitiq/pt/tests/test_pt.py
+++ b/mitiq/pt/tests/test_pt.py
@@ -42,14 +42,14 @@ def test_generate_lookup_table():
 @pytest.mark.parametrize(
     "gate, seed_val, expected_tuple",
     [
-        ("CNOT", 0, (cirq.Y, cirq.X, cirq.X, cirq.Y)),
-        ("CZ", 0, (cirq.Y, cirq.Z, cirq.Z, cirq.Y)),
-        ("CNOT", 1, (cirq.I, cirq.X, cirq.X, cirq.I)),
-        ("CZ", 1, (cirq.Z, cirq.I, cirq.I, cirq.Z)),
+        (cirq.CNOT, 0, (cirq.I, cirq.Z, cirq.Z, cirq.I)),
+        (cirq.CZ, 2, (cirq.Z, cirq.I, cirq.X, cirq.Z)),
+        (cirq.CNOT, 3, (cirq.Z, cirq.X, cirq.X, cirq.Z)),
+        (cirq.CZ, 4, (cirq.Z, cirq.I, cirq.I, cirq.Z)),
     ],
 )
 def test_sample_paulis(gate, seed_val, expected_tuple):
-    seed(seed_val)  # Fix random seed for reproducibility
+    seed(seed_val)  # Fix random seed for reproducibility - it's broken
     P1, P2, R1, R2 = sample_paulis(gate)
     assert (P1, P2, R1, R2) == expected_tuple
 


### PR DESCRIPTION
## Description

Add ability to execute circuits with Pauli twirling on CNOT gates as suggested in https://github.com/unitaryfund/mitiq/issues/1774.

fixes https://github.com/unitaryfund/mitiq/issues/1774

---

### Notes until ready for review:

So far I have only tested simple cases with `add_paulis` which was made very simple using Cirq's [`map_operations`](https://quantumai.google/reference/python/cirq/map_operations) function.

Currently the `sample_paulis` function is executed _inside_ `twirl_CNOT`. I can imagine it being useful to have this outside, and $P, Q, R$ and $S$ passed in as variables. It might separate the logic a little more in case we wanted to modify how these unitaries are sampled as the circuits are generated. If not, this is probably unnecessary.

#### TODO:
- [x] docstrings
- [x] tests
- [x] `sample_paulis` implementation / table
- [ ] some sort of `check_twirlable` function (_can do this later_, no rush)
- [x] mypy issue (haven't been able to figure out the difference between `floating[Any]` and `float`)
