### PR TITLE
Supports observable multiplication with observable and PauliString

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,3 +44,7 @@ dependabot[bot]
 allcontributors[bot]
 Isaac Griswold-Steiner
 Tim (Yi-Ting) Chen
+Ammar Jahin
+Dariel Mok
+Preksha Naik
+Abdulrahman Sahmoud

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -185,8 +185,8 @@ class Observable:
 
 
 def _combine_duplicate_pauli_strings(
-    paulis: list[PauliString],
-) -> list[PauliString]:
+    paulis: Iterable[PauliString],
+) -> List[PauliString]:
     """Combines duplicate PauliStrings by adding their coefficients.
     Discards paulis with zero coefficients.
 

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -197,8 +197,7 @@ def _combine_duplicate_pauli_strings(
     )
     for pauli_string in paulis:
         cache_key = pauli_string.with_coeff(1)
-        new_coeff = pauli_string.coeff + pauli_string_coefficients[cache_key]
-        pauli_string_coefficients[cache_key] = new_coeff
+        pauli_string_coefficients[cache_key] += pauli_string.coeff
     return list(
         [
             pauli_string.with_coeff(coeff)

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -82,10 +82,11 @@ class Observable:
         if isinstance(other, (PauliString, complex, float, int)):
             return Observable(*[pauli * other for pauli in self._paulis])
         elif isinstance(other, Observable):
-            all_paulis = []
-            for other_pauli in other._paulis:
-                all_paulis += [pauli * other_pauli for pauli in self._paulis]
-            new_observable = Observable(*all_paulis)
+            new_observable = Observable(
+                pauli * other_pauli
+                for pauli in self._paulis
+                for other_pauli in other._paulis
+            )
             return new_observable.combine_duplicates()
         return NotImplemented
 

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -155,7 +155,13 @@ class Observable:
         return Executor(execute).evaluate(circuit, observable=self)[0]
 
     def _combine_duplicates(self) -> None:
-        pauli_string_coefficients = defaultdict(int)
+        """Modifies self._paulis in place.
+        Combines duplicate PauliStrings by adding their coefficients.
+        Discards paulis with zero coefficients.
+        """
+        pauli_string_coefficients: defaultdict[
+            PauliString, complex
+        ] = defaultdict(complex)
         for pauli_string in self._paulis:
             cache_key = pauli_string.with_coeff(1)
             new_coeff = (

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import copy
-from typing import Callable, cast, List, Optional, Set, Union, Any
+from typing import Callable, cast, List, Optional, Set, Union, Any, Iterable
 
 import numpy as np
 import numpy.typing as npt
@@ -39,7 +39,7 @@ class Observable:
             paulis: PauliStrings used to define the observable.
 
         """
-        self._paulis = _combine_duplicate_pauli_strings(list(paulis))
+        self._paulis = _combine_duplicate_pauli_strings(paulis)
         self._groups: List[PauliStringCollection]
         self._ngroups: int
         self.partition()
