### PR TITLE
use 1.7.0 link for grove

### DIFF
--- a/docs/source/examples/vqe-pyquil-demo.ipynb
+++ b/docs/source/examples/vqe-pyquil-demo.ipynb
@@ -569,7 +569,7 @@
     "\n",
     "## References\n",
     "[1] Rigetti Computing (2018) Grove (Version 1.7.0) \n",
-    "[[Source code].](https://github.com/rigetti/grove/blob/master/grove/pyvqe/vqe.py)\n",
+    "[[Source code].](https://github.com/rigetti/grove/blob/v1.7.0/grove/pyvqe/vqe.py)\n",
     "\n",
     "[2] [[VQE tutorial in pyQuil / Grove].](https://grove-docs.readthedocs.io/en/latest/vqe.html)"
    ]


### PR DESCRIPTION
## Description

Had a spurious docs build failure on this link and noticed it was set for master, despite being a reference to a specific version of Grove. Bring link in line with text.