### PR TITLE
Add function to register user defined Mitiq converters

### DIFF
--- a/mitiq/interface/__init__.py
+++ b/mitiq/interface/__init__.py
@@ -11,6 +11,7 @@ from mitiq.interface.conversions import (
     convert_to_mitiq,
     noise_scaling_converter,
     append_cirq_circuit_to_qprogram,
+    register_mitiq_converter,
     CircuitConversionError,
     UnsupportedCircuitError,
 )

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -19,18 +19,20 @@ class UnsupportedCircuitError(Exception):
 class CircuitConversionError(Exception):
     pass
 
+
 register_dict: Dict[Tuple[str, str], Callable[[Any], Circuit]] = {}
 
+
 def register_mitiq_converter(
-    package_name: str, 
-    direction: str, 
-    convert_function: Callable[[Any], Circuit]
-):
+    package_name: str,
+    direction: str,
+    convert_function: Callable[[Any], Circuit],
+) -> None:
+    global register_dict
     if direction not in ["to", "from"]:
         raise ValueError("Invalid direction. Expected 'to' or 'from'.")
     register_dict[(package_name, direction)] = convert_function
-    global register_dict
-    register_dict[package_name] = convert_function
+
 
 def convert_to_mitiq(circuit: QPROGRAM) -> Tuple[Circuit, str]:
     """Converts any valid input circuit to a mitiq circuit.
@@ -80,17 +82,19 @@ def convert_to_mitiq(circuit: QPROGRAM) -> Tuple[Circuit, str]:
 
         def conversion_function(circ: Circuit) -> Circuit:
             return circ
+
     else:
-        for package_name in register_dict:
-             if package_name in package:
-                conversion_function = register_dict[(package_name, "from")]
+        for package_name, _ in register_dict:
+            if package_name in package:
+                conversion_function = register_dict[package_name, "from"]
                 break
         else:
-             raise UnsupportedCircuitError(
-            f"Circuit from module {package} is not supported.\n\n"
-            f"Please define a converter with register_mitiq_converter(),"
-            f"\nor specify a supported Circuit type: \n{SUPPORTED_PROGRAM_TYPES}"
-        )
+            raise UnsupportedCircuitError(
+                f"Circuit from module {package} is not supported.\n\n"
+                f"Please define a converter with register_mitiq_converter(),"
+                f"\nor specify a supported Circuit type:"
+                f"\n{SUPPORTED_PROGRAM_TYPES}"
+            )
 
     try:
         mitiq_circuit = conversion_function(circuit)
@@ -136,17 +140,20 @@ def convert_from_mitiq(circuit: Circuit, conversion_type: str) -> QPROGRAM:
 
         def conversion_function(circ: Circuit) -> Circuit:
             return circ
+
     else:
-        for package_name in register_dict:
-             if package_name == conversion_type:
-                conversion_function = register_dict[(package_name, "from")]
+        for package_name, _ in register_dict:
+            if package_name == conversion_type:
+                conversion_function = register_dict[package_name, "from"]
                 break
         else:
             raise UnsupportedCircuitError(
-            f"Conversion to circuit of type {conversion_type} is unsupported."
-            f"\n\nPlease define a converter with register_mitiq_converter(),"
-            f"\nor specify a supported Circuit type: \n{SUPPORTED_PROGRAM_TYPES}"
-        )
+                f"Conversion to circuit type {conversion_type} is unsupported."
+                f"\n\nPlease register a converter with"
+                f"register_mitiq_converter(),"
+                f"\nor specify a supported Circuit type:"
+                f"\n{SUPPORTED_PROGRAM_TYPES}"
+            )
 
     try:
         converted_circuit = conversion_function(circuit)

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -36,7 +36,9 @@ except NameError:
 def register_mitiq_converter(
     package_name: str,
     direction: str,
-    convert_function: Union[Callable[[Any], Circuit], Callable[[Circuit], Any]],
+    convert_function: Union[
+        Callable[[Any], Circuit], Callable[[Circuit], Any]
+    ],
 ) -> None:
     """Registers converters for unsupported circuit types.
 

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -124,8 +124,8 @@ def convert_to_mitiq(circuit: QPROGRAM) -> Tuple[Circuit, str]:
             raise UnsupportedCircuitError(
                 f"Circuit from module {package} is not supported.\n\n"
                 f"Please define a converter with register_mitiq_converter(),"
-                f"\nor specify a supported Circuit type:"
-                f"\n{SUPPORTED_PROGRAM_TYPES}"
+                f"\n or specify a supported Circuit type:"
+                f"\n {SUPPORTED_PROGRAM_TYPES}"
             )
 
     try:
@@ -136,8 +136,8 @@ def convert_to_mitiq(circuit: QPROGRAM) -> Tuple[Circuit, str]:
             "This may be because the circuit contains custom gates or Pragmas "
             "(pyQuil). If you think this is a bug or that this circuit should "
             "be supported, you can open an issue at "
-            "https://github.com/unitaryfund/mitiq. \n\nProvided circuit has "
-            f"type {type(circuit)} and is:\n\n{circuit}\n\nCircuit types "
+            "https://github.com/unitaryfund/mitiq. \n\n Provided circuit has "
+            f"type {type(circuit)} and is:\n\n{circuit}\n\n Circuit types "
             f"supported by Mitiq are \n{SUPPORTED_PROGRAM_TYPES}."
         )
 
@@ -176,15 +176,15 @@ def convert_from_mitiq(circuit: Circuit, conversion_type: str) -> QPROGRAM:
     else:
         for package_name, _ in register_to_dict:
             if package_name == conversion_type:
-                conversion_function = register_to_dict[package_name, "from"]
+                conversion_function = register_to_dict[package_name, "to"]
                 break
         else:
             raise UnsupportedCircuitError(
                 f"Conversion to circuit type {conversion_type} is unsupported."
-                f"\n\nPlease register a converter with"
+                f"\n\n Please register a converter with"
                 f"register_mitiq_converter(),"
-                f"\nor specify a supported Circuit type:"
-                f"\n{SUPPORTED_PROGRAM_TYPES}"
+                f"\n or specify a supported Circuit type:"
+                f"\n {SUPPORTED_PROGRAM_TYPES}"
             )
 
     try:

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -32,6 +32,21 @@ def register_mitiq_converter(
     direction: str,
     convert_function: Callable[[Any], Circuit],
 ) -> None:
+    """Registers converters for unsupported circuit types.
+
+    Args:
+        package_name: A quantum circuit module name that is not currently
+            supported by Mitiq. Note: this name should be the same as the
+            return from "circuit".__module__.
+                 See mitiq.SUPPORTED_PROGRAM_TYPES.
+        direction: Specifies the conversion direction relative to the non-Mitiq
+            circuit. i.e. "from" returns a Mitiq/Cirq circuit, "to" returns a
+            Non-Mitiq circuit.
+        convert_function: User specified function to convert to and from an
+            unsupported circuit type. These functions should follow the
+            direction hint above: "from" returns a Mitiq/Cirq circuit,
+            "to" returns a Non-Mitiq circuit.
+    """
     global register_dict
     if direction not in ["to", "from"]:
         raise ValueError("Invalid direction. Expected 'to' or 'from'.")

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -20,7 +20,11 @@ class CircuitConversionError(Exception):
     pass
 
 
-register_dict: Dict[Tuple[str, str], Callable[[Any], Circuit]] = {}
+register_dict: Dict[Tuple[str, str], Callable[[Any], Circuit]]
+try:
+    register_dict
+except NameError:
+    register_dict = {}
 
 
 def register_mitiq_converter(
@@ -86,6 +90,7 @@ def convert_to_mitiq(circuit: QPROGRAM) -> Tuple[Circuit, str]:
     else:
         for package_name, _ in register_dict:
             if package_name in package:
+                input_circuit_type = package_name
                 conversion_function = register_dict[package_name, "from"]
                 break
         else:

--- a/mitiq/tests/test_conversions.py
+++ b/mitiq/tests/test_conversions.py
@@ -114,6 +114,15 @@ def test_to_mitiq_bad_types(item):
         convert_to_mitiq(item)
 
 
+def test_register_bad_args():
+    circuit = qasm_circuit
+    with pytest.raises(
+        ValueError,
+        match="Invalid direction. Expected 'to' or 'from'.",
+    ):
+        register_mitiq_converter(circuit.__module__, "mitiq", from_qasm)
+
+
 @pytest.mark.parametrize("to_type", SUPPORTED_PROGRAM_TYPES.keys())
 def test_from_mitiq(to_type):
     converted_circuit = convert_from_mitiq(cirq_circuit, to_type)


### PR DESCRIPTION
## Description

Fixes #1377

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file