@@ -198,10 +198,8 @@ def _combine_duplicate_pauli_strings(
     for pauli_string in paulis:
         cache_key = pauli_string.with_coeff(1)
         pauli_string_coefficients[cache_key] += pauli_string.coeff
-    return list(
-        [
-            pauli_string.with_coeff(coeff)
-            for (pauli_string, coeff) in pauli_string_coefficients.items()
-            if not np.isclose(coeff, 0.0)
-        ]
-    )
+    return [
+        pauli_string.with_coeff(coeff)
+        for (pauli_string, coeff) in pauli_string_coefficients.items()
+        if not np.isclose(coeff, 0.0)
+    ]

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import copy
-from typing import Callable, cast, List, Optional, Set
+from typing import Callable, cast, List, Optional, Set, Union, Dict
 
 import numpy as np
 import numpy.typing as npt
@@ -77,7 +77,9 @@ class Observable:
     def nqubits(self) -> int:
         return len(self.qubit_indices)
 
-    def __mul__(self, other):
+    def __mul__(
+        self, other: Union["Observable", "PauliString", complex, float, int]
+    ) -> "Observable":
         if isinstance(other, (PauliString, complex, float, int)):
             return Observable(*[pauli * other for pauli in self._paulis])
         elif isinstance(other, Observable):
@@ -89,7 +91,9 @@ class Observable:
             return new_observable
         return NotImplemented
 
-    def __rmul__(self, other):
+    def __rmul__(
+        self, other: Union["PauliString", complex, float, int]
+    ) -> "Observable":
         if isinstance(other, (PauliString, complex, float, int)):
             return Observable(*[other * pauli for pauli in self._paulis])
         return NotImplemented
@@ -149,8 +153,8 @@ class Observable:
 
         return Executor(execute).evaluate(circuit, observable=self)[0]
 
-    def _combine_duplicates(self):
-        d = {}
+    def _combine_duplicates(self) -> None:
+        d: Dict[PauliString, PauliString] = {}
         for pauli_string in self._paulis:
             cache_key = pauli_string.with_coeff(1)
             if cache_key in d:

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -30,6 +30,7 @@ import numpy as np
 import numpy.typing as npt
 import cirq
 
+from numbers import Number
 from mitiq import QPROGRAM, MeasurementResult
 from mitiq.interface import atomic_converter
 from mitiq.utils import _cirq_pauli_to_string
@@ -169,18 +170,16 @@ class PauliString:
             measurements
         )
 
-    def __mul__(
-        self, other: Union["PauliString", complex, float, int]
-    ) -> "PauliString":
+    def __mul__(self, other: Union["PauliString", Number]) -> "PauliString":
         if isinstance(other, PauliString):
             return PauliString.from_cirq_pauli_string(
                 self._pauli * other._pauli
             )
-        elif isinstance(other, (complex, float, int)):
+        elif isinstance(other, Number):
             return PauliString.from_cirq_pauli_string(self._pauli * other)
         return NotImplemented
 
-    def __rmul__(self, other: Union[complex, float, int]) -> "PauliString":
+    def __rmul__(self, other: Number) -> "PauliString":
         return self.__mul__(other)
 
     def __eq__(self, other: Any) -> bool:

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -180,7 +180,9 @@ class PauliString:
         return NotImplemented
 
     def __rmul__(self, other: Number) -> "PauliString":
-        return self.__mul__(other)
+        if isinstance(other, Number):
+            return self.__mul__(other)
+        return NotImplemented
 
     def __eq__(self, other: Any) -> bool:
         return self._pauli == other._pauli

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -132,12 +132,15 @@ class PauliString:
                 return False
         return True
 
-    def with_coeff(self, coeff) -> "PauliString":
-        return PauliString(spec=self.spec, coeff=coeff, support=self.support())
+    def with_coeff(self, coeff: complex) -> "PauliString":
+        return PauliString(
+            spec=self.spec, coeff=coeff, support=sorted(self.support())
+        )
 
     @property
     def spec(self) -> str:
