### PR TITLE
Clean up types

### DIFF
--- a/docs/source/examples/molecular_hydrogen.md
+++ b/docs/source/examples/molecular_hydrogen.md
@@ -13,14 +13,11 @@ kernelspec:
 
 # Estimating the potential energy surface of molecular Hydrogen with ZNE and OpenFermion
 
-+++
-
 In this example we apply zero-noise extrapolation (ZNE) to the estimation of the potential energy surface of molecular Hydrogen ($\rm H_2$).
-The variational algorithm used in this example is based on *O’Malley et al. PRX (2016)* {cite}`OMalley_2016_PRX`.
+The variational algorithm used in this example is based on _O’Malley et al. PRX (2016)_ {cite}`OMalley_2016_PRX`.
 
 With the appropriate settings (see code comments in the ZNE subsection), this notebook reproduces the results
 shown in Figure 4 of the Mitiq white paper.
-
 
 ```{figure} ../img/h2_molecule.svg
 ---
@@ -62,12 +59,12 @@ where $g_i$ are numerical values that depend on the bond length $R$. The above H
 
 Each coefficient $g_i$ is a function of the bond length $g_i = g_i(R)$. The exact parameters can be extracted from Appendix C of {cite}`OMalley_2016_PRX`.
 
-We can also calculate their values automatically using OpenFermion (an open source quantum chemistry package). 
+We can also calculate their values automatically using OpenFermion (an open source quantum chemistry package).
 To run the code of this example, the Python package `openfermionpyscf` must be [installed](https://github.com/quantumlib/OpenFermion-PySCF) in your system.
 This results in slightly modified hamiltonians of the form:
 
 \begin{equation}
-    H = g_0 I + g_1 Z_0 + g_2 Z_1 + g_3 Z_0 Z_1 + g_4 X_0 X_1
+   H = g_0 I + g_1 Z_0 + g_2 Z_1 + g_3 Z_0 Z_1 + g_4 X_0 X_1
 \end{equation}
 
 ```{code-cell} ipython3
@@ -100,7 +97,6 @@ def get_hamiltonian(bond_length) -> Observable:
 hamiltonians = [get_hamiltonian(i) for i in radii]
 print(hamiltonians[0])
 ```
-
 
 ## Evaluating the energy landscape for a fixed $R$
 
@@ -136,7 +132,7 @@ all_energies = []
 for pval in pvals:
     energies = []
     for theta in thetas:
-        results = hamiltonians[0].expectation(ansatz(theta), execute=partial(compute_density_matrix, noise_model=cirq.depolarize, noise_level=(pval,)))
+        results = hamiltonians[0].expectation(ansatz(theta), execute=partial(compute_density_matrix, noise_model_function=cirq.depolarize, noise_level=(pval,)))
         energies.append(np.real(results))
     all_energies.append(energies)
 ```
@@ -161,7 +157,7 @@ num_to_average = 1
 
 # To reproduce the results of the Mitiq paper use the following settings
 # scaling_function = zne.scaling.fold_gates_at_random
-# pfac = zne.inference.PolyFactory(order=3, 
+# pfac = zne.inference.PolyFactory(order=3,
 #                           scale_factors=[1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5, 5., 5.5, 6.])
 # num_to_average = 5
 # pvals = (0.00, 0.02, 0.04, 0.06)
@@ -172,7 +168,7 @@ for p in pvals[1:]:
     mitigated = []
     for theta in thetas:
         # Define an executor function
