### PR TITLE
Improve twirling test

### DIFF
--- a/mitiq/pt/tests/test_pt.py
+++ b/mitiq/pt/tests/test_pt.py
@@ -108,10 +108,12 @@ def test_twirl_CNOT_increases_layer_count():
     )
     num_CNOTS = sum([op.gate == cirq.CNOT for op in circuit.all_operations()])
     twirled = twirl_CNOT_gates(circuit, num_circuits=1)[0]
+    num_gates_before = len(list(circuit.all_operations()))
+    num_gates_after = len(list(twirled.all_operations()))
     if num_CNOTS:
-        assert len(twirled) > len(circuit)
+        assert num_gates_after > num_gates_before
     else:
-        assert len(twirled) == len(circuit)
+        assert num_gates_after == num_gates_before
 
 
 def test_execute_with_pauli_twirling():


### PR DESCRIPTION
This PR makes a twirling test more deterministic.
It should avoid random failures like [this](https://github.com/unitaryfund/mitiq/actions/runs/4958936031/jobs/8872423020#step:5:3813).

Specifically, the new tests compares the number of gates instead of comparing the number of moments.