### PR TITLE
add unitaryHACK banner to docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -311,6 +311,12 @@ html_favicon = "img/mitiq.ico"
 # These files are copied directly to the root of the documentation.
 html_extra_path = ["robots.txt"]
 
+html_theme_options = {
+    "announcement": '<a href="https://unitaryhack.dev/">unitaryHACK</a> is \
+    coming <b>May 26-Jun 13</b>! Get rewarded for contributing to open source \
+    quantum software!'
+}
+
 myst_update_mathjax = False
 
 nbsphinx_custom_formats = {


### PR DESCRIPTION
## Description

Adds a simple banner to the top of all doc pages. Example:
<img width="812" alt="Screenshot 2023-05-15 at 1 00 04 PM" src="https://github.com/unitaryfund/mitiq/assets/12703123/cd9d310e-8229-440e-96f7-a25c7ff24404">

In terms of making this viewable when visiting https://mitiq.readthedocs.io/, we have two options (that I know of)

1. Do a patch release (0.26.1) so that the banner shows up on "stable".
2. Change the default version on RTD to be "latest" (now it's "stable") until the official 0.27.0 release at the start of the hackathon.

I have a preference for 2 as it's much simpler. WDYT?