-        """Returns a string representation of the Pauli gates in the PauliString."""
+        """Returns a string representation of the Pauli gates in
+        the PauliString."""
         return "".join(
             self._gate_to_string_map[self._pauli[q]]
             for q in sorted(self._pauli.qubits)
@@ -171,6 +174,9 @@ class PauliString:
             result._pauli = self._pauli * other
             return result
         return NotImplemented
+
+    def __rmul__(self, other: Union[complex, float, int]) -> "PauliString":
+        return self.__mul__(other)
 
     def __eq__(self, other: Any) -> bool:
         return self._pauli == other._pauli

--- a/mitiq/observable/tests/test_observable.py
+++ b/mitiq/observable/tests/test_observable.py
@@ -282,10 +282,12 @@ def test_observable_mul():
     XZ = PauliString("XZ", 0.1)
     ZX = PauliString("ZX", 0.2)
     IZ = PauliString("IZ", -0.4)
-    o1 = Observable(XI, YY, XZ)
-    o2 = Observable(ZX, IZ)
-    o3 = Observable(XI * ZX, XI * IZ, YY * ZX, YY * IZ, XZ * ZX, XZ * IZ)
-    assert np.allclose((o1 * o2).matrix(), o3.matrix())
+    obs1 = Observable(XI, YY, XZ)
+    obs2 = Observable(ZX, IZ)
+    correct_obs = Observable(
+        XI * ZX, XI * IZ, YY * ZX, YY * IZ, XZ * ZX, XZ * IZ
+    )
+    assert np.allclose((obs1 * obs2).matrix(), correct_obs.matrix())
 
 
 def test_observable_multiplication():
@@ -298,13 +300,13 @@ def test_observable_multiplication():
     IIXYZ = PauliString("IIXYZ", 0.7)
     ZYXIZ = PauliString("ZYXIZ", 0.1)
     YIZXI = PauliString("YIZXI", 0.2)
-    l1 = [YXXYZ, ZYIZX, IZZXY, YZIXZ, XZYII]
-    l2 = [YYZXI, IIXYZ, ZYXIZ, YIZXI]
-    o1 = Observable(*l1)
-    o2 = Observable(*l2)
-    l3 = [p1 * p2 for p1 in l1 for p2 in l2]
-    o3 = Observable(*l3)
-    assert np.allclose((o1 * o2).matrix(), o3.matrix())
+    pauli_strings_1 = [YXXYZ, ZYIZX, IZZXY, YZIXZ, XZYII]
+    pauli_strings_2 = [YYZXI, IIXYZ, ZYXIZ, YIZXI]
+    obs1 = Observable(*pauli_strings_1)
+    obs2 = Observable(*pauli_strings_2)
+    l3 = [p1 * p2 for p1 in pauli_strings_1 for p2 in pauli_strings_2]
+    correct_obs = Observable(*l3)
+    assert np.allclose((obs1 * obs2).matrix(), correct_obs.matrix())
 
 
 def test_pauli_string_left_multiplication():
@@ -312,10 +314,10 @@ def test_pauli_string_left_multiplication():
     YY = PauliString("YY", 0.7)
     XZ = PauliString("XZ", 0.1)
     IZ = PauliString("IZ", -0.4)
-    l = [XI, YY, XZ]
-    o1 = Observable(*l)
-    o2 = Observable(*[p * IZ for p in l])
-    assert np.allclose((o1 * IZ).matrix(), o2.matrix())
+    pauli_strings = [XI, YY, XZ]
+    obs1 = Observable(*pauli_strings)
+    correct_obs = Observable(*[p * IZ for p in pauli_strings])
+    assert np.allclose((obs1 * IZ).matrix(), correct_obs.matrix())
 
 
 def test_pauli_string_right_multiplication():
@@ -323,7 +325,7 @@ def test_pauli_string_right_multiplication():
     YY = PauliString("YY", 0.7)
     XZ = PauliString("XZ", 0.1)
     IZ = PauliString("IZ", -0.4)
-    l = [XI, YY, XZ]
-    o1 = Observable(*l)
-    o2 = Observable(*[IZ * p for p in l])
-    assert np.allclose((IZ * o1).matrix(), o2.matrix())
+    pauli_strings = [XI, YY, XZ]
+    obs1 = Observable(*pauli_strings)
+    correct_obs = Observable(*[IZ * p for p in pauli_strings])
+    assert np.allclose((IZ * obs1).matrix(), correct_obs.matrix())

--- a/mitiq/observable/tests/test_observable.py
+++ b/mitiq/observable/tests/test_observable.py
@@ -116,8 +116,8 @@ def test_observable_partition_can_be_measured_with():
     )
 
     assert obs.nqubits == n
-    assert obs.nterms == nterms
-    assert obs.ngroups <= nterms
+    assert obs.nterms <= nterms  # because of deduplication
+    assert obs.ngroups <= obs.nterms
 
     for pset in obs.groups:
         pauli_list = list(pset.elements)