-        executor = Executor(partial(compute_density_matrix, noise_model=cirq.depolarize, noise_level=(p,)))
+        executor = Executor(partial(compute_density_matrix, noise_model_function=cirq.depolarize, noise_level=(p,)))
         # Run ZNE
         zne_value = zne.execute_with_zne(
             ansatz(theta),
@@ -187,6 +183,7 @@ for p in pvals[1:]:
 ```
 
 In the next figure we visualize the following results:
+
 1. The ideal noiseless energy landscape $E(\theta, R)$ corresponding to `all_energies[0]`;
 2. The noisy (unmitigated) energies `all_energies`;
 3. The corresponding error-mitigated energies `all_mitigated`.
@@ -282,8 +279,6 @@ for pval in pvals:
 
 The unmitigated potential energy surfaces are now stored in the `best_energies` variable and will be visualized later.
 
-
-
 ### Applying zero-noise extrapolation to estimate $V(R)$
 
 We use zero-noise extrapolation to error-mitigate the potential energy surface $V(R)$.
@@ -300,7 +295,7 @@ for pval in pvals[1:]:
         def objective_function(theta):
             return np.real(zne.execute_with_zne(
                 ansatz(theta),
-                Executor(partial(compute_density_matrix, noise_model=cirq.depolarize, noise_level=(pval,))),
+                Executor(partial(compute_density_matrix, noise_model_function=cirq.depolarize, noise_level=(pval,))),
                 hamiltonians[i],
                 factory=fac,
                 scale_noise=scaling_function,
@@ -323,6 +318,7 @@ for pval in pvals[1:]:
 ```
 
 In the next figure we visualize the following results:
+
 1. The ideal noiseless potential energy surface $V(R)$ corresponding to `best_energies[0]`;
 2. The noisy (unmitigated) potential energy surfaces `best_energies`;
 3. The corresponding error-mitigated potential energy surfaces `best_mitigated_energies`.

--- a/docs/source/examples/molecular_hydrogen.md
+++ b/docs/source/examples/molecular_hydrogen.md
@@ -266,10 +266,19 @@ for pval in pvals:
     for i in range(len(radii)):
         # Objective function to minimize
         def obj(theta):
-            val = hamiltonians[i].expectation(ansatz(theta[0]), execute=partial(compute_density_matrix, noise_model=cirq.depolarize, noise_level=(pval,)))
+            val = hamiltonians[i].expectation(
+                ansatz(theta[0]),
+                execute=partial(
+                    compute_density_matrix,
+                    noise_model_function=cirq.depolarize,
+                    noise_level=(pval,),
+                ),
+            )
             return np.real(val)
 
-        res = brute(obj, ranges=[(0, 2 * np.pi)], Ns=10, finish=None, full_output=True)
+        res = brute(
+            obj, ranges=[(0, 2 * np.pi)], Ns=10, finish=None, full_output=True
+        )
         these_thetas.append(res[0])
         these_energies.append(res[1])
 

--- a/docs/source/examples/molecular_hydrogen_pennylane.md
+++ b/docs/source/examples/molecular_hydrogen_pennylane.md
@@ -16,7 +16,7 @@ kernelspec:
 +++
 
 In this example we apply zero-noise extrapolation (ZNE) to the estimation of the potential energy surface of molecular Hydrogen ($\rm H_2$).
-The variational algorithm used in this example is based on *O’Malley et al. PRX (2016)* {cite}`OMalley_2016_PRX`.
+The variational algorithm used in this example is based on _O’Malley et al. PRX (2016)_ {cite}`OMalley_2016_PRX`.
 
 With the appropriate settings (see code comments in the ZNE subsection), this notebook reproduces the results
 shown in Figure 4 of the Mitiq white paper.
@@ -62,7 +62,7 @@ where $g_i$ are numerical values that depend on the bond length $R$. The above H
 
 Each coefficient $g_i$ is a function of the bond length $g_i = g_i(R)$. We obtain the `H` for $\rm H_2$ at any given bond length $R$
 by first building the full molecular Hamiltonian using [`PennyLane`](https://pennylane.readthedocs.io/) and then
-tapering it using the symmetries mentioned in the Appendix A of {cite}`OMalley_2016_PRX` to reduce it to a two qubit Hamiltonian, 
+tapering it using the symmetries mentioned in the Appendix A of {cite}`OMalley_2016_PRX` to reduce it to a two qubit Hamiltonian,
 where the qubits `0` and `2` corresponds to the labels `0` and `1` in the Hamiltonian `H` given above.
 
 ```{code-cell} ipython3
@@ -71,15 +71,15 @@ ang_to_bohr = 1.8897259886 # pennylane specifies coordinates in terms of Bohr ra
 def molecular_hamiltonian(bond_length: float) -> mitiq.Observable:
     """ Builds the Hamiltonian for H2 at a given bond length """
     symbols = ['H', 'H']
-    geometry = ang_to_bohr * np.array([[0., 0., - 0.5 * bond_length], 
+    geometry = ang_to_bohr * np.array([[0., 0., - 0.5 * bond_length],
                                        [0., 0., 0.5 * bond_length]])
     mol = qml.qchem.Molecule(symbols, geometry)
-    Hamil, qubits = qml.qchem.molecular_hamiltonian(symbols, geometry, basis="sto-6g", 
+    Hamil, qubits = qml.qchem.molecular_hamiltonian(symbols, geometry, basis="sto-6g",
                                                     method="pyscf", mapping="bravyi_kitaev")
 
     # tapering the Hamiltonian using symmetries
-    generators = [qml.PauliZ(1), qml.PauliZ(3)] # symmetries corresponding to qubit 1 and 3 
-    paulix_ops = [qml.PauliX(1), qml.PauliX(3)] # corresponding paulix ops for tapering 
+    generators = [qml.PauliZ(1), qml.PauliZ(3)] # symmetries corresponding to qubit 1 and 3
+    paulix_ops = [qml.PauliX(1), qml.PauliX(3)] # corresponding paulix ops for tapering
     eigval_sec = [1, 1] # optimal sector containing the ground state
     Hamil_tapered = qml.taper(Hamil, generators, paulix_ops, eigval_sec)
 
@@ -108,7 +108,7 @@ def energy(
     """Computes the energy at a given bond length (radius)."""
     hamiltonian = hamiltonians[radius_index]
     executor = mitiq.Executor(compute_density_matrix)
-    kwargs = {"noise_model":cirq.depolarize, "noise_level":(depo_noise_strength,)}
+    kwargs = {"noise_model_function":cirq.depolarize, "noise_level":(depo_noise_strength,)}
     expec_val = executor.evaluate(ansatz, hamiltonian, **kwargs)[0]
     return expec_val.real
 ```
@@ -172,7 +172,7 @@ num_to_average = 1
 
 # To reproduce the results of the Mitiq paper use the following settings
 # scaling_function = zne.scaling.fold_gates_at_random
-# pfac = zne.inference.PolyFactory(order=3, 
+# pfac = zne.inference.PolyFactory(order=3,
 #                           scale_factors=[1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5, 5., 5.5, 6.])
 # num_to_average = 5
 # pvals = (0.00, 0.02, 0.04, 0.06)
@@ -197,6 +197,7 @@ for p in pvals[1:]:
 ```
 
 In the next figure we visualize the following results:
+
 1. The ideal noiseless energy landscape $E(\theta, R)$ corresponding to `all_energies[0]`;
 2. The noisy (unmitigated) energies `all_energies`;
 3. The corresponding error-mitigated energies `all_mitigated`.
@@ -291,8 +292,6 @@ for pval in pvals:
 
 The unmitigated potential energy surfaces are now stored in the `best_energies` variable and will be visualized later.
 
-
-
 ### Applying zero-noise extrapolation to estimate $V(R)$
 
 We use zero-noise extrapolation to error-mitigate the potential energy surface $V(R)$.
@@ -331,6 +330,7 @@ for pval in pvals[1:]:
 ```
 
 In the next figure we visualize the following results:
+
 1. The ideal noiseless potential energy surface $V(R)$ corresponding to `best_energies[0]`;
 2. The noisy (unmitigated) potential energy surfaces `best_energies`;
 3. The corresponding error-mitigated potential energy surfaces `best_mitigated_energies`.

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -53,10 +53,8 @@ def generate_rb_circuits(
 
     if n_qubits == 1:
         c1 = cliffords.c1_in_xy
-        cfd_mat_1q = cast(
-            npt.NDArray[np.complex64],
-            [_gate_seq_to_mats(gates) for gates in c1],
-        )
+        cfd_mat_1q = np.array([_gate_seq_to_mats(gates) for gates in c1])
+
         circuits = [
             _random_single_q_clifford(qubits[0], num_cliffords, c1, cfd_mat_1q)
             for _ in range(trials)

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -4,10 +4,9 @@
 # LICENSE file in the root directory of this source tree.
 
 """Functions for generating randomized benchmarking circuits."""
-from typing import List, Optional, cast
+from typing import List, Optional
 
 import numpy as np
-import numpy.typing as npt
 
 from cirq.experiments.qubit_characterizations import (
     _single_qubit_cliffords,

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -52,7 +52,9 @@ def generate_rb_circuits(
 
     if n_qubits == 1:
         c1 = cliffords.c1_in_xy
-        cfd_mat_1q = np.array([_gate_seq_to_mats(gates) for gates in c1])
+        cfd_mat_1q = np.array(
+            [_gate_seq_to_mats(gates) for gates in c1], dtype=np.complex64
+        )
 
         circuits = [
             _random_single_q_clifford(qubits[0], num_cliffords, c1, cfd_mat_1q)

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -193,7 +193,7 @@ class Strategy:
         if self.technique is MitigationTechnique.ZNE:
             inference_func = self.technique_params["factory"]
             summary["factory"] = inference_func.__class__.__name__
-            summary["scale_factors"] = inference_func.get_scale_factors()
+            summary["scale_factors"] = inference_func._scale_factors
             summary["scale_method"] = self.technique_params[
                 "scale_noise"
             ].__name__

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -193,7 +193,7 @@ class Strategy:
         if self.technique is MitigationTechnique.ZNE:
             inference_func = self.technique_params["factory"]
             summary["factory"] = inference_func.__class__.__name__
-            summary["scale_factors"] = inference_func._scale_factors
+            summary["scale_factors"] = inference_func.get_scale_factors()
             summary["scale_method"] = self.technique_params[
                 "scale_noise"
             ].__name__

--- a/mitiq/cdr/clifford_training_data.py
+++ b/mitiq/cdr/clifford_training_data.py
@@ -135,7 +135,7 @@ def _map_to_near_clifford(
     )
 
     # Replace selected operations.
-    clifford_ops: Sequence[cirq.ops.Operation] = _replace(
+    clifford_ops = _replace(
         [non_clifford_ops[i] for i in indices_of_selected_ops],
         method_replace,
         sigma_replace,
@@ -144,9 +144,7 @@ def _map_to_near_clifford(
 
     # Return sequence of (near) Clifford operations.
     return [
-        cast(List[cirq.ops.Operation], clifford_ops).pop(0)
-        if i in indices_of_selected_ops
-        else op
+        clifford_ops.pop(0) if i in indices_of_selected_ops else op
         for (i, op) in enumerate(non_clifford_ops)
     ]
 
@@ -209,7 +207,7 @@ def _replace(
     method: str = "uniform",
     sigma: float = 1.0,
     random_state: Optional[np.random.RandomState] = None,
-) -> Sequence[cirq.ops.Operation]:
+) -> List[cirq.ops.Operation]:
     """Function that takes the non-Clifford angles and replacement and
     selection specifications, returning the projected angles according to a
     specific method.

--- a/mitiq/cdr/clifford_training_data.py
+++ b/mitiq/cdr/clifford_training_data.py
@@ -169,7 +169,8 @@ def _select(
                       method_select = 'gaussian'.
         random_state: Random state for sampling.
     """
-    random_state = random_state or np.random.RandomState()
+    if random_state is None:
+        random_state = np.random  # type: ignore
 
     num_non_cliff = len(non_clifford_ops)
     num_to_replace = int(round(fraction_non_clifford * num_non_cliff))
@@ -193,7 +194,7 @@ def _select(
         )
 
     # Select (indices of) non-Clifford operations to replace.
-    selected_indices = random_state.choice(
+    selected_indices = cast(np.random.RandomState, random_state).choice(
         range(num_non_cliff),
         num_non_cliff - num_to_replace,
         replace=False,
@@ -229,7 +230,8 @@ def _replace(
         Exception: If argument 'method_replace' is not either 'closest',
         'uniform' or 'gaussian'.
     """
-    random_state = random_state or np.random.RandomState()
+    if random_state is None:
+        random_state = np.random  # type: ignore
 
     # TODO: Update these functions to act on operations instead of angles.
     non_clifford_angles = np.array(
@@ -240,7 +242,7 @@ def _replace(
 
     elif method == "uniform":
         clifford_angles = random_clifford(
-            len(non_clifford_angles), random_state
+            len(non_clifford_angles), cast(np.random.RandomState, random_state)
         )
 
     elif method == "gaussian":

--- a/mitiq/cdr/clifford_training_data.py
+++ b/mitiq/cdr/clifford_training_data.py
@@ -171,8 +171,7 @@ def _select(
                       method_select = 'gaussian'.
         random_state: Random state for sampling.
     """
-    if random_state is None:
-        random_state = np.random  # type: ignore
+    random_state = random_state or np.random.RandomState()
 
     num_non_cliff = len(non_clifford_ops)
     num_to_replace = int(round(fraction_non_clifford * num_non_cliff))
@@ -196,7 +195,7 @@ def _select(
         )
 
     # Select (indices of) non-Clifford operations to replace.
-    selected_indices = cast(np.random.RandomState, random_state).choice(
+    selected_indices = random_state.choice(
         range(num_non_cliff),
         num_non_cliff - num_to_replace,
         replace=False,
@@ -232,8 +231,7 @@ def _replace(
         Exception: If argument 'method_replace' is not either 'closest',
         'uniform' or 'gaussian'.
     """
-    if random_state is None:
-        random_state = np.random  # type: ignore
+    random_state = random_state or np.random.RandomState()
 
     # TODO: Update these functions to act on operations instead of angles.
     non_clifford_angles = np.array(
@@ -244,7 +242,7 @@ def _replace(
 
     elif method == "uniform":
         clifford_angles = random_clifford(
-            len(non_clifford_angles), cast(np.random.RandomState, random_state)
+            len(non_clifford_angles), random_state
         )
 
     elif method == "gaussian":

--- a/mitiq/ddd/tests/test_ddd.py
+++ b/mitiq/ddd/tests/test_ddd.py
@@ -43,7 +43,7 @@ circuit_cirq_b += cirq.inverse(circuit_cirq_b)
 def amp_damp_executor(circuit: QPROGRAM, noise: float = 0.005) -> float:
     circuit, _ = convert_to_mitiq(circuit)
     return compute_density_matrix(
-        circuit, noise_model=cirq.amplitude_damp, noise_level=(noise,)
+        circuit, noise_model_function=cirq.amplitude_damp, noise_level=(noise,)
     )[0, 0].real
 
 

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -209,7 +209,7 @@ class Executor:
                 f" {self._executor_return_type}."
             )
 
-        return results  # type: ignore[return-value]
+        return results
 
     def run(
         self,
@@ -289,7 +289,7 @@ class Executor:
         Args:
             to_run: Circuit(s) to run.
         """
-        result = self._executor(to_run, **kwargs)  # type: ignore
+        result = self._executor(to_run, **kwargs)
         self._calls_to_executor += 1
 
         if self.can_batch:

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -5,7 +5,7 @@
 
 """Functions for converting to/from Mitiq's internal circuit representation."""
 from functools import wraps
-from typing import Any, Callable, cast, Iterable, Tuple, Dict
+from typing import Any, Callable, Dict, Iterable, Tuple, cast
 
 from cirq import Circuit
 
@@ -272,10 +272,11 @@ def noise_scaling_converter(
     ) -> QPROGRAM:
         # Pre atomic conversion
         if "qiskit" in circuit.__module__:
+            from qiskit.transpiler.passes import RemoveBarriers
+
             from mitiq.interface.mitiq_qiskit.conversions import (
                 _add_identity_to_idle,
             )
-            from qiskit.transpiler.passes import RemoveBarriers
 
             # Avoid mutating the input circuit
             circuit = circuit.copy()
@@ -328,9 +329,9 @@ def noise_scaling_converter(
         # Qiskit: Keep the same register structure and measurement order.
         if "qiskit" in scaled_circuit.__module__:
             from mitiq.interface.mitiq_qiskit.conversions import (
-                _transform_registers,
                 _measurement_order,
                 _remove_identity_from_idle,
+                _transform_registers,
             )
 
             scaled_circuit.remove_final_measurements()

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -295,8 +295,6 @@ def noise_scaling_converter(
             from pyquil import Program
             from pyquil.quilbase import Declare, Measurement
 
-            circuit = cast(Program, circuit)
-
             # Grab all measurements from the input circuit.
             measurements = [
                 instr

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -296,6 +296,8 @@ def noise_scaling_converter(
             from pyquil import Program
             from pyquil.quilbase import Declare, Measurement
 
+            circuit = cast(Program, circuit)
+
             # Grab all measurements from the input circuit.
             measurements = [
                 instr

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -195,9 +195,7 @@ def accept_any_qprogram_as_input(
         circuit: QPROGRAM, *args: Any, **kwargs: Any
     ) -> Any:
         cirq_circuit, _ = convert_to_mitiq(circuit)
-        return accept_cirq_circuit_function(  # type: ignore
-            cirq_circuit, *args, **kwargs
-        )
+        return accept_cirq_circuit_function(cirq_circuit, *args, **kwargs)
 
     return accept_any_qprogram_function
 
@@ -272,7 +270,6 @@ def noise_scaling_converter(
     def new_scaling_function(
         circuit: QPROGRAM, *args: Any, **kwargs: Any
     ) -> QPROGRAM:
-
         # Pre atomic conversion
         if "qiskit" in circuit.__module__:
             from mitiq.interface.mitiq_qiskit.conversions import (
@@ -339,13 +336,10 @@ def noise_scaling_converter(
             )
 
             scaled_circuit.remove_final_measurements()
-            _transform_registers(
-                scaled_circuit,
-                new_qregs=circuit.qregs,  # type: ignore
-            )
+            _transform_registers(scaled_circuit, new_qregs=circuit.qregs)
             _remove_identity_from_idle(scaled_circuit, idle_qubits)
-            if circuit.cregs and not scaled_circuit.cregs:  # type: ignore
-                scaled_circuit.add_register(*circuit.cregs)  # type: ignore
+            if circuit.cregs and not scaled_circuit.cregs:
+                scaled_circuit.add_register(*circuit.cregs)
 
             for q, c in _measurement_order(circuit):
                 scaled_circuit.measure(q, c)

--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -86,7 +86,7 @@ def execute_with_depolarizing_noise(
     Returns:
         The expectation value of obs as a float.
     """
-    circuit = circuit.with_noise(cirq.depolarize(p=noise))  # type: ignore
+    circuit = circuit.with_noise(cirq.depolarize(p=noise))
     simulator = cirq.DensityMatrixSimulator()
     rho = simulator.simulate(circuit).final_density_matrix
     expectation = np.real(np.trace(rho @ obs))

--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 """Cirq utility functions."""
 
-from typing import Tuple
+from typing import Tuple, Callable
 
 import numpy as np
 import numpy.typing as npt
@@ -15,7 +15,9 @@ from mitiq import MeasurementResult
 # Executors.
 def sample_bitstrings(
     circuit: cirq.Circuit,
-    noise_model: cirq.NOISE_MODEL_LIKE = cirq.amplitude_damp,  # type: ignore
+    noise_model_function: Callable[
+        ..., cirq.NOISE_MODEL_LIKE
+    ] = cirq.amplitude_damp,
     noise_level: Tuple[float] = (0.01,),
     sampler: cirq.Sampler = cirq.DensityMatrixSimulator(),
     shots: int = 8192,
@@ -34,7 +36,7 @@ def sample_bitstrings(
         Sampled outcome from a measurement.
     """
     if sum(noise_level) > 0:
-        circuit = circuit.with_noise(noise_model(*noise_level))  # type: ignore
+        circuit = circuit.with_noise(noise_model_function(*noise_level))
 
     result = sampler.run(circuit, repetitions=shots)
     return MeasurementResult(
@@ -50,7 +52,9 @@ def sample_bitstrings(
 
 def compute_density_matrix(
     circuit: cirq.Circuit,
-    noise_model: cirq.NOISE_MODEL_LIKE = cirq.amplitude_damp,  # type: ignore
+    noise_model_function: Callable[
+        ..., cirq.NOISE_MODEL_LIKE
+    ] = cirq.amplitude_damp,
     noise_level: Tuple[float] = (0.01,),
 ) -> npt.NDArray[np.complex64]:
     """Returns the density matrix of the quantum state after the
@@ -65,7 +69,7 @@ def compute_density_matrix(
         The final density matrix as a NumPy array.
     """
     if sum(noise_level) > 0:
-        circuit = circuit.with_noise(noise_model(*noise_level))  # type: ignore
+        circuit = circuit.with_noise(noise_model_function(*noise_level))
 
     return cirq.DensityMatrixSimulator().simulate(circuit).final_density_matrix
 

--- a/mitiq/interface/mitiq_pyquil/compiler.py
+++ b/mitiq/interface/mitiq_pyquil/compiler.py
@@ -207,14 +207,14 @@ def _Z(q: QubitLike) -> Program:
     return p
 
 
-def is_magic_angle(angle: AngleLike) -> bool:
+def is_magic_angle(angle: complex) -> bool:
     """
     Checks to see if an angle is 0, +/-pi/2, or +/-pi.
     """
     return bool(
-        np.isclose(np.abs(cast(float, angle)), pi / 2)
-        or np.isclose(np.abs(cast(float, angle)), pi)
-        or np.isclose(cast(float, angle), 0.0)
+        np.isclose(np.abs(angle), pi / 2)
+        or np.isclose(np.abs(angle), pi)
+        or np.isclose(angle, 0.0)
     )
 
 
@@ -257,8 +257,8 @@ def basic_compile(program: Program) -> Program:
                 angle_param = inst.params[0]
                 new_prog += _PHASE(angle_param, inst.qubits[0])
             elif inst.name == "RX":
-                angle_param = inst.params[0]
-                if is_magic_angle(inst.params[0]):
+                angle_param = cast(complex, inst.params[0])
+                if is_magic_angle(angle_param):
                     # in case dagger
                     new_prog += RX(angle_param, inst.qubits[0])
                 else:

--- a/mitiq/interface/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/qiskit_utils.py
@@ -184,7 +184,7 @@ def execute_with_shots_and_noise(
 def sample_bitstrings(
     circuit: QuantumCircuit,
     backend: Optional[Backend] = None,
-    noise_model: Optional[NoiseModel] = None,  # type: ignore
+    noise_model: Optional[NoiseModel] = None,
     shots: int = 10000,
     measure_all: bool = False,
     qubit_indices: Optional[Tuple[int]] = None,
@@ -250,7 +250,7 @@ def compute_expectation_value_on_noisy_backend(
     circuit: QuantumCircuit,
     obs: Observable,
     backend: Optional[Backend] = None,
-    noise_model: Optional[NoiseModel] = None,  # type: ignore
+    noise_model: Optional[NoiseModel] = None,
     shots: int = 10000,
     measure_all: bool = False,
     qubit_indices: Optional[Tuple[int]] = None,

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -5,7 +5,6 @@
 
 import copy
 from typing import Callable, cast, List, Optional, Set, Union, Any, Iterable
-import random
 
 import numpy as np
 import numpy.typing as npt
@@ -98,11 +97,11 @@ class Observable:
         return self._ngroups
 
     def partition(self, seed: Optional[int] = None) -> None:
-        rng = random.Random(seed)
+        rng = np.random.RandomState(seed)
 
         psets: List[PauliStringCollection] = []
         paulis = copy.deepcopy(self._paulis)
-        rng.shuffle(paulis)
+        rng.shuffle(paulis)  # type: ignore
 
         while paulis:
             pauli = paulis.pop()

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -5,6 +5,7 @@
 
 import copy
 from typing import Callable, cast, List, Optional, Set, Union, Any, Iterable
+import random
 
 import numpy as np
 import numpy.typing as npt
@@ -97,16 +98,16 @@ class Observable:
         return self._ngroups
 
     def partition(self, seed: Optional[int] = None) -> None:
-        rng = np.random.RandomState(seed)
+        rng = random.Random(seed)
 
         psets: List[PauliStringCollection] = []
         paulis = copy.deepcopy(self._paulis)
-        rng.shuffle(paulis)  # type: ignore
+        rng.shuffle(paulis)
 
         while paulis:
             pauli = paulis.pop()
             added = False
-            for (i, pset) in enumerate(psets):
+            for i, pset in enumerate(psets):
                 if pset.can_add(pauli):
                     pset.add(pauli)
                     added = True

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -88,7 +88,7 @@ class PauliString:
 
     @property
     def coeff(self) -> complex:
-        return self._pauli.coefficient  # type: ignore
+        return cast(complex, self._pauli.coefficient)
 
     def matrix(
         self,

--- a/mitiq/observable/tests/test_observable.py
+++ b/mitiq/observable/tests/test_observable.py
@@ -81,8 +81,8 @@ def test_observable_partition_single_qubit_paulis():
     obs.partition(seed=2)
     expected_groups = [
         PauliStringCollection(x),
-        PauliStringCollection(z),
         PauliStringCollection(y),
+        PauliStringCollection(z),
     ]
     assert obs.groups == expected_groups
 

--- a/mitiq/observable/tests/test_observable.py
+++ b/mitiq/observable/tests/test_observable.py
@@ -81,8 +81,8 @@ def test_observable_partition_single_qubit_paulis():
     obs.partition(seed=2)
     expected_groups = [
         PauliStringCollection(x),
-        PauliStringCollection(y),
         PauliStringCollection(z),
+        PauliStringCollection(y),
     ]
     assert obs.groups == expected_groups
 

--- a/mitiq/pec/channels.py
+++ b/mitiq/pec/channels.py
@@ -74,7 +74,7 @@ def _circuit_to_choi(circuit: Circuit) -> npt.NDArray[np.complex64]:
     full_circ = deepcopy(circuit)[0:0]
     full_circ += _max_ent_state_circuit(2 * num_qubits)
     full_circ += circuit
-    return simulator.simulate(full_circ).final_density_matrix  # type: ignore
+    return simulator.simulate(full_circ).final_density_matrix
 
 
 def _operation_to_choi(operation_tree: OP_TREE) -> npt.NDArray[np.complex64]:

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -136,10 +136,7 @@ def execute_with_pec(
     results = executor.evaluate(sampled_circuits, observable, force_run_all)
 
     # Evaluate unbiased estimators [Temme2017] [Endo2018] [Takagi2020]
-    unbiased_estimators = [
-        norm * s * val  # type: ignore[operator]
-        for s, val in zip(signs, results)
-    ]
+    unbiased_estimators = [norm * s * val for s, val in zip(signs, results)]
 
     pec_value = cast(float, np.average(unbiased_estimators))
 

--- a/mitiq/pec/sampling.py
+++ b/mitiq/pec/sampling.py
@@ -91,9 +91,7 @@ def sample_sequence(
     sequences = []
     signs = []
     for _ in range(num_samples):
-        noisy_op, sign, _ = operation_representation.sample(
-            random_state  # type: ignore
-        )
+        noisy_op, sign, _ = operation_representation.sample(random_state)
         if operation_representation.is_qubit_dependent:
             native_circ = noisy_op.native_circuit
         else:

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -30,7 +30,6 @@ def get_pauli_and_cnot_representations(
     base_noise: float,
     qubits: Optional[List[cirq.Qid]] = None,
 ) -> List[OperationRepresentation]:
-
     if qubits is None:
         qreg = cirq.LineQubit.range(2)
     else:
@@ -66,7 +65,7 @@ def serial_executor(circuit: QPROGRAM, noise: float = BASE_NOISE) -> float:
     """
     circuit, _ = convert_to_mitiq(circuit)
     return compute_density_matrix(
-        circuit, noise_model=cirq.depolarize, noise_level=(noise,)
+        circuit, noise_model_function=cirq.depolarize, noise_level=(noise,)
     )[0, 0].real
 
 
@@ -278,7 +277,7 @@ def test_execute_with_pec_with_observable():
     obs = Observable(PauliString("ZZ"))
     executor = partial(
         mitiq_cirq.compute_density_matrix,
-        noise_model=cirq.depolarize,
+        noise_model_function=cirq.depolarize,
         noise_level=(BASE_NOISE,),
     )
     true_value = 1.0
@@ -305,7 +304,7 @@ def test_execute_with_pec_partial_representations():
         twoq_circ,
         executor=partial(
             mitiq_cirq.compute_density_matrix,
-            noise_model=cirq.depolarize,
+            noise_model_function=cirq.depolarize,
             noise_level=(BASE_NOISE,),
         ),
         observable=Observable(PauliString("ZZ")),
@@ -626,7 +625,6 @@ def test_doc_is_preserved():
 
 @pytest.mark.parametrize("circuit_type", SUPPORTED_PROGRAM_TYPES.keys())
 def test_executed_circuits_have_the_expected_type(circuit_type):
-
     circuit = convert_from_mitiq(oneq_circ, circuit_type)
     circuit_type = type(circuit)
 

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -326,6 +326,12 @@ def test_representation_sample_seed():
         assert np.isclose(coeff1, coeff2)
 
 
+def test_representation_sample_bad_seed_type():
+    _, _, _, decomp = get_test_representation()
+    with pytest.raises(TypeError, match="should be of type"):
+        decomp.sample(random_state=7)
+
+
 def test_representation_sample_zero_coefficient():
     ideal = cirq.Circuit(cirq.H(cirq.LineQubit(0)))
 

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -329,7 +329,7 @@ def test_representation_sample_seed():
 def test_representation_sample_bad_seed_type():
     _, _, _, decomp = get_test_representation()
     with pytest.raises(TypeError, match="should be of type"):
-        decomp.sample(random_state=7)
+        decomp.sample(random_state="8")
 
 
 def test_representation_sample_zero_coefficient():

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -326,12 +326,6 @@ def test_representation_sample_seed():
         assert np.isclose(coeff1, coeff2)
 
 
-def test_representation_sample_bad_seed_type():
-    _, _, _, decomp = get_test_representation()
-    with pytest.raises(TypeError, match="should be of type"):
-        decomp.sample(random_state=7)
-
-
 def test_representation_sample_zero_coefficient():
     ideal = cirq.Circuit(cirq.H(cirq.LineQubit(0)))
 

--- a/mitiq/pec/types/types.py
+++ b/mitiq/pec/types/types.py
@@ -233,11 +233,19 @@ class OperationRepresentation:
         Args:
             random_state: Defines the seed for sampling if provided.
         """
+        if not random_state:
+            rng = np.random
+        elif isinstance(random_state, int):
+            rng = np.random.RandomState(random_state)  # type: ignore
+        elif isinstance(random_state, np.random.RandomState):
+            rng = random_state  # type: ignore
+        else:
+            raise TypeError(
+                "Arg `random_state` should be of type `np.random.RandomState` "
+                f"or `int`, but was {type(random_state)}."
+            )
 
-        if random_state is None or isinstance(random_state, int):
-            random_state = np.random.RandomState(random_state)
-
-        idx = random_state.choice(len(self.coeffs), p=self.distribution)
+        idx = rng.choice(len(self.coeffs), p=self.distribution)
         coeff, noisy_op = self.basis_expansion[idx]
         return noisy_op, int(np.sign(coeff)), coeff
 

--- a/mitiq/pec/types/types.py
+++ b/mitiq/pec/types/types.py
@@ -5,7 +5,7 @@
 
 """Types used in probabilistic error cancellation."""
 from copy import deepcopy
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Union
 import warnings
 
 import numpy as np
@@ -126,7 +126,6 @@ class NoisyBasis:
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-
         raise NotImplementedError(
             "The NoisyBasis class has been removed since Mitiq v0.24.0."
             " Please replace it with a list of NoisyOperation objects."
@@ -227,24 +226,18 @@ class OperationRepresentation:
         return self._distribution
 
     def sample(
-        self, random_state: Optional[np.random.RandomState] = None
+        self, random_state: Optional[Union[int, np.random.RandomState]] = None
     ) -> Tuple[NoisyOperation, int, float]:
         """Returns a randomly sampled NoisyOperation from the basis expansion.
 
         Args:
             random_state: Defines the seed for sampling if provided.
         """
-        if not random_state:
-            rng = np.random
-        elif isinstance(random_state, np.random.RandomState):
-            rng = random_state  # type: ignore
-        else:
-            raise TypeError(
-                "Arg `random_state` should be of type `np.random.RandomState` "
-                f"but was {type(random_state)}."
-            )
 
-        idx = rng.choice(len(self.coeffs), p=self.distribution)
+        if random_state is None or isinstance(random_state, int):
+            random_state = np.random.RandomState(random_state)
+
+        idx = random_state.choice(len(self.coeffs), p=self.distribution)
         coeff, noisy_op = self.basis_expansion[idx]
         return noisy_op, int(np.sign(coeff)), coeff
 

--- a/mitiq/pt/tests/test_pt.py
+++ b/mitiq/pt/tests/test_pt.py
@@ -29,7 +29,7 @@ circuit.append(cirq.CZ(*qubits))
 
 def amp_damp_executor(circuit: cirq.Circuit, noise: float = 0.005) -> float:
     return compute_density_matrix(
-        circuit, noise_model=cirq.amplitude_damp, noise_level=(noise,)
+        circuit, noise_model_function=cirq.amplitude_damp, noise_level=(noise,)
     )[0, 0].real
 
 

--- a/mitiq/qse/tests/test_qse.py
+++ b/mitiq/qse/tests/test_qse.py
@@ -26,7 +26,7 @@ from mitiq.interface.mitiq_cirq import compute_density_matrix
 def execute_with_depolarized_noise(circuit: QPROGRAM) -> np.ndarray:
     return compute_density_matrix(
         convert_to_mitiq(circuit)[0],
-        noise_model=cirq.depolarize,
+        noise_model_function=cirq.depolarize,
         noise_level=(0.01,),
     )
 
@@ -171,7 +171,7 @@ def test_qse_decorator():
     def decorated_executor(circuit: QPROGRAM) -> np.ndarray:
         return compute_density_matrix(
             convert_to_mitiq(circuit)[0],
-            noise_model=cirq.depolarize,
+            noise_model_function=cirq.depolarize,
             noise_level=(0.01,),
         )
 
@@ -191,7 +191,7 @@ def test_qse_decorator():
     def decorated_executor(circuit: QPROGRAM) -> np.ndarray:
         return compute_density_matrix(
             convert_to_mitiq(circuit)[0],
-            noise_model=cirq.depolarize,
+            noise_model_function=cirq.depolarize,
             noise_level=(0.01,),
         )
 

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -104,7 +104,7 @@ class MeasurementResult:
             self.result: List[List[int]] = list(int_result)
 
         if isinstance(self.result, np.ndarray):
-            self.result = cast(List[Bitstring], self.result.tolist())
+            self.result = self.result.tolist()
 
         self._bitstrings = np.array(self.result)
 

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -14,7 +14,7 @@
        computed. Note this includes expectation values themselves.
 """
 from dataclasses import dataclass
-from typing import cast, List, Optional, Tuple, Union, Sequence, Dict, Any
+from typing import List, Optional, Tuple, Union, Sequence, Dict, Any
 
 import numpy as np
 import numpy.typing as npt

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -222,25 +222,23 @@ class Factory(ABC):
         self._already_reduced = False
         self._options: Dict[str, Optional[float]] = {}
 
-    def get_scale_factors(self) -> npt.NDArray[np.float64]:
+    def get_scale_factors(self) -> List[float]:
         """Returns the scale factors at which the factory has computed
         expectation values.
         """
-        return np.array(
-            [params.get("scale_factor") for params in self._instack]
-        )
+        return [params.get("scale_factor", 0.0) for params in self._instack]
 
-    def get_expectation_values(self) -> npt.NDArray[np.float64]:
+    def get_expectation_values(self) -> List[float]:
         """Returns the expectation values computed by the factory."""
-        return np.array(self._outstack)
+        return self._outstack
 
-    def get_optimal_parameters(self) -> npt.NDArray[np.float64]:
+    def get_optimal_parameters(self) -> List[float]:
         """Returns the optimal model parameters produced by the extrapolation
         fit.
         """
         if self._opt_params is None:
             raise ValueError(DATA_MISSING_ERR)
-        return np.array(self._opt_params)
+        return self._opt_params
 
     def get_parameters_covariance(self) -> npt.NDArray[np.float64]:
         """Returns the covariance matrix of the model parameters produced by
@@ -248,7 +246,7 @@ class Factory(ABC):
         """
         if self._params_cov is None:
             raise ValueError(DATA_MISSING_ERR)
-        return np.array(self._params_cov)
+        return self._params_cov
 
     def get_zero_noise_limit(self) -> float:
         """Returns the last evaluation of the zero-noise limit
@@ -575,7 +573,7 @@ class BatchedFactory(Factory, ABC):
         reshaped = np.array(res).reshape((-1, num_to_average))
 
         # Average the "num_to_average" columns
-        self._outstack = np.average(reshaped, axis=1)
+        self._outstack = np.average(reshaped, axis=1).tolist()
 
         return self
 
@@ -962,7 +960,6 @@ class FakeNodesFactory(BatchedFactory):
         exp_values: Sequence[float],
         full_output: bool = False,
     ) -> ExtrapolationResult:
-
         if not FakeNodesFactory._is_equally_spaced(scale_factors):
             raise ValueError("The scale factors must be equally spaced.")
 
@@ -1595,7 +1592,7 @@ class AdaExpFactory(AdaptiveFactory):
         return len(self._outstack) == self._steps
 
     @staticmethod
-    def extrapolate(  # type: ignore
+    def extrapolate(
         scale_factors: Sequence[float],
         exp_values: Sequence[float],
         asymptote: Optional[float] = None,
@@ -1666,9 +1663,9 @@ class AdaExpFactory(AdaptiveFactory):
             self._opt_params,
             self._params_cov,
             self._zne_curve,
-        ) = self.extrapolate(  # type: ignore
-            cast(Sequence[float], self.get_scale_factors()),
-            cast(Sequence[float], self.get_expectation_values()),
+        ) = self.extrapolate(  # type: ignore [misc]
+            self.get_scale_factors(),
+            self.get_expectation_values(),
             asymptote=self.asymptote,
             avoid_log=self.avoid_log,
             full_output=True,

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -137,7 +137,7 @@ def mitiq_curve_fit(
             # replace OptimizeWarning with ExtrapolationWarning
             if warn.category is OptimizeWarning:
                 warn.category = ExtrapolationWarning
-                warn.message = _EXTR_WARN  # type: ignore
+                warn.message = _EXTR_WARN
             # re-raise all warnings
             warnings.warn_explicit(
                 warn.message, warn.category, warn.filename, warn.lineno
@@ -186,7 +186,7 @@ def mitiq_polyfit(
         # replace RankWarning with ExtrapolationWarning
         if warn.category is RankWarning:
             warn.category = ExtrapolationWarning
-            warn.message = _EXTR_WARN  # type: ignore
+            warn.message = _EXTR_WARN
         # re-raise all warnings
         warnings.warn_explicit(
             warn.message, warn.category, warn.filename, warn.lineno
@@ -816,7 +816,7 @@ class PolyFactory(BatchedFactory):
         self._options = {"order": order}
 
     @staticmethod
-    def extrapolate(  # type: ignore
+    def extrapolate(
         scale_factors: Sequence[float],
         exp_values: Sequence[float],
         order: int,
@@ -889,7 +889,7 @@ class RichardsonFactory(BatchedFactory):
     """
 
     @staticmethod
-    def extrapolate(  # type: ignore
+    def extrapolate(
         scale_factors: Sequence[float],
         exp_values: Sequence[float],
         full_output: bool = False,
@@ -957,7 +957,7 @@ class FakeNodesFactory(BatchedFactory):
     """
 
     @staticmethod
-    def extrapolate(  # type: ignore
+    def extrapolate(
         scale_factors: Sequence[float],
         exp_values: Sequence[float],
         full_output: bool = False,
@@ -1057,7 +1057,7 @@ class LinearFactory(BatchedFactory):
     """
 
     @staticmethod
-    def extrapolate(  # type: ignore
+    def extrapolate(
         scale_factors: Sequence[float],
         exp_values: Sequence[float],
         full_output: bool = False,
@@ -1142,7 +1142,7 @@ class ExpFactory(BatchedFactory):
         }
 
     @staticmethod
-    def extrapolate(  # type: ignore
+    def extrapolate(
         scale_factors: Sequence[float],
         exp_values: Sequence[float],
         asymptote: Optional[float] = None,
@@ -1263,7 +1263,7 @@ class PolyExpFactory(BatchedFactory):
         }
 
     @staticmethod
-    def extrapolate(  # type: ignore
+    def extrapolate(
         scale_factors: Sequence[float],
         exp_values: Sequence[float],
         order: int,
@@ -1448,7 +1448,7 @@ class PolyExpFactory(BatchedFactory):
             scale_factors,
             zstack,
             deg=order,
-            weights=np.sqrt(np.abs(shifted_y)),  # type: ignore
+            weights=np.sqrt(np.abs(shifted_y)),
         )
         # The zero noise limit is ansatz(0)
         zne_limit = asymptote + sign * np.exp(z_coefficients[-1])

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -151,7 +151,7 @@ def test_get_scale_factors_static_factories(factory):
 
     # Compute expectation values at all the scale factors
     fac.run_classical(apply_seed_to_func(f_lin, seed=1))
-    assert isinstance(fac.get_scale_factors(), np.ndarray)
+    assert isinstance(fac.get_scale_factors(), list)
     assert np.allclose(fac.get_scale_factors(), scale_factors)
 
 
@@ -161,26 +161,24 @@ def test_get_scale_factors_adaptive_factories(factory):
     fac = AdaExpFactory(steps=num_steps, scale_factor=2.0, asymptote=None)
 
     # Expectation values haven't been computed at any scale factors yet
-    assert isinstance(fac.get_scale_factors(), np.ndarray)
+    assert isinstance(fac.get_scale_factors(), list)
     assert len(fac.get_scale_factors()) == 0
 
     # Compute expectation values at all the scale factors
     fac.run_classical(apply_seed_to_func(f_exp_up, seed=1))
-    assert isinstance(fac.get_scale_factors(), np.ndarray)
+    assert isinstance(fac.get_scale_factors(), list)
 
     # Given this seeded executor, the scale factors should be as follows
-    correct_scale_factors = np.array(
-        [
-            1.0,
-            2.0,
-            4.0,
-            4.20469548,
-            4.20310693,
-            4.2054822,
-            4.2031916,
-            4.2052843,
-        ]
-    )
+    correct_scale_factors = [
+        1.0,
+        2.0,
+        4.0,
+        4.20469548,
+        4.20310693,
+        4.2054822,
+        4.2031916,
+        4.2052843,
+    ]
     assert len(fac.get_scale_factors()) == num_steps
     assert np.allclose(fac.get_scale_factors(), correct_scale_factors)
 
@@ -199,7 +197,7 @@ def test_get_scale_factors_adaptive_factories(factory):
 def test_get_expectation_values_static_factories(factory):
     scale_factors = np.linspace(1.0, 10.0, num=20)
     executor = apply_seed_to_func(f_lin, seed=1)
-    expectation_values = np.array([executor(scale) for scale in scale_factors])
+    expectation_values = [executor(scale) for scale in scale_factors]
 
     if factory is PolyFactory or factory is PolyExpFactory:
         fac = factory(scale_factors=scale_factors, order=2)
@@ -207,12 +205,12 @@ def test_get_expectation_values_static_factories(factory):
         fac = factory(scale_factors=scale_factors)
 
     # Expectation values haven't been computed at any scale factors yet
-    assert isinstance(fac.get_expectation_values(), np.ndarray)
+    assert isinstance(fac.get_expectation_values(), list)
     assert len(fac.get_expectation_values()) == 0
 
     # Compute expectation values at all the scale factors
     fac.run_classical(executor)
-    assert isinstance(fac.get_expectation_values(), np.ndarray)
+    assert isinstance(fac.get_expectation_values(), list)
     assert np.allclose(
         fac.get_expectation_values(), expectation_values, atol=1e-3
     )
@@ -225,29 +223,27 @@ def test_get_expectation_values_adaptive_factories(factory):
     executor = apply_seed_to_func(f_exp_up, seed=1)
 
     # Expectation values haven't been computed at any scale factors yet
-    assert isinstance(fac.get_expectation_values(), np.ndarray)
+    assert isinstance(fac.get_expectation_values(), list)
     assert len(fac.get_expectation_values()) == 0
 
     # Compute expectation values at all the scale factors
     fac.run_classical(executor)
-    assert isinstance(fac.get_scale_factors(), np.ndarray)
+    assert isinstance(fac.get_scale_factors(), list)
 
     # Given this seeded executor, the scale factors should be as follows
-    correct_scale_factors = np.array(
-        [
-            1.0,
-            2.0,
-            4.0,
-            4.20469548,
-            4.20310693,
-            4.2054822,
-            4.2031916,
-            4.2052843,
-        ]
-    )
-    correct_expectation_values = np.array(
-        [executor(scale) for scale in correct_scale_factors]
-    )
+    correct_scale_factors = [
+        1.0,
+        2.0,
+        4.0,
+        4.20469548,
+        4.20310693,
+        4.2054822,
+        4.2031916,
+        4.2052843,
+    ]
+    correct_expectation_values = [
+        executor(scale) for scale in correct_scale_factors
+    ]
     assert len(fac.get_expectation_values()) == num_steps
     assert np.allclose(
         fac.get_expectation_values(), correct_expectation_values, atol=1e-3
@@ -275,7 +271,7 @@ def test_run_sequential_and_batched(factory, batched):
         fac = factory(scale_factors=scale_factors)
 
     # Expectation values haven't been computed at any scale factors yet
-    assert isinstance(fac.get_expectation_values(), np.ndarray)
+    assert isinstance(fac.get_expectation_values(), list)
     assert len(fac.get_expectation_values()) == 0
 
     # Compute expectation values at all the scale factors
@@ -291,7 +287,7 @@ def test_run_sequential_and_batched(factory, batched):
 
     fac.run(cirq.Circuit(), executor, scale_noise=lambda circ, _: circ)
 
-    assert isinstance(fac.get_expectation_values(), np.ndarray)
+    assert isinstance(fac.get_expectation_values(), list)
     assert np.allclose(
         fac.get_expectation_values(), np.ones_like(scale_factors)
     )

--- a/mitiq/zne/tests/test_zne.py
+++ b/mitiq/zne/tests/test_zne.py
@@ -91,7 +91,9 @@ def test_with_observable_batched_factory(executor):
     noisy_value = observable.expectation(circuit, sample_bitstrings)
     zne_value = execute_with_zne(
         circuit,
-        executor=functools.partial(executor, noise_model=cirq.depolarize),
+        executor=functools.partial(
+            executor, noise_model_function=cirq.depolarize
+        ),
         observable=observable,
         factory=PolyFactory(scale_factors=[1, 3, 5], order=2),
     )
@@ -112,7 +114,9 @@ def test_with_observable_adaptive_factory(executor):
     noisy_value = observable.expectation(circuit, sample_bitstrings)
     zne_value = execute_with_zne(
         circuit,
-        executor=functools.partial(executor, noise_model=cirq.amplitude_damp),
+        executor=functools.partial(
+            executor, noise_model_function=cirq.amplitude_damp
+        ),
         observable=observable,
         factory=AdaExpFactory(steps=4, asymptote=0.5),
     )
@@ -138,7 +142,9 @@ def test_with_observable_two_qubits(executor):
     noisy_value = observable.expectation(circuit, sample_bitstrings)
     zne_value = execute_with_zne(
         circuit,
-        executor=functools.partial(executor, noise_model=cirq.depolarize),
+        executor=functools.partial(
+            executor, noise_model_function=cirq.depolarize
+        ),
         observable=observable,
         factory=PolyFactory(scale_factors=[1, 3, 5], order=2),
     )


### PR DESCRIPTION
## Description

A "quick" pass over all all of our `# type: ignore` comments, as well as `typing.cast` calls. Was able to remove many without any mypy error. It's a good reminder to check when refactoring code.

Things I thought about while making these changes:
1. We should have a consistent style for setting random states/seeds. Often we support `int` or `np.random.RandomState`, in some places and just a `np.random.RandomState` in others. Maybe we allow user facing functions to take both (maybe in addition to [`random.Random`](https://docs.python.org/3/library/random.html#random.Random)?), and then expect a single type once digested from the user.
2. We can definitely do better at type-hinting function arguments more generally, and return types more specifically.
3. If we want to make type changes to `QPROGRAM`/`Executor`, it's going to take some work. Fun work, however :). I played around with making `QPROGRAM` a `typing.TypeVar`, and it broke everything. A lot of things will need to change in conjuction with that, since `QPROGRAM` being a union means mypy's type checks are pretty loose. We'd have to be much more careful in tracking types in our [conversions](https://github.com/unitaryfund/mitiq/blob/ec5d2584e5d9bd193c4ca9bd7322272b47100e84/mitiq/interface/conversions.py) files.

### Reviewer Note

It's probably easiest to review this commit by commit since some changes modify multiple files.