### PR TITLE
Add download option button to tutorials in docs

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -19,7 +19,7 @@ sphinxcontrib-bibtex==2.5.0
 sphinx-copybutton==0.5.0
 sphinx-autodoc-typehints==1.19.4
 myst-nb==0.17.1
-pydata-sphinx-theme==0.11.0
+sphinx-book-theme==1.0.1
 jupytext==1.14.1
 sphinx-gallery==0.10.1
 nbsphinx==0.9.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -295,7 +295,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "pydata_sphinx_theme"  # 'alabaster', 'sphinx_rtd_theme'
+html_theme = "sphinx_book_theme"  # 'alabaster', 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -314,7 +314,15 @@ html_extra_path = ["robots.txt"]
 html_theme_options = {
     "announcement": '<a href="https://unitaryhack.dev/">unitaryHACK</a> is \
     coming <b>May 26-Jun 13</b>! Get rewarded for contributing to open source \
-    quantum software!'
+    quantum software!',
+    "repository_url": "https://github.com/unitaryfund/mitiq",
+    "repository_branch": "master",
+    "use_source_button": False,
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "use_download_button": True,
+    "use_fullscreen_button": False,
+    "path_to_docs": "docs/source",
 }
 
 myst_update_mathjax = False


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.

  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.

  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->

This PR is regarding #1619. This issue is to add download option button to tutorials in docs, including .ipynb option. I am currently working on this issue, opening this PR to be in loop with maintainers. I have added sphinx_book_theme which can be used to add download buttons in docs. This issue is being solved by me and @aryanguptaaa together as a team.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file