@@ -287,7 +287,7 @@ def test_observable_multuplication_1():
     correct_obs = Observable(
         XI * ZX, XI * IZ, YY * ZX, YY * IZ, XZ * ZX, XZ * IZ
     )
-    assert np.allclose((obs1 * obs2).matrix(), correct_obs.matrix())
+    assert obs1 * obs2 == correct_obs
 
 
 def test_observable_multiplication_2():
@@ -306,14 +306,14 @@ def test_observable_multiplication_2():
     obs2 = Observable(*pauli_strings_2)
     l3 = [p1 * p2 for p1 in pauli_strings_1 for p2 in pauli_strings_2]
     correct_obs = Observable(*l3)
-    assert np.allclose((obs1 * obs2).matrix(), correct_obs.matrix())
+    assert obs1 * obs2 == correct_obs
 
 
 def test_scalar_multiplication():
     YXXYZ = PauliString("YXXYZ", 0.3)
     obs = Observable(YXXYZ)
-    assert np.allclose((obs * 2.0).matrix(), Observable(YXXYZ * 2.0).matrix())
-    assert np.allclose((2.0 * obs).matrix(), Observable(YXXYZ * 2.0).matrix())
+    assert obs * 2.0 == Observable(YXXYZ * 2.0)
+    assert 2.0 * obs == Observable(YXXYZ * 2.0)
 
 
 def test_pauli_string_left_multiplication():
@@ -324,7 +324,7 @@ def test_pauli_string_left_multiplication():
     pauli_strings = [XI, YY, XZ]
     obs1 = Observable(*pauli_strings)
     correct_obs = Observable(*[p * IZ for p in pauli_strings])
-    assert np.allclose((obs1 * IZ).matrix(), correct_obs.matrix())
+    assert obs1 * IZ == correct_obs
 
 
 def test_pauli_string_right_multiplication():
@@ -335,4 +335,4 @@ def test_pauli_string_right_multiplication():
     pauli_strings = [XI, YY, XZ]
     obs1 = Observable(*pauli_strings)
     correct_obs = Observable(*[IZ * p for p in pauli_strings])
-    assert np.allclose((IZ * obs1).matrix(), correct_obs.matrix())
+    assert IZ * obs1 == correct_obs

--- a/mitiq/observable/tests/test_observable.py
+++ b/mitiq/observable/tests/test_observable.py
@@ -336,3 +336,30 @@ def test_pauli_string_right_multiplication():
     obs1 = Observable(*pauli_strings)
     correct_obs = Observable(*[IZ * p for p in pauli_strings])
     assert IZ * obs1 == correct_obs
+
+
+def test_pauli_string_deduplication():
+    XI = PauliString("XI", 0.3)
+    YY = PauliString("YY", 0.7)
+    XZ = PauliString("XZ", 0.1)
+    n_repeat_paulis = 4
+    pauli_strings = [XI, YY, XZ] * n_repeat_paulis
+
+    obs = Observable(*pauli_strings)
+    assert obs.nterms == 3
+    assert obs == Observable(
+        XI.with_coeff(XI.coeff * n_repeat_paulis),
+        YY.with_coeff(YY.coeff * n_repeat_paulis),
+        XZ.with_coeff(XZ.coeff * n_repeat_paulis),
+    )
+
+
+def test_pauli_string_deduplication_removal_of_0_coefficients():
+    XI = PauliString("XI", 0.3)
+    YY = PauliString("YY", 0.7)
+
+    pauli_strings = [XI, YY, XI, YY.with_coeff(-YY.coeff)]
+
+    obs = Observable(*pauli_strings)
+    assert obs.nterms == 1
+    assert obs == Observable(XI.with_coeff(XI.coeff * 2))

--- a/mitiq/observable/tests/test_observable.py
+++ b/mitiq/observable/tests/test_observable.py
@@ -274,3 +274,56 @@ def test_observable_expectation_supported_qubits(executor):
     # <Z2> = 0.
     obs = Observable(PauliString(spec="Z", support=(2,)))
     assert np.isclose(obs.expectation(circuit, executor), 0.0, atol=5e-2)
