### PR TITLE
Adding PEC as technique supported by calibration

### DIFF
--- a/docs/source/guide/calibrators.md
+++ b/docs/source/guide/calibrators.md
@@ -43,8 +43,8 @@ from mitiq import Calibrator
 ```
 
 To instantiate a `Calibrator` we need to pass it an executor (as defined above), and a `Settings` object.
-You are free to define your own `Settings`, but we provide `ZNESettings` as a simple starting point based on different zero-noise extrapolation strategies.
-Finally, the `execute_with_mitigation` function allows us to pass the calibration results directly to Mitiq and have it pick the strategy that performed best.
+You are free to define your own `Settings`, but as a simple starting point, we provide `ZNESettings` based on different zero-noise extrapolation strategies and `PECSettings` based on different quasiprobability representations of ideal gates.
+Finally, the `execute_with_mitigation` function allows us to pass the calibration results directly to Mitiq and have it pick the strategy that performed best of those supplied in the `Settings` object.
 
 ## Calibration Experiments
 

--- a/mitiq/calibration/__init__.py
+++ b/mitiq/calibration/__init__.py
@@ -4,4 +4,4 @@
 # LICENSE file in the root directory of this source tree.
 
 from mitiq.calibration.calibrator import Calibrator, execute_with_mitigation
-from mitiq.calibration.settings import Settings, ZNESettings
+from mitiq.calibration.settings import Settings, ZNESettings, PECSettings

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -427,17 +427,7 @@ PECSettings = Settings(
             "operations": [CNOT, CZ],
             "is_qubit_dependent": False,
             "noise_level": 0.001,
-            "num_samples": 50,
-        },
-        {
-            "technique": "pec",
-            "representation_function": (
-                represent_operation_with_local_depolarizing_noise
-            ),
-            "operations": [CNOT, CZ],
-            "is_qubit_dependent": False,
-            "noise_level": 0.005,
-            "num_samples": 50,
+            "num_samples": 200,
         },
         {
             "technique": "pec",
@@ -447,27 +437,7 @@ PECSettings = Settings(
             "operations": [CNOT, CZ],
             "is_qubit_dependent": False,
             "noise_level": 0.01,
-            "num_samples": 50,
-        },
-        {
-            "technique": "pec",
-            "representation_function": (
-                represent_operation_with_local_depolarizing_noise
-            ),
-            "operations": [CNOT, CZ],
-            "is_qubit_dependent": False,
-            "noise_level": 0.015,
-            "num_samples": 50,
-        },
-        {
-            "technique": "pec",
-            "representation_function": (
-                represent_operation_with_local_depolarizing_noise
-            ),
-            "operations": [CNOT, CZ],
-            "is_qubit_dependent": False,
-            "noise_level": 0.02,
-            "num_samples": 50,
+            "num_samples": 200,
         },
     ],
 )

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -52,6 +52,12 @@ class MitigationTechnique(Enum):
             return execute
 
 
+calibration_supported_techniques = {
+    "ZNE": MitigationTechnique.ZNE,
+    "PEC": MitigationTechnique.PEC,
+}
+
+
 @dataclass
 class BenchmarkProblem:
     """A dataclass containing information for instances of problems that will
@@ -159,7 +165,7 @@ class Strategy:
         return None
 
     @property
-    def mitigation_function(self) -> Union[Callable[..., float], None]:
+    def mitigation_function(self) -> Callable[..., float]:
         if self.technique is MitigationTechnique.PEC:
             exclude_params = [
                 "representation_function",
@@ -181,7 +187,12 @@ class Strategy:
             return partial(
                 self.technique.mitigation_function, **self.technique_params
             )
-        return None
+        else:
+            raise ValueError(
+                """Specified technique is not supported by calibration.
+                    See {} for supported techniques.""",
+                calibration_supported_techniques,
+            )
 
     def to_dict(self) -> Dict[str, Any]:
         """A summary of the strategies parameters, without the technique added.

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -151,7 +151,7 @@ class Strategy:
             is_qubit_dependent = params_copy.pop("is_qubit_dependent", True)
             representations = [
                 rep_function(
-                    Circuit(op(*LineQubit.range(2))),
+                    op,
                     noise_level,
                     is_qubit_dependent,
                 )
@@ -424,7 +424,10 @@ PECSettings = Settings(
             "representation_function": (
                 represent_operation_with_local_depolarizing_noise
             ),
-            "operations": [CNOT, CZ],
+            "operations": [
+                Circuit(CNOT(*LineQubit.range(2))),
+                Circuit(CZ(*LineQubit.range(2))),
+            ],
             "is_qubit_dependent": False,
             "noise_level": 0.001,
             "num_samples": 200,
@@ -434,7 +437,10 @@ PECSettings = Settings(
             "representation_function": (
                 represent_operation_with_local_depolarizing_noise
             ),
-            "operations": [CNOT, CZ],
+            "operations": [
+                Circuit(CNOT(*LineQubit.range(2))),
+                Circuit(CZ(*LineQubit.range(2))),
+            ],
             "is_qubit_dependent": False,
             "noise_level": 0.01,
             "num_samples": 200,

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -131,7 +131,7 @@ def pec_execute(circuit, noise_level=0.01):
 def test_PEC_workflow():
     cal = Calibrator(pec_execute, frontend="cirq", settings=PECSettings)
     cost = cal.get_cost()
-    assert cost == {"noisy_executions": 20, "ideal_executions": 0}
+    assert cost == {"noisy_executions": 8, "ideal_executions": 0}
 
     cal.run()
     num_strategies, num_problems = cal.results.mitigated.shape

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -8,7 +8,6 @@ from functools import partial
 import pytest
 
 import cirq
-from cirq import Circuit, LineQubit, CNOT, CZ
 import numpy as np
 
 from mitiq import Executor, MeasurementResult, SUPPORTED_PROGRAM_TYPES
@@ -78,8 +77,8 @@ light_pec_settings = Settings(
                 represent_operation_with_local_depolarizing_noise
             ),
             "operations": [
-                Circuit(CNOT(*LineQubit.range(2))),
-                Circuit(CZ(*LineQubit.range(2))),
+                cirq.Circuit(cirq.CNOT(*cirq.LineQubit.range(2))),
+                cirq.Circuit(cirq.CZ(*cirq.LineQubit.range(2))),
             ],
             "is_qubit_dependent": False,
             "noise_level": 0.001,

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -146,7 +146,7 @@ def test_PECSettings():
         for s in ("type", "ideal_distribution", "num_qubits", "circuit_depth")
     )
     assert len(circuits) == 4
-    assert len(strategies) == 5
+    assert len(strategies) == 2
 
 
 @pytest.mark.parametrize("circuit_type", SUPPORTED_PROGRAM_TYPES.keys())

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -8,7 +8,7 @@ import cirq
 import qiskit
 
 from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES
-from mitiq.calibration import ZNESettings, Settings
+from mitiq.calibration import ZNESettings, PECSettings, Settings
 from mitiq.calibration.settings import MitigationTechnique, BenchmarkProblem
 from mitiq.raw import execute
 from mitiq.pec import execute_with_pec
@@ -128,15 +128,25 @@ def test_make_strategies_invalid_technique():
 def test_ZNESettings():
     circuits = ZNESettings.make_problems()
     strategies = ZNESettings.make_strategies()
-
     repr_string = repr(circuits[0])
     assert all(
         s in repr_string
         for s in ("type", "ideal_distribution", "num_qubits", "circuit_depth")
     )
-
     assert len(circuits) == 4
     assert len(strategies) == 2 * 2 * 2
+
+
+def test_PECSettings():
+    circuits = PECSettings.make_problems()
+    strategies = PECSettings.make_strategies()
+    repr_string = repr(circuits[0])
+    assert all(
+        s in repr_string
+        for s in ("type", "ideal_distribution", "num_qubits", "circuit_depth")
+    )
+    assert len(circuits) == 4
+    assert len(strategies) == 5
 
 
 @pytest.mark.parametrize("circuit_type", SUPPORTED_PROGRAM_TYPES.keys())

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -9,7 +9,11 @@ import qiskit
 
 from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES
 from mitiq.calibration import ZNESettings, PECSettings, Settings
-from mitiq.calibration.settings import MitigationTechnique, BenchmarkProblem
+from mitiq.calibration.settings import (
+    MitigationTechnique,
+    BenchmarkProblem,
+    Strategy,
+)
 from mitiq.raw import execute
 from mitiq.pec import (
     execute_with_pec,
@@ -179,6 +183,15 @@ def test_make_strategies_invalid_technique():
                 }
             ],
         )
+
+
+def test_unsupported_technique_error():
+    strategy = Strategy(1, MitigationTechnique.RAW, {})
+    with pytest.raises(
+        ValueError,
+        match="Specified technique is not supported by calibration.",
+    ):
+        strategy.mitigation_function()
 
 
 def test_PEC_representations():

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -11,9 +11,65 @@ from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES
 from mitiq.calibration import ZNESettings, PECSettings, Settings
 from mitiq.calibration.settings import MitigationTechnique, BenchmarkProblem
 from mitiq.raw import execute
-from mitiq.pec import execute_with_pec
+from mitiq.pec import (
+    execute_with_pec,
+    represent_operation_with_local_depolarizing_noise,
+)
 from mitiq.zne.scaling import fold_global
 from mitiq.zne.inference import RichardsonFactory, LinearFactory
+
+light_pec_settings = Settings(
+    [
+        {
+            "circuit_type": "mirror",
+            "num_qubits": 1,
+            "circuit_depth": 1,
+        },
+        {
+            "circuit_type": "mirror",
+            "num_qubits": 2,
+            "circuit_depth": 1,
+        },
+    ],
+    strategies=[
+        {
+            "technique": "pec",
+            "representation_function": (
+                represent_operation_with_local_depolarizing_noise
+            ),
+            "operations": [
+                cirq.Circuit(cirq.CNOT(*cirq.LineQubit.range(2))),
+                cirq.Circuit(cirq.CZ(*cirq.LineQubit.range(2))),
+            ],
+            "is_qubit_dependent": False,
+            "noise_level": 0.001,
+            "num_samples": 200,
+        },
+    ],
+)
+
+
+light_zne_settings = Settings(
+    [
+        {
+            "circuit_type": "mirror",
+            "num_qubits": 1,
+            "circuit_depth": 1,
+        },
+        {
+            "circuit_type": "mirror",
+            "num_qubits": 2,
+            "circuit_depth": 1,
+        },
+    ],
+    strategies=[
+        {
+            "technique": "zne",
+            "scale_noise": fold_global,
+            "factory": LinearFactory([1.0, 2.0]),
+        },
+    ],
+)
 
 
 def test_MitigationTechnique():
@@ -125,6 +181,14 @@ def test_make_strategies_invalid_technique():
         )
 
 
+def test_PEC_representations():
+    pec_strategy = light_pec_settings.make_strategies()[0]
+    assert len(pec_strategy.representations) > 0
+
+    zne_strategy = light_zne_settings.make_strategies()[0]
+    assert not zne_strategy.representations
+
+
 def test_ZNESettings():
     circuits = ZNESettings.make_problems()
     strategies = ZNESettings.make_strategies()
@@ -203,3 +267,27 @@ def test_settings_make_problems():
     assert problem.two_qubit_gate_count == 2
     assert problem.num_qubits == 2
     assert problem.circuit_depth == 2
+
+
+def test_to_dict():
+    pec_strategy = light_pec_settings.make_strategies()[0]
+    assert pec_strategy.to_dict() == {
+        "technique": "PEC",
+        "representation_function": (
+            represent_operation_with_local_depolarizing_noise
+        ),
+        "operations": [
+            cirq.Circuit(cirq.CNOT(*cirq.LineQubit.range(2))),
+            cirq.Circuit(cirq.CZ(*cirq.LineQubit.range(2))),
+        ],
+        "is_qubit_dependent": False,
+        "noise_level": 0.001,
+    }
+
+    zne_strategy = light_zne_settings.make_strategies()[0]
+    assert zne_strategy.to_dict() == {
+        "technique": "ZNE",
+        "scale_method": "fold_global",
+        "factory": "LinearFactory",
+        "scale_factors": [1.0, 2.0],
+    }

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -59,9 +59,10 @@ def represent_operation_with_local_biased_noise(
             channel and :math:`\eta = \infty` describing a fully dephasing
             channel.
         is_qubit_dependent: If True, the representation corresponds to the
-            operation on the specific qubits defined in `ideal_operation`. If False, the
-            representation is valid for the same gate even if acting on
-            different qubits from those specified in `ideal_operation`.
+            operation on the specific qubits defined in `ideal_operation`.
+            If False, the representation is valid for the same gate even if
+            acting on different qubits from those specified in
+            `ideal_operation`.
 
     Returns:
         The quasi-probability representation of the ``ideal_operation``.

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -59,9 +59,9 @@ def represent_operation_with_local_biased_noise(
             channel and :math:`\eta = \infty` describing a fully dephasing
             channel.
         is_qubit_dependent: If True, the representation corresponds to the
-            operation on the specific qubits defined in `ideal`. If False, the
+            operation on the specific qubits defined in `ideal_operation`. If False, the
             representation is valid for the same gate even if acting on
-            different qubits from those specified in `ideal`.
+            different qubits from those specified in `ideal_operation`.
 
     Returns:
         The quasi-probability representation of the ``ideal_operation``.

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -26,6 +26,7 @@ def represent_operation_with_local_biased_noise(
     ideal_operation: QPROGRAM,
     epsilon: float,
     eta: float,
+    is_qubit_dependent: bool = True,
 ) -> OperationRepresentation:
     r"""This function maps an
     ``ideal_operation`` :math:`\mathcal{U}` into its quasi-probability
@@ -57,6 +58,10 @@ def represent_operation_with_local_biased_noise(
             channels with :math:`\eta = 0` describing a fully depolarizing
             channel and :math:`\eta = \infty` describing a fully dephasing
             channel.
+        is_qubit_dependent: If True, the representation corresponds to the
+            operation on the specific qubits defined in `ideal`. If False, the
+            representation is valid for the same gate even if acting on
+            different qubits from those specified in `ideal`.
 
     Returns:
         The quasi-probability representation of the ``ideal_operation``.
@@ -142,4 +147,6 @@ def represent_operation_with_local_biased_noise(
 
     # Build basis expansion.
     noisy_operations = [NoisyOperation(c) for c in imp_op_circuits]
-    return OperationRepresentation(ideal_operation, noisy_operations, alphas)
+    return OperationRepresentation(
+        ideal_operation, noisy_operations, alphas, is_qubit_dependent
+    )

--- a/mitiq/pec/representations/damping.py
+++ b/mitiq/pec/representations/damping.py
@@ -44,9 +44,9 @@ def _represent_operation_with_amplitude_damping_noise(
         ideal_operation: The ideal operation (as a QPROGRAM) to represent.
         noise_level: The noise level of each amplitude damping channel.
         is_qubit_dependent: If True, the representation corresponds to the
-            operation on the specific qubits defined in `ideal`. If False, the
+            operation on the specific qubits defined in `ideal_operation`. If False, the
             representation is valid for the same gate even if acting on
-            different qubits from those specified in `ideal`.
+            different qubits from those specified in `ideal_operation`.
 
     Returns:
         The quasi-probability representation of the ``ideal_operation``.

--- a/mitiq/pec/representations/damping.py
+++ b/mitiq/pec/representations/damping.py
@@ -27,6 +27,7 @@ from mitiq.pec.channels import tensor_product
 def _represent_operation_with_amplitude_damping_noise(
     ideal_operation: Circuit,
     noise_level: float,
+    is_qubit_dependent: bool = True,
 ) -> OperationRepresentation:
     r"""Returns the quasi-probability representation of the input
     single-qubit ``ideal_operation`` with respect to a basis of noisy
@@ -42,6 +43,10 @@ def _represent_operation_with_amplitude_damping_noise(
     Args:
         ideal_operation: The ideal operation (as a QPROGRAM) to represent.
         noise_level: The noise level of each amplitude damping channel.
+        is_qubit_dependent: If True, the representation corresponds to the
+            operation on the specific qubits defined in `ideal`. If False, the
+            representation is valid for the same gate even if acting on
+            different qubits from those specified in `ideal`.
 
     Returns:
         The quasi-probability representation of the ``ideal_operation``.
@@ -82,7 +87,9 @@ def _represent_operation_with_amplitude_damping_noise(
     imp_op_circuits = [ideal_operation + Circuit(op) for op in post_ops]
     noisy_operations = [NoisyOperation(c) for c in imp_op_circuits]
 
-    return OperationRepresentation(ideal_operation, noisy_operations, etas)
+    return OperationRepresentation(
+        ideal_operation, noisy_operations, etas, is_qubit_dependent
+    )
 
 
 def amplitude_damping_kraus(

--- a/mitiq/pec/representations/damping.py
+++ b/mitiq/pec/representations/damping.py
@@ -44,9 +44,10 @@ def _represent_operation_with_amplitude_damping_noise(
         ideal_operation: The ideal operation (as a QPROGRAM) to represent.
         noise_level: The noise level of each amplitude damping channel.
         is_qubit_dependent: If True, the representation corresponds to the
-            operation on the specific qubits defined in `ideal_operation`. If False, the
-            representation is valid for the same gate even if acting on
-            different qubits from those specified in `ideal_operation`.
+            operation on the specific qubits defined in `ideal_operation`.
+            If False, the representation is valid for the same gate even if
+            acting on different qubits from those specified in
+            `ideal_operation`.
 
     Returns:
         The quasi-probability representation of the ``ideal_operation``.

--- a/mitiq/pec/representations/depolarizing.py
+++ b/mitiq/pec/representations/depolarizing.py
@@ -33,7 +33,9 @@ from mitiq.pec.channels import tensor_product
 
 
 def represent_operation_with_global_depolarizing_noise(
-    ideal_operation: QPROGRAM, noise_level: float
+    ideal_operation: QPROGRAM,
+    noise_level: float,
+    is_qubit_dependent: bool = True,
 ) -> OperationRepresentation:
     r"""As described in :cite:`Temme_2017_PRL`, this function maps an
     ``ideal_operation`` :math:`\mathcal{U}` into its quasi-probability
@@ -76,6 +78,10 @@ def represent_operation_with_global_depolarizing_noise(
     Args:
         ideal_operation: The ideal operation (as a QPROGRAM) to represent.
         noise_level: The noise level (as a float) of the depolarizing channel.
+        is_qubit_dependent: If True, the representation corresponds to the
+            operation on the specific qubits defined in `ideal`. If False, the
+            representation is valid for the same gate even if acting on
+            different qubits from those specified in `ideal`.
 
     Returns:
         The quasi-probability representation of the ``ideal_operation``.
@@ -144,11 +150,15 @@ def represent_operation_with_global_depolarizing_noise(
 
     noisy_operations = [NoisyOperation(c) for c in imp_op_circuits]
 
-    return OperationRepresentation(ideal_operation, noisy_operations, alphas)
+    return OperationRepresentation(
+        ideal_operation, noisy_operations, alphas, is_qubit_dependent
+    )
 
 
 def represent_operation_with_local_depolarizing_noise(
-    ideal_operation: QPROGRAM, noise_level: float
+    ideal_operation: QPROGRAM,
+    noise_level: float,
+    is_qubit_dependent: bool = True,
 ) -> OperationRepresentation:
     r"""As described in :cite:`Temme_2017_PRL`, this function maps an
     ``ideal_operation`` :math:`\mathcal{U}` into its quasi-probability
@@ -173,7 +183,10 @@ def represent_operation_with_local_depolarizing_noise(
     Args:
         ideal_operation: The ideal operation (as a QPROGRAM) to represent.
         noise_level: The noise level of each depolarizing channel.
-
+        is_qubit_dependent: If True, the representation corresponds to the
+            operation on the specific qubits defined in `ideal`. If False, the
+            representation is valid for the same gate even if acting on
+            different qubits from those specified in `ideal`.
     Returns:
         The quasi-probability representation of the ``ideal_operation``.
 
@@ -239,7 +252,9 @@ def represent_operation_with_local_depolarizing_noise(
 
     noisy_operations = [NoisyOperation(c) for c in imp_op_circuits]
 
-    return OperationRepresentation(ideal_operation, noisy_operations, alphas)
+    return OperationRepresentation(
+        ideal_operation, noisy_operations, alphas, is_qubit_dependent
+    )
 
 
 def represent_operations_in_circuit_with_global_depolarizing_noise(

--- a/mitiq/pec/representations/depolarizing.py
+++ b/mitiq/pec/representations/depolarizing.py
@@ -79,9 +79,9 @@ def represent_operation_with_global_depolarizing_noise(
         ideal_operation: The ideal operation (as a QPROGRAM) to represent.
         noise_level: The noise level (as a float) of the depolarizing channel.
         is_qubit_dependent: If True, the representation corresponds to the
-            operation on the specific qubits defined in `ideal`. If False, the
+            operation on the specific qubits defined in `ideal_operation`. If False, the
             representation is valid for the same gate even if acting on
-            different qubits from those specified in `ideal`.
+            different qubits from those specified in `ideal_operation`.
 
     Returns:
         The quasi-probability representation of the ``ideal_operation``.
@@ -184,9 +184,9 @@ def represent_operation_with_local_depolarizing_noise(
         ideal_operation: The ideal operation (as a QPROGRAM) to represent.
         noise_level: The noise level of each depolarizing channel.
         is_qubit_dependent: If True, the representation corresponds to the
-            operation on the specific qubits defined in `ideal`. If False, the
+            operation on the specific qubits defined in `ideal_operation`. If False, the
             representation is valid for the same gate even if acting on
-            different qubits from those specified in `ideal`.
+            different qubits from those specified in `ideal_operation`.
     Returns:
         The quasi-probability representation of the ``ideal_operation``.
 

--- a/mitiq/pec/representations/depolarizing.py
+++ b/mitiq/pec/representations/depolarizing.py
@@ -79,9 +79,10 @@ def represent_operation_with_global_depolarizing_noise(
         ideal_operation: The ideal operation (as a QPROGRAM) to represent.
         noise_level: The noise level (as a float) of the depolarizing channel.
         is_qubit_dependent: If True, the representation corresponds to the
-            operation on the specific qubits defined in `ideal_operation`. If False, the
-            representation is valid for the same gate even if acting on
-            different qubits from those specified in `ideal_operation`.
+            operation on the specific qubits defined in `ideal_operation`.
+            If False, the representation is valid for the same gate even if
+            acting on different qubits from those specified in
+            `ideal_operation`.
 
     Returns:
         The quasi-probability representation of the ``ideal_operation``.
@@ -184,9 +185,10 @@ def represent_operation_with_local_depolarizing_noise(
         ideal_operation: The ideal operation (as a QPROGRAM) to represent.
         noise_level: The noise level of each depolarizing channel.
         is_qubit_dependent: If True, the representation corresponds to the
-            operation on the specific qubits defined in `ideal_operation`. If False, the
-            representation is valid for the same gate even if acting on
-            different qubits from those specified in `ideal_operation`.
+            operation on the specific qubits defined in `ideal_operation`.
+            If False, the representation is valid for the same gate even
+            if acting on different qubits from those specified in
+            `ideal_operation`.
     Returns:
         The quasi-probability representation of the ``ideal_operation``.
 

--- a/mitiq/pec/representations/optimal.py
+++ b/mitiq/pec/representations/optimal.py
@@ -116,9 +116,10 @@ def find_optimal_representation(
         initial_guess: Optional initial guess for the coefficients
             :math:`\{ \eta_\alpha \}`.
         is_qubit_dependent: If True, the representation corresponds to the
-            operation on the specific qubits defined in `ideal_operation`. If False, the
-            representation is valid for the same gate even if acting on
-            different qubits from those specified in `ideal_operation`.
+            operation on the specific qubits defined in `ideal_operation`.
+            If False, the representation is valid for the same gate even if
+            acting on different qubits from those specified in
+            `ideal_operation`.
 
     Returns: The optimal OperationRepresentation.
     """

--- a/mitiq/pec/representations/optimal.py
+++ b/mitiq/pec/representations/optimal.py
@@ -91,6 +91,7 @@ def find_optimal_representation(
     noisy_operations: List[NoisyOperation],
     tol: float = 1.0e-8,
     initial_guess: Optional[npt.NDArray[np.float64]] = None,
+    is_qubit_dependent: bool = True,
 ) -> OperationRepresentation:
     r"""Returns the ``OperationRepresentation`` of the input ideal operation
     which minimizes the one-norm of the associated quasi-probability
@@ -114,6 +115,10 @@ def find_optimal_representation(
             of the represented operation.
         initial_guess: Optional initial guess for the coefficients
             :math:`\{ \eta_\alpha \}`.
+        is_qubit_dependent: If True, the representation corresponds to the
+            operation on the specific qubits defined in `ideal`. If False, the
+            representation is valid for the same gate even if acting on
+            different qubits from those specified in `ideal`.
 
     Returns: The optimal OperationRepresentation.
     """
@@ -144,5 +149,8 @@ def find_optimal_representation(
     )
 
     return OperationRepresentation(
-        ideal_operation, noisy_operations, quasi_prob_dist.tolist()
+        ideal_operation,
+        noisy_operations,
+        quasi_prob_dist.tolist(),
+        is_qubit_dependent,
     )

--- a/mitiq/pec/representations/optimal.py
+++ b/mitiq/pec/representations/optimal.py
@@ -116,9 +116,9 @@ def find_optimal_representation(
         initial_guess: Optional initial guess for the coefficients
             :math:`\{ \eta_\alpha \}`.
         is_qubit_dependent: If True, the representation corresponds to the
-            operation on the specific qubits defined in `ideal`. If False, the
+            operation on the specific qubits defined in `ideal_operation`. If False, the
             representation is valid for the same gate even if acting on
-            different qubits from those specified in `ideal`.
+            different qubits from those specified in `ideal_operation`.
 
     Returns: The optimal OperationRepresentation.
     """

--- a/mitiq/utils.py
+++ b/mitiq/utils.py
@@ -144,7 +144,9 @@ def _equal(
         circuit_one = deepcopy(circuit_one)
         circuit_two = deepcopy(circuit_two)
 
-    if not require_qubit_equality:
+    if (not require_qubit_equality) and (
+        len(circuit_one.all_qubits()) == len(circuit_two.all_qubits())
+    ):
         # Transform the qubits of circuit one to those of circuit two
         qubit_map = dict(
             zip(


### PR DESCRIPTION
## Description

Prototype for PEC calibration. 

Fixes #1737

1. Add simple `PECSettings` object with 5 different noise levels of depolarizing noise, representing CNOT and CZ gates only. 
2. Update `settings.Strategy.mitigation_function` to generate representations from relevant `PECSettings`.
3. Update `representations` functions, e.g. `represent_operation_with_local_depolarizing_noise` to take optional `is_qubit_dependent` argument.
4. Update qubit transformation condition in `utils._equal` to check if the number of qubits in both circuits is the same before performing the qubit mapping. If they don't, the circuits are unequal --> already return `False` and move on to the next iteration without throwing an unnecessary error.
5. Add PEC calibration tests.
6. Update user guide to mention `PECSettings` (more details to come in future issues/PRs).

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file