### PR TITLE
bump nbsphinx

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -22,7 +22,7 @@ myst-nb==0.17.1
 pydata-sphinx-theme==0.11.0
 jupytext==1.14.1
 sphinx-gallery==0.10.1
-nbsphinx==0.8.9
+nbsphinx==0.9.1
 pyscf==2.2.1; sys_platform != 'win32'
 openfermion==1.5.1; sys_platform != 'win32'
 openfermionpyscf==0.5; sys_platform != 'win32'


### PR DESCRIPTION
## Description

Dependabot didn't upgrade this as it's told to ignore minor versions in our config file: https://github.com/unitaryfund/mitiq/blob/4e94c995816aa372402f16e6c104a33dac3ac6b5/.github/dependabot.yml#L35-L36

fixes https://github.com/unitaryfund/mitiq/issues/1498