### PR TITLE
clean up sidebar

### DIFF
--- a/docs/source/examples/learning-depolarizing-noise.md
+++ b/docs/source/examples/learning-depolarizing-noise.md
@@ -17,7 +17,7 @@ In this example, we demonstrate the workflow of learning quasiprobability repres
 from Clifford circuit data.
 The depolarizing noise model is parameterized by the noise strength, `epsilon`.
 The resulting quasiprobability representations of the `CNOT` gate are then used to obtain an error-mitigated expectation value with Mitiq's
-{ref}`probabilistic error cancellation module <guide/pec/pec>`. 
+{ref}`probabilistic error cancellation module <guide/pec>`.
 For a more in-depth description of the learning function used in this example, see the section on {func}`.learn_depolarizing_noise_parameter`
 in the API-doc.
 The learning-based PEC workflow was inspired by the procedure described in *Strikis et al. PRX Quantum (2021)* {cite}`Strikis_2021_PRXQuantum`.
@@ -46,7 +46,7 @@ from mitiq.pec.representations.learning import (
 ```
 
 Since the learning-based workflow uses the function {func}`.cdr.clifford_training_data.generate_training_circuits` from Mitiq's {ref}`Clifford data regression module
-<guide/cdr/cdr>` to generate the near-Clifford training circuits, the input circuit must be one that is compiled into the Rx-Rz-CNOT gateset. 
+<guide/cdr>` to generate the near-Clifford training circuits, the input circuit must be one that is compiled into the Rx-Rz-CNOT gateset.
 Here we use a simple Rx-Rz-CNOT circuit, with an (optional) seed for reproducibility.
 
 ```{code-cell} ipython3
@@ -56,7 +56,7 @@ circuit = random_x_z_cnot_circuit(
 print(circuit)
 ```
 
-Define the ideal executor function for simulating the Clifford training circuits without noise. 
+Define the ideal executor function for simulating the Clifford training circuits without noise.
 This will be used for comparison to the error-mitigated expectation values in the learning function, and for a final comparison with the
 mitigated and unmitigated values at the end of the workflow.
 
@@ -69,7 +69,7 @@ def ideal_execute(circ: Circuit) -> np.ndarray:
 ideal_executor = Executor(ideal_execute)
 ```
 
-Define the noisy executor, in this case for simulating depolarizing noise on the `CNOT` gate in each of the training circuits. 
+Define the noisy executor, in this case for simulating depolarizing noise on the `CNOT` gate in each of the training circuits.
 The optimized value of the noise strength `epsilon` should be close to the value defined for this executor.
 
 ```{code-cell} ipython3
@@ -86,7 +86,7 @@ def noisy_execute(circ: Circuit) -> np.ndarray:
         index = op[0] + 1
         qubits = op[1].qubits
         for q in qubits:
-            insertions.append((index, DepolarizingChannel(epsilon)(q))) 
+            insertions.append((index, DepolarizingChannel(epsilon)(q)))
     noisy_circ.batch_insert(insertions)
 
     return ideal_execute(noisy_circ)
@@ -96,8 +96,8 @@ noisy_executor = Executor(noisy_execute)
 ```
 
 Before calling the optimizer, let's plot the loss function that will be minimized in the learning routine, over a small range of noise strength values.
-The loss function calls {func}`.pec.execute_with_pec`, and we can optionally pass keyword arguments to set the number of PEC samples, among other options. 
-Here we set a relatively small value of `num_samples` to obtain a reasonable execution time. 
+The loss function calls {func}`.pec.execute_with_pec`, and we can optionally pass keyword arguments to set the number of PEC samples, among other options.
+Here we set a relatively small value of `num_samples` to obtain a reasonable execution time.
 However, we avoid using a number of PEC samples that is too small, as it can result in a large statistical error and ultimately cause the optimization process to fail.
 
 ```{code-cell} ipython3
@@ -151,7 +151,6 @@ name: depolarizing_noise_loss_function
 The figure is a plot of the loss function for optimizing quasi-probability representations assuming a depolarizing noise model depending on
 one real parameter.
 ```
-
 
 Now we set the initial conditions for the optimization. For purposes of this demonstration, our initial guess for epsilon, `epsilon0`, is
 slightly offset from the true value of `epsilon`.

--- a/docs/source/examples/learning-depolarizing-noise.md
+++ b/docs/source/examples/learning-depolarizing-noise.md
@@ -17,7 +17,7 @@ In this example, we demonstrate the workflow of learning quasiprobability repres
 from Clifford circuit data.
 The depolarizing noise model is parameterized by the noise strength, `epsilon`.
 The resulting quasiprobability representations of the `CNOT` gate are then used to obtain an error-mitigated expectation value with Mitiq's
-{ref}`probabilistic error cancellation module <guide/pec>`.
+[probabilistic error cancellation module](../guide/pec.md).
 For a more in-depth description of the learning function used in this example, see the section on {func}`.learn_depolarizing_noise_parameter`
 in the API-doc.
 The learning-based PEC workflow was inspired by the procedure described in *Strikis et al. PRX Quantum (2021)* {cite}`Strikis_2021_PRXQuantum`.
@@ -45,8 +45,7 @@ from mitiq.pec.representations.learning import (
 )
 ```
 
-Since the learning-based workflow uses the function {func}`.cdr.clifford_training_data.generate_training_circuits` from Mitiq's {ref}`Clifford data regression module
-<guide/cdr>` to generate the near-Clifford training circuits, the input circuit must be one that is compiled into the Rx-Rz-CNOT gateset.
+Since the learning-based workflow uses the function {func}`.cdr.clifford_training_data.generate_training_circuits` from Mitiq's [Clifford data regression module](../guide/cdr.md) to generate the near-Clifford training circuits, the input circuit must be one that is compiled into the Rx-Rz-CNOT gateset.
 Here we use a simple Rx-Rz-CNOT circuit, with an (optional) seed for reproducibility.
 
 ```{code-cell} ipython3

--- a/docs/source/guide/cdr.md
+++ b/docs/source/guide/cdr.md
@@ -1,8 +1,6 @@
-(guide/cdr/cdr)=
 # Clifford Data Regression
 
 Clifford data regression (CDR) is a learning-based quantum error mitigation technique in which an error mitigation model is trained with quantum circuits that _resemble_ the circuit of interest, but which are easier to classically simulate {cite}`Czarnik_2021_Quantum, Lowe_2021_PRR`.
-
 
 ```{figure} ../img/cdr_workflow2_steps.png
 ---
@@ -13,7 +11,6 @@ The CDR workflow in Mitiq is fully explained in the [What happens when I use CDR
 ```
 
 Below you can find sections of the documentation that address the following questions:
-
 
 ```{toctree}
 ---

--- a/docs/source/guide/ddd.md
+++ b/docs/source/guide/ddd.md
@@ -7,7 +7,6 @@ between the qubits and the environment, mitigating the effects of noise.
 For more discussion of the theory of DDD, see the section [What is the theory
 behind DDD?](ddd-5-theory.md).
 
-
 ```{figure} ../img/ddd_workflow.svg
 ---
 width: 700px
@@ -17,7 +16,6 @@ Workflow of the DDD technique in Mitiq, detailed in the [What happens when I use
 ```
 
 Below you can find sections of the documentation that address the following questions:
-
 
 ```{toctree}
 ---

--- a/docs/source/guide/glossary.md
+++ b/docs/source/guide/glossary.md
@@ -12,6 +12,7 @@ kernelspec:
 ---
 
 # Glossary
+
 [Calibration](calibrators.md)
 : The process of choosing
 the optimal QEM method and/or the optimal parameter settings of a method for a user's specific situation
@@ -21,38 +22,38 @@ tuning a physical device so that it better approximates some ideal property or o
 
 Expectation Value
 : The expectation value of an observable $A$ on state $\rho$ is the average
-readout value when $A$ is measured on $\rho$. Mathematically, this is $\text{Tr}[A\rho]$ and usually denoted $\langle A \rangle$ (when this notation is used, the state $\rho$ that $A$ is being measured on should be clear from context). Expectation values are important 
+readout value when $A$ is measured on $\rho$. Mathematically, this is $\text{Tr}[A\rho]$ and usually denoted $\langle A \rangle$ (when this notation is used, the state $\rho$ that $A$ is being measured on should be clear from context). Expectation values are important
 for near-term quantum computing because in variational quantum algorithms,
 the only role of the quantum processor is to repeatedly compute expectation values, which a classical processor then uses to perform some overall useful computational task. In Mitiq, [Executors](executors.md) are used to calculate error-mitigated expectation values.
 
 Gate Fidelity
-: A number between 0 and 1 measuring how 
+: A number between 0 and 1 measuring how
 closely a particular device's (noisy) physical implementation of a gate approximates the ideal gate's action on quantum states. Mitiq implements a noise-scaling method for ZNE in which each gate of the input circuit is sampled for [unitary folding](./zne-3-options.md#unitary-folding) with probability proportional to its infidelity (1 - fidelity), described [here](./zne-3-options.md#folding-gates-by-fidelity) and [here](https://mitiq.readthedocs.io/en/stable/apidoc.html#mitiq.zne.scaling.folding.fold_gates_at_random) in the documentation.
 
 Hamiltonian
 : A Hermitian operator whose eigenvalues and eigenvectors represent, respectively, a quantum system's possible energy levels and corresponding energy states. Most variational quantum algorithms work by encoding the objective of an optimization problem (e.g. finding the maximum cut in a graph) as the task of minimizing the expectation value of a problem-specific Hamiltonian, which physically corresponds to finding the ground-state energy of that Hamiltonian. For an example of how error mitigation helps such algorithms, see [Solving MaxCut with Mitiq-improved QAOA](../examples/maxcut-demo.md).
 
 Sampling Overhead
-: The basic resource-cost measure used to evaluate QEM methods---how many more circuit executions ("runs," "shots") does a method need to achieve the same level of statistical precision in estimating an expectation value, compared to 
+: The basic resource-cost measure used to evaluate QEM methods---how many more circuit executions ("runs," "shots") does a method need to achieve the same level of statistical precision in estimating an expectation value, compared to
 the naive (i.e. unmitigated) method of running the same noisy input circuit $N$ times and returning the
 sample mean of the measurement outcomes. Also called sampling cost, it is usually reported as a multiplicative factor $C$, defined as the ratio of the QEM estimator's variance to the sample-mean estimator's variance, and meaning that
-the method needs $C \cdot N$ circuit shots to obtain the same precision as the sample-mean estimator would with only $N$ shots. 
-
+the method needs $C \cdot N$ circuit shots to obtain the same precision as the sample-mean estimator would with only $N$ shots.
 
 ## QEM Methods
+
 [Clifford Data Regression (CDR)](cdr.md)
 : An error mitigation model is
-trained with quantum circuits that resemble the circuit of interest, but which are easier to classically simulate. 
+trained with quantum circuits that resemble the circuit of interest, but which are easier to classically simulate.
 
 [Digital Dynamical Decoupling (DDD)](ddd.md)
 : Sequences of gates are applied to slack windows (single-qubit idle windows) in a quantum circuit to reduce the coupling
-between the qubits and the environment, mitigating the effects of noise. 
+between the qubits and the environment, mitigating the effects of noise.
 
 [Probabilistic Error Cancellation (PEC)](pec.md)
 : Ideal operations are represented as quasi-probability distributions over noisy implementable operations, and unbiased estimates of expectation values are obtained by averaging over circuits sampled according to this representation.
 
 [Readout Error Mitigation (REM)](rem.md)
-: Inverted transition/confusion matrices are applied to noisy measurement results to mitigate errors in the estimation of expectation values.  
+: Inverted transition/confusion matrices are applied to noisy measurement results to mitigate errors in the estimation of expectation values.
 
 [Zero Noise Extrapolation (ZNE)](zne.md)
 : An expectation value is computed at different noise levels and then

--- a/docs/source/guide/pec.md
+++ b/docs/source/guide/pec.md
@@ -1,5 +1,4 @@
-(guide/pec/pec)=
-# Probabilistic error cancellation
+# Probabilistic Error Cancellation
 
 Probabilistic error cancellation (PEC) is an error mitigation technique in which ideal operations are represented as linear combinations of noisy operations. In PEC, unbiased estimates of expectation values are obtained by Monte Carlo averaging over different noisy circuits (see [What is the theory behind PEC?](pec-5-theory.md) for more information on the theory).
 
@@ -23,7 +22,9 @@ pec-3-options.md
 pec-4-low-level.md
 pec-5-theory.md
 ```
+
 Here are some tutorials on how to use PEC in Mitiq:
+
 - [Learning quasiprobability representations with a depolarizing noise model](../examples/learning-depolarizing-noise.md)
 - [Probabilistic error cancellation (PEC) with Mirror Circuits](../examples/pec_tutorial.md)
 

--- a/docs/source/guide/rem.md
+++ b/docs/source/guide/rem.md
@@ -7,7 +7,6 @@ mitigation" or "readout confusion inversion".
 For more discussion of the theory of REM, see the section [What is the theory
 behind REM?](rem-5-theory.md).
 
-
 ```{figure} ../img/rem_workflow.svg
 ---
 width: 700px
@@ -17,7 +16,6 @@ Workflow of the REM technique in Mitiq, detailed in the [What happens when I use
 ```
 
 Below you can find sections of the documentation that address the following questions:
-
 
 ```{toctree}
 ---

--- a/docs/source/guide/zne.md
+++ b/docs/source/guide/zne.md
@@ -1,4 +1,4 @@
-# Zero Noise Extrapolation
+# Zero-Noise Extrapolation
 
 Zero-noise extrapolation (ZNE) is an error mitigation technique in which an expectation
 value is computed at different noise levels and, as a second step, the ideal
@@ -25,7 +25,9 @@ zne-3-options.md
 zne-4-low-level.md
 zne-5-theory.md
 ```
+
 Here are some examples on how to use ZNE in Mitiq:
+
 - [Zero-noise extrapolation with Qiskit on IBMQ backends](../examples/ibmq-backends.md)
 - [Zero-noise extrapolation with Pennylane on IBMQ backends](../examples/pennylane-ibmq-backends.md)
 - [Zero-noise extrapolation with Braket on the IonQ backend](../examples/zne-braket-ionq.md)


### PR DESCRIPTION
## Description

Wanted to make a super small change because I noticed PEC was the only technique that was capitalized differently:
<img width="224" alt="Screenshot 2023-05-08 at 11 02 49 PM" src="https://user-images.githubusercontent.com/12703123/237007779-fbc07996-28b8-4b0e-b1d6-9f00438514e3.png">

Also strip the whitespace at the ends of lines (there's a lot!). I've also removed the anchors at the top of the page, since linking to an anchor at the top of the page is the same as linking to the page, but with more complication.