+
+
+def test_observable_mul():
+    XI = PauliString("XI", 0.3)
+    YY = PauliString("YY", 0.7)
+    XZ = PauliString("XZ", 0.1)
+    ZX = PauliString("ZX", 0.2)
+    IZ = PauliString("IZ", -0.4)
+    o1 = Observable(XI, YY, XZ)
+    o2 = Observable(ZX, IZ)
+    o3 = Observable(XI * ZX, XI * IZ, YY * ZX, YY * IZ, XZ * ZX, XZ * IZ)
+    assert np.allclose((o1 * o2).matrix(), o3.matrix())
+
+
+def test_observable_multiplication():
+    YXXYZ = PauliString("YXXYZ", 0.3)
+    ZYIZX = PauliString("ZYIZX", 0.7)
+    IZZXY = PauliString("IZZXY", 0.1)
+    YZIXZ = PauliString("YZIXZ", 0.2)
+    XZYII = PauliString("XZYII", -0.4)
+    YYZXI = PauliString("YYZXI", 0.7)
+    IIXYZ = PauliString("IIXYZ", 0.7)
+    ZYXIZ = PauliString("ZYXIZ", 0.1)
+    YIZXI = PauliString("YIZXI", 0.2)
+    l1 = [YXXYZ, ZYIZX, IZZXY, YZIXZ, XZYII]
+    l2 = [YYZXI, IIXYZ, ZYXIZ, YIZXI]
+    o1 = Observable(*l1)
+    o2 = Observable(*l2)
+    l3 = [p1 * p2 for p1 in l1 for p2 in l2]
+    o3 = Observable(*l3)
+    assert np.allclose((o1 * o2).matrix(), o3.matrix())
+
+
+def test_pauli_string_left_multiplication():
+    XI = PauliString("XI", 0.3)
+    YY = PauliString("YY", 0.7)
+    XZ = PauliString("XZ", 0.1)
+    IZ = PauliString("IZ", -0.4)
+    l = [XI, YY, XZ]
+    o1 = Observable(*l)
+    o2 = Observable(*[p * IZ for p in l])
+    assert np.allclose((o1 * IZ).matrix(), o2.matrix())
+
+
+def test_pauli_string_right_multiplication():
+    XI = PauliString("XI", 0.3)
+    YY = PauliString("YY", 0.7)
+    XZ = PauliString("XZ", 0.1)
+    IZ = PauliString("IZ", -0.4)
+    l = [XI, YY, XZ]
+    o1 = Observable(*l)
+    o2 = Observable(*[IZ * p for p in l])
+    assert np.allclose((IZ * o1).matrix(), o2.matrix())

--- a/mitiq/observable/tests/test_observable.py
+++ b/mitiq/observable/tests/test_observable.py
@@ -276,7 +276,7 @@ def test_observable_expectation_supported_qubits(executor):
     assert np.isclose(obs.expectation(circuit, executor), 0.0, atol=5e-2)
 
 
-def test_observable_mul():
+def test_observable_multuplication_1():
     XI = PauliString("XI", 0.3)
     YY = PauliString("YY", 0.7)
     XZ = PauliString("XZ", 0.1)
@@ -290,7 +290,7 @@ def test_observable_mul():
     assert np.allclose((obs1 * obs2).matrix(), correct_obs.matrix())
 
 
-def test_observable_multiplication():
+def test_observable_multiplication_2():
     YXXYZ = PauliString("YXXYZ", 0.3)
     ZYIZX = PauliString("ZYIZX", 0.7)
     IZZXY = PauliString("IZZXY", 0.1)
@@ -307,6 +307,13 @@ def test_observable_multiplication():
     l3 = [p1 * p2 for p1 in pauli_strings_1 for p2 in pauli_strings_2]
     correct_obs = Observable(*l3)
     assert np.allclose((obs1 * obs2).matrix(), correct_obs.matrix())
+
+
+def test_scalar_multiplication():
+    YXXYZ = PauliString("YXXYZ", 0.3)
+    obs = Observable(YXXYZ)
+    assert np.allclose((obs * 2.0).matrix(), Observable(YXXYZ * 2.0).matrix())
+    assert np.allclose((2.0 * obs).matrix(), Observable(YXXYZ * 2.0).matrix())
 
 
 def test_pauli_string_left_multiplication():

--- a/mitiq/observable/tests/test_pauli.py
+++ b/mitiq/observable/tests/test_pauli.py
@@ -375,10 +375,8 @@ def test_pstringcollection_expectation_from_measurements_qubit_indices():
 
 
 def test_spec():
-    x = PauliString(spec="XIZYII")
-    assert x.spec == "XZY"
+    assert PauliString(spec="XIZYII").spec == "XZY"
 
 
 def test_with_coeff():
-    x = PauliString(spec="X")
-    assert x.with_coeff(2) == 2
+    assert PauliString(spec="X").with_coeff(2).coeff == 2

--- a/mitiq/observable/tests/test_pauli.py
+++ b/mitiq/observable/tests/test_pauli.py
@@ -372,3 +372,13 @@ def test_pstringcollection_expectation_from_measurements_qubit_indices():
         PauliString(spec="Z", coeff=-2.0, support=(5,))
     )
     assert np.isclose(pset._expectation_from_measurements(measurements), 0.0)
+
+
+def test_spec():
+    x = PauliString(spec="XIZYII")
+    assert x.spec == "XZY"
+
+
+def test_with_coeff():
+    x = PauliString(spec="X")
+    assert x.with_coeff(2) == 2

--- a/mitiq/observable/tests/test_pauli.py
+++ b/mitiq/observable/tests/test_pauli.py
@@ -190,6 +190,8 @@ def test_weight():
 
 def test_multiplication():
     Pauli = PauliString
+    assert 2 * Pauli("X") == Pauli("X", coeff=2)
+    assert Pauli("X") * 2 == Pauli("X", coeff=2)
     assert Pauli("X") * Pauli("I") == Pauli("X")
     assert Pauli("X") * Pauli("Y") == Pauli("Z", coeff=1j)
     assert Pauli("X") * Pauli("Y", support=(1,)) == Pauli("XY")

--- a/mitiq/utils.py
+++ b/mitiq/utils.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Tuple
 import numpy as np
 import numpy.typing as npt
 
+import cirq
 from cirq import (
     LineQubit,
     Circuit,
@@ -254,3 +255,15 @@ def _operation_to_choi(operation_tree: OP_TREE) -> npt.NDArray[np.complex64]:
     """
     circuit = Circuit(operation_tree)
     return _circuit_to_choi(circuit)
+
+
+def _cirq_pauli_to_string(pauli: cirq.PauliString[Any]) -> str:
+    """Returns the string representation of a Cirq PauliString.
+
+    Args:
+        pauli: The input PauliString.
+    Returns:
+        The string representation of the input PauliString.
+    """
+    gate_to_string_map = {cirq.I: "I", cirq.X: "X", cirq.Y: "Y", cirq.Z: "Z"}
+    return "".join(gate_to_string_map[pauli[q]] for q in sorted(pauli.qubits))


### PR DESCRIPTION
closes #1810 

## Description

Supports observable multiplication with observable, PauliString and numeric types.

I realized that combining duplicates would be necessary to ensure the compactness of the observable and efficiency of computing its expectation value when we multiply an observable by an observable. So I added a private `_combine_duplicates` function to be used after the full set of product PauliString is computed.

`_combine_duplicates` required PauliString to support a `with_coeff` method to allow us to normalize the states to a fixed coeff before computing the hash which will allow us to dedupe the PauliString's using a dictionary.

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [X] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [X] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [X] Added myself / the copyright holder to the AUTHORS file