### PR TITLE
Mirror Quantum Volume Circuits

### DIFF
--- a/docs/source/apidoc.md
+++ b/docs/source/apidoc.md
@@ -47,6 +47,12 @@
    :members:
 ```
 
+### W State Circuits
+```{eval-rst}
+.. automodule:: mitiq.benchmarks.mirror_qv_circuits.py
+   :members:
+```
+
 ## Circuit types and result types
 
 ```{eval-rst}

--- a/docs/source/apidoc.md
+++ b/docs/source/apidoc.md
@@ -47,9 +47,9 @@
    :members:
 ```
 
-### W State Circuits
+### Mirror Quantum Volume Circuits
 ```{eval-rst}
-.. automodule:: mitiq.benchmarks.mirror_qv_circuits.py
+.. automodule:: mitiq.benchmarks.mirror_qv_circuits
    :members:
 ```
 

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1,6 +1,17 @@
 # Style for keys: Lastname_YYYY_PRL,
 
 # Letter A
+
+@misc{Amico_2023_arxiv,
+  author        = {{Amico}, Mirko and {Zhang}, Helena and {Jurcevic}, Petar and {Bishop}, Lev S. and {Nation}, Paul and {Wack}, Andrew and {McKay}, David C.},
+  title         = {{Defining Standard Strategies for Quantum Benchmarks}},
+  year          = {2023},
+  month         = {mar},
+  archiveprefix = {arXiv},
+  eprint        = {2303.02108},
+  primaryclass  = {quant-ph},
+}
+
 # Letter B
 
 @article{Bonet_2018_PRA,

--- a/mitiq/benchmarks/mirror_quantum_volume_circuits.py
+++ b/mitiq/benchmarks/mirror_quantum_volume_circuits.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2023 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Functions to create a Mirror Quantum Volume Benchmarking circuit
+as defined in https://arxiv.org/abs/2303.02108."""
+
+from mitiq.benchmarks.quantum_volume_circuits import generate_quantum_volume_circuit
+import cirq
+
+def generate_mirror_qv_circuit(
+    num_qubits: int,
+    depth: int,
+    decompose: bool = False,
+    seed: Optional[int] = None,
+    return_type: Optional[str] = None,
+) -> Tuple[QPROGRAM, Sequence[Bitstring]]:
+    """Generate a mirror quantum volume circuit with the given number of qubits and
+    depth.
+
+    The generated circuit consists of a quantum volume circuit upto `depth/2` layers
+    followed by an inverse of the quantum volume portion upto `depth/2`.
+
+    The output bit-string is always supposed to be a string of zeroes. 
+
+    Args:
+        num_qubits: The number of qubits in the generated circuit.
+        depth: The number of layers in the generated circuit.
+        decompose: Recursively decomposes the randomly sampled (numerical)
+            unitary matrix gates into simpler gates.
+        seed: Seed for generating random circuit.
+        return_type: String which specifies the type of the returned
+            circuits. See the keys of ``mitiq.SUPPORTED_PROGRAM_TYPES``
+            for options. If ``None``, the returned circuits have type
+            ``cirq.Circuit``.
+
+    Returns:
+        A quantum volume circuit acting on ``num_qubits`` qubits.
+        A list of the bitstrings for the returned circuit.
+    """
+    first_half_depth = int(depth/2)
+    random_option = random.RandomState(seed)
+
+    circ = cirq.Circuit()
+    qv_half = generate_quantum_volume_circuit(num_qubits, first_half_depth, decompose, random_option)
+    mirror_qv_half = cirq.inverse(qv_half)
+    circ.append(qv_half, mirror_qv_half)
+
+    return(circ)
+
+
+
+

--- a/mitiq/benchmarks/mirror_qv_circuits.py
+++ b/mitiq/benchmarks/mirror_qv_circuits.py
@@ -55,11 +55,11 @@ def generate_mirror_qv_circuit(
         A list of the bitstrings for the returned circuit.
     """
 
-    if depth%2 ==0:
-        first_half_depth = int(depth/2)
+    if depth % 2 == 0:
+        first_half_depth = int(depth / 2)
     else:
-        first_half_depth = int((depth+1)/2)
-    
+        first_half_depth = int((depth + 1) / 2)
+
     qv_generated, _ = generate_quantum_volume_circuit(
         num_qubits, first_half_depth, seed=seed, decompose=decompose
     )

--- a/mitiq/benchmarks/mirror_qv_circuits.py
+++ b/mitiq/benchmarks/mirror_qv_circuits.py
@@ -11,7 +11,7 @@ from typing import Optional, Tuple, Sequence
 
 from mitiq import QPROGRAM
 from mitiq import Bitstring
-from mitiq.interface.conversions import convert_to_mitiq
+from mitiq.interface.conversions import convert_to_mitiq, convert_from_mitiq
 
 
 from mitiq.benchmarks.quantum_volume_circuits import (
@@ -82,4 +82,9 @@ def generate_mirror_qv_circuit(
     simulate_result = cirq.Simulator().run(circ_with_measurements)
     bitstring = list(simulate_result.measurements.values())[0][0].tolist()
 
-    return (circ, bitstring)
+    if decompose:
+        # Decompose random unitary gates into simpler gates.
+        circ = cirq.Circuit(cirq.decompose(circ))
+
+    return_type = "cirq" if not return_type else return_type
+    return convert_from_mitiq(circ, return_type), bitstring

--- a/mitiq/benchmarks/mirror_qv_circuits.py
+++ b/mitiq/benchmarks/mirror_qv_circuits.py
@@ -30,14 +30,14 @@ def generate_mirror_qv_circuit(
     """Generate a mirror quantum volume circuit with the given number of qubits
     and depth as defined in :cite:`Amico_2023_arxiv`.
 
-    The generated circuit consists of a quantum volume circuit upto `depth/2`
-    layers followed by an inverse of the quantum volume portion upto `depth/2`
+    The generated circuit consists of a quantum volume circuit up to `depth/2`
+    layers followed by an inverse of the quantum volume portion up to `depth/2`
     when `depth` is an even number.
 
-    When `depth` is odd, the layers will be chnaged to `depth+1`.
+    When `depth` is odd, the layers will be changed to `depth+1`.
 
 
-    The output bit-string is always supposed to be a string of zeroes.
+    The ideal output bit-string is a string of zeroes.
 
     Args:
         num_qubits: The number of qubits in the generated circuit.

--- a/mitiq/benchmarks/mirror_qv_circuits.py
+++ b/mitiq/benchmarks/mirror_qv_circuits.py
@@ -7,14 +7,17 @@
 as defined in https://arxiv.org/abs/2303.02108."""
 
 from typing import Optional, Tuple, Sequence
-import numpy as np
+
 
 from mitiq import QPROGRAM
 from mitiq import Bitstring
-from mitiq.interface import convert_from_mitiq
 
-from mitiq.benchmarks.quantum_volume_circuits import generate_quantum_volume_circuit
+
+from mitiq.benchmarks.quantum_volume_circuits import (
+    generate_quantum_volume_circuit,
+)
 import cirq
+
 
 def generate_mirror_qv_circuit(
     num_qubits: int,
@@ -23,17 +26,17 @@ def generate_mirror_qv_circuit(
     seed: Optional[int] = None,
     return_type: Optional[str] = None,
 ) -> Tuple[QPROGRAM, Sequence[Bitstring]]:
-    """Generate a mirror quantum volume circuit with the given number of qubits and
-    depth.
+    """Generate a mirror quantum volume circuit with the given number of qubits
+    and depth.
 
-    The generated circuit consists of a quantum volume circuit upto `depth/2` layers
-    followed by an inverse of the quantum volume portion upto `depth/2` when `depth`
-    is an even number. 
-    
+    The generated circuit consists of a quantum volume circuit upto `depth/2`
+    layers followed by an inverse of the quantum volume portion upto `depth/2`
+    when `depth` is an even number.
+
     When `depth` is odd, the layers will be chnaged to `depth+1`.
-    
 
-    The output bit-string is always supposed to be a string of zeroes. 
+
+    The output bit-string is always supposed to be a string of zeroes.
 
     Args:
         num_qubits: The number of qubits in the generated circuit.
@@ -50,19 +53,18 @@ def generate_mirror_qv_circuit(
         A quantum volume circuit acting on ``num_qubits`` qubits.
         A list of the bitstrings for the returned circuit.
     """
-    
-    first_half_depth = depth
-    
-    qv_half_circ, _ = generate_quantum_volume_circuit(num_qubits, first_half_depth, seed=seed, decompose=decompose)
-    mirror_half_circ = cirq.inverse(half_circ)
-    circ = qv_half_circ + mirror_half_circ
-    circ_with_mes = circ + cirq.measure(circ.all_qubits())
 
-    
+    first_half_depth = depth
+
+    qv_half_circ, _ = generate_quantum_volume_circuit(
+        num_qubits, first_half_depth, seed=seed, decompose=decompose
+    )
+    mirror_half_circ = cirq.inverse(qv_half_circ)
+    circ = qv_half_circ + mirror_half_circ
+
     # get the bitstring
     circ_with_measurements = circ + cirq.measure(circ.all_qubits())
     simulate_result = cirq.Simulator().run(circ_with_measurements)
     bitstring = list(simulate_result.measurements.values())[0][0].tolist()
-    
 
-    return(circ, bitstring)
+    return (circ, bitstring)

--- a/mitiq/benchmarks/mirror_qv_circuits.py
+++ b/mitiq/benchmarks/mirror_qv_circuits.py
@@ -54,7 +54,11 @@ def generate_mirror_qv_circuit(
         A list of the bitstrings for the returned circuit.
     """
 
-    first_half_depth = depth
+    if depth%2 ==0:
+        first_half_depth = int(depth/2)
+    else:
+        first_half_depth = int((depth+1)/2)
+    
 
     qv_half_circ, _ = generate_quantum_volume_circuit(
         num_qubits, first_half_depth, seed=seed, decompose=decompose

--- a/mitiq/benchmarks/mirror_qv_circuits.py
+++ b/mitiq/benchmarks/mirror_qv_circuits.py
@@ -6,11 +6,10 @@
 """Functions to create a Mirror Quantum Volume Benchmarking circuit
 as defined in https://arxiv.org/abs/2303.02108."""
 
-from typing import Optional, Tuple, Sequence
+from typing import Optional
 
 
 from mitiq import QPROGRAM
-from mitiq import Bitstring
 from mitiq.interface.conversions import convert_to_mitiq, convert_from_mitiq
 
 
@@ -26,7 +25,7 @@ def generate_mirror_qv_circuit(
     decompose: bool = False,
     seed: Optional[int] = None,
     return_type: Optional[str] = None,
-) -> Tuple[QPROGRAM, Sequence[Bitstring]]:
+) -> QPROGRAM:
     """Generate a mirror quantum volume circuit with the given number of qubits
     and depth as defined in :cite:`Amico_2023_arxiv`.
 
@@ -77,14 +76,9 @@ def generate_mirror_qv_circuit(
 
     circ = qv_half_circ + mirror_half_circ
 
-    # get the bitstring
-    circ_with_measurements = circ + cirq.measure(circ.all_qubits())
-    simulate_result = cirq.Simulator().run(circ_with_measurements)
-    bitstring = list(simulate_result.measurements.values())[0][0].tolist()
-
     if decompose:
         # Decompose random unitary gates into simpler gates.
         circ = cirq.Circuit(cirq.decompose(circ))
 
     return_type = "cirq" if not return_type else return_type
-    return convert_from_mitiq(circ, return_type), bitstring
+    return convert_from_mitiq(circ, return_type)

--- a/mitiq/benchmarks/mirror_qv_circuits.py
+++ b/mitiq/benchmarks/mirror_qv_circuits.py
@@ -51,7 +51,6 @@ def generate_mirror_qv_circuit(
 
     Returns:
         A quantum volume circuit acting on ``num_qubits`` qubits.
-        A list of the bitstrings for the returned circuit.
     """
     if depth <= 0:
         raise ValueError(

--- a/mitiq/benchmarks/mirror_qv_circuits.py
+++ b/mitiq/benchmarks/mirror_qv_circuits.py
@@ -28,7 +28,7 @@ def generate_mirror_qv_circuit(
     return_type: Optional[str] = None,
 ) -> Tuple[QPROGRAM, Sequence[Bitstring]]:
     """Generate a mirror quantum volume circuit with the given number of qubits
-    and depth.
+    and depth as defined in :cite:`Amico_2023_arxiv`.
 
     The generated circuit consists of a quantum volume circuit upto `depth/2`
     layers followed by an inverse of the quantum volume portion upto `depth/2`

--- a/mitiq/benchmarks/mirror_qv_circuits.py
+++ b/mitiq/benchmarks/mirror_qv_circuits.py
@@ -54,6 +54,10 @@ def generate_mirror_qv_circuit(
         A quantum volume circuit acting on ``num_qubits`` qubits.
         A list of the bitstrings for the returned circuit.
     """
+    if depth <= 0:
+        raise ValueError(
+            "{} is invalid for the generated circuit depth.", depth
+        )
 
     if depth % 2 == 0:
         first_half_depth = int(depth / 2)

--- a/mitiq/benchmarks/quantum_volume_circuits.py
+++ b/mitiq/benchmarks/quantum_volume_circuits.py
@@ -47,7 +47,7 @@ def generate_quantum_volume_circuit(
 
     Args:
         num_qubits: The number of qubits in the generated circuit.
-        depth: The number of qubits in the generated circuit.
+        depth: The number of layers in the generated circuit.
         decompose: Recursively decomposes the randomly sampled (numerical)
             unitary matrix gates into simpler gates.
         seed: Seed for generating random circuit.

--- a/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
@@ -1,0 +1,22 @@
+# Copyright (C) Unitary Fund
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for mirror quantum volume circuits."""
+
+import pytest
+import cirq
+
+from mitiq.benchmarks.mirror_qv_circuits import generate_mirror_qv_circuit
+
+def test_generate_mirror_qv_circuit_bitstring():
+    test_circ, _ =  generate_mirror_qv_circuit(4, 3)
+    bit_test= cirq.Simulator().run(test_circ, repetitions=1000)
+    test_bitstring = list(bit_test.measurements.values())[0][0].tolist()
+    expected_bitstring = [0] * 4
+    assert test_bitstring == expected_bitstring
+
+
+
+

--- a/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
@@ -7,13 +7,19 @@
 
 
 import cirq
+import pytest
 
 from mitiq.benchmarks.mirror_qv_circuits import generate_mirror_qv_circuit
 
 
-def test_generate_mirror_qv_circuit_bitstring():
-    # odd depth layers
-    test_circ, _ = generate_mirror_qv_circuit(4, 3)
+@pytest.mark.parametrize(
+    "depth_num",
+    [1, 2, 3, 4, 5, 6, 7, 8],
+)
+def test_generate_mirror_qv_circuit(depth_num):
+    test_circ, _ = generate_mirror_qv_circuit(4, depth_num)
+
+    # check bitstring is all 0's
     bit_test = cirq.Simulator().run(
         test_circ + cirq.measure(test_circ.all_qubits()), repetitions=1000
     )
@@ -21,11 +27,10 @@ def test_generate_mirror_qv_circuit_bitstring():
     expected_bitstring = [0] * 4
     assert test_bitstring == expected_bitstring
 
-    # even depth layers
-    test_circ, _ = generate_mirror_qv_circuit(4, 4)
-    bit_test = cirq.Simulator().run(
-        test_circ + cirq.measure(test_circ.all_qubits()), repetitions=1000
-    )
-    test_bitstring = list(bit_test.measurements.values())[0][0].tolist()
-    expected_bitstring = [0] * 4
-    assert test_bitstring == expected_bitstring
+
+def test_bad_depth_number():
+    for n in (-1, 0):
+        with pytest.raises(
+            ValueError, match="{} is invalid for the generated circuit depth."
+        ):
+            generate_mirror_qv_circuit(3, n)

--- a/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
@@ -12,7 +12,7 @@ from mitiq.benchmarks.mirror_qv_circuits import generate_mirror_qv_circuit
 
 def test_generate_mirror_qv_circuit_bitstring():
     test_circ, _ =  generate_mirror_qv_circuit(4, 3)
-    bit_test= cirq.Simulator().run(test_circ, repetitions=1000)
+    bit_test= cirq.Simulator().run(test_circ + cirq.measure(test_circ.all_qubits()), repetitions=1000)
     test_bitstring = list(bit_test.measurements.values())[0][0].tolist()
     expected_bitstring = [0] * 4
     assert test_bitstring == expected_bitstring

--- a/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
@@ -5,18 +5,17 @@
 
 """Tests for mirror quantum volume circuits."""
 
-import pytest
+
 import cirq
 
 from mitiq.benchmarks.mirror_qv_circuits import generate_mirror_qv_circuit
 
+
 def test_generate_mirror_qv_circuit_bitstring():
-    test_circ, _ =  generate_mirror_qv_circuit(4, 3)
-    bit_test= cirq.Simulator().run(test_circ + cirq.measure(test_circ.all_qubits()), repetitions=1000)
+    test_circ, _ = generate_mirror_qv_circuit(4, 3)
+    bit_test = cirq.Simulator().run(
+        test_circ + cirq.measure(test_circ.all_qubits()), repetitions=1000
+    )
     test_bitstring = list(bit_test.measurements.values())[0][0].tolist()
     expected_bitstring = [0] * 4
     assert test_bitstring == expected_bitstring
-
-
-
-

--- a/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
@@ -18,7 +18,8 @@ from mitiq import SUPPORTED_PROGRAM_TYPES
     [1, 2, 3, 4, 5, 6, 7, 8],
 )
 def test_generate_mirror_qv_circuit(depth_num):
-    test_circ, _ = generate_mirror_qv_circuit(4, depth_num)
+    """Check the circuit output."""
+    test_circ = generate_mirror_qv_circuit(4, depth_num)
 
     # check bitstring is all 0's
     bit_test = cirq.Simulator().run(
@@ -30,6 +31,7 @@ def test_generate_mirror_qv_circuit(depth_num):
 
 
 def test_bad_depth_number():
+    """Check if an unacceptable depth number rasies an error."""
     for n in (-1, 0):
         with pytest.raises(
             ValueError, match="{} is invalid for the generated circuit depth."
@@ -39,15 +41,16 @@ def test_bad_depth_number():
 
 @pytest.mark.parametrize("return_type", SUPPORTED_PROGRAM_TYPES.keys())
 def test_volume_conversion(return_type):
-    circuit, _ = generate_mirror_qv_circuit(4, 3, return_type=return_type)
+    """Check generated circuit's return type."""
+    circuit = generate_mirror_qv_circuit(4, 3, return_type=return_type)
     assert return_type in circuit.__module__
 
 
 def test_generate_model_circuit_with_seed():
     """Test that a model circuit is determined by its seed."""
-    circuit_1, _ = generate_mirror_qv_circuit(4, 3, seed=1)
-    circuit_2, _ = generate_mirror_qv_circuit(4, 3, seed=1)
-    circuit_3, _ = generate_mirror_qv_circuit(4, 3, seed=2)
+    circuit_1 = generate_mirror_qv_circuit(4, 3, seed=1)
+    circuit_2 = generate_mirror_qv_circuit(4, 3, seed=1)
+    circuit_3 = generate_mirror_qv_circuit(4, 3, seed=2)
 
     assert circuit_1 == circuit_2
     assert circuit_2 != circuit_3
@@ -63,6 +66,6 @@ def test_circuit_decomposition():
         ops.MeasurementGate,
         ops.GlobalPhaseGate
     """
-    circuit, _ = generate_mirror_qv_circuit(4, 3, decompose=True)
+    circuit = generate_mirror_qv_circuit(4, 3, decompose=True)
     for op in [operation for moment in circuit for operation in moment]:
         assert op in cirq.protocols.decompose_protocol.DECOMPOSE_TARGET_GATESET

--- a/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
@@ -12,7 +12,17 @@ from mitiq.benchmarks.mirror_qv_circuits import generate_mirror_qv_circuit
 
 
 def test_generate_mirror_qv_circuit_bitstring():
+    # odd depth layers
     test_circ, _ = generate_mirror_qv_circuit(4, 3)
+    bit_test = cirq.Simulator().run(
+        test_circ + cirq.measure(test_circ.all_qubits()), repetitions=1000
+    )
+    test_bitstring = list(bit_test.measurements.values())[0][0].tolist()
+    expected_bitstring = [0] * 4
+    assert test_bitstring == expected_bitstring
+
+    # even depth layers
+    test_circ, _ = generate_mirror_qv_circuit(4, 4)
     bit_test = cirq.Simulator().run(
         test_circ + cirq.measure(test_circ.all_qubits()), repetitions=1000
     )


### PR DESCRIPTION
Fixes #1788 

List of tests to add:

- [x] DIfference between odd and even depth : both should have the same output of all zero bitstrings
- [x] Check decompose option
- [x] Add  function in API docs: https://mitiq.readthedocs.io/en/stable/contributing_docs.html#automatically-add-information-from-the-api-docs
- [x] Conversion options
- [x] Check output as expected with seed and no seed
