### PR TITLE
Make sure PEC preserves measurement gates

### DIFF
--- a/mitiq/pec/sampling.py
+++ b/mitiq/pec/sampling.py
@@ -149,19 +149,13 @@ def sample_circuit(
     norm = 1.0
 
     for op in ideal.all_operations():
-        # Ignore all measurements.
-        if cirq.is_measurement(op):
-            continue
-
         sequences, loc_signs, loc_norm = sample_sequence(
             cirq.Circuit(op),
             representations,
             num_samples=num_samples,
             random_state=random_state,
         )
-
         norm *= loc_norm
-
         for j in range(num_samples):
             sampled_signs[j] *= loc_signs[j]
             cirq_seq, _ = convert_to_mitiq(sequences[j])

--- a/mitiq/pec/tests/test_pec_sampling.py
+++ b/mitiq/pec/tests/test_pec_sampling.py
@@ -147,7 +147,10 @@ def test_qubit_independent_representation_cirq():
     )
 
     expected_a = Circuit([cirq.I.on(LineQubit(0)), cirq.X.on(LineQubit(1))])
+    expected_a.append(measure_each(*LineQubit.range(2)))
+
     expected_b = Circuit([cirq.I.on(LineQubit(0)), cirq.Z.on(LineQubit(1))])
+    expected_b.append(measure_each(*LineQubit.range(2)))
 
     for _ in range(5):
         seqs, signs, norm = sample_circuit(circuit, representations=[rep])
@@ -272,9 +275,15 @@ def test_sample_circuit_cirq(measure):
         )
 
         assert isinstance(sampled_circuits[0], Circuit)
-        assert len(sampled_circuits[0]) == 2
         assert signs[0] in (-1, 1)
         assert norm >= 1
+        if measure:
+            assert len(sampled_circuits[0]) == 3
+            assert cirq.is_measurement(
+                sampled_circuits[0][-1][0]  # first op of last moment
+            )
+        else:
+            assert len(sampled_circuits[0]) == 2
 
 
 def test_sample_circuit_partial_representations():

--- a/mitiq/pec/tests/test_pec_sampling.py
+++ b/mitiq/pec/tests/test_pec_sampling.py
@@ -280,7 +280,7 @@ def test_sample_circuit_cirq(measure):
         if measure:
             assert len(sampled_circuits[0]) == 3
             assert cirq.is_measurement(
-                sampled_circuits[0][-1][0]  # first op of last moment
+                list(sampled_circuits[0].all_operations())[-1]  # last gate
             )
         else:
             assert len(sampled_circuits[0]) == 2


### PR DESCRIPTION

## Description

PEC is currently ignoring (and removing!) measurement gates #1805 . This is a bug which emerged in #1737.
This PR fixes #1805.

Curiosity: When never tried but, in principle, after this PR one could also mitigate measurement gates in the same
way as we typically mitigate other gates. (This possibility is known in the PEC literature). 



---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
