### PR TITLE
Removed Windows Note From CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,33 +131,6 @@ Milestones are tracked using the [GitHub milestone feature](https://github.com/u
 All releases for Mitiq are tagged on the `master` branch with tags for the version number of the release.
 Find all the previous releases [here](https://github.com/unitaryfund/mitiq/releases).
 
----
-### Special Note for Windows Users Using Python 3.8:
-To prevent errors when running `make docs` and `make doctest`, Windows developers using Python 3.8 will also need to edit `__init__.py` in their environment's asyncio directory.
-This is due to Python changing `asyncio`'s [default event loop in Windows beginning in Python 3.8](https://docs.python.org/3/library/asyncio-policy.html#asyncio.DefaultEventLoopPolicy).
-The new default event loop will not support Unix-style APIs used by some dependencies.
-1. Locate your environment directory (likely `C:\Users\{username}\anaconda3\envs\{your_env}`), and open `{env_dir}/Lib/asyncio/__init__.py`.
-2. Add `import asyncio` to the file's import statements.
-3. Find the block of code below and replace it with the provided replacement.
-    * Original Code
-
-          if sys.platform == 'win32':  # pragma: no cover
-              from .windows_events import *
-              __all__ += windows_events.__all__
-          else:
-              from .unix_events import *  # pragma: no cover
-              __all__ += unix_events.__all__
-
-    * Replacement Code
-
-          if sys.platform == 'win32':  # pragma: no cover
-              from .windows_events import *
-              asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-              __all__ += windows_events.__all__
-          else:
-              from .unix_events import *  # pragma: no cover
-              __all__ += unix_events.__all__
-
 ## Code of conduct
 Mitiq development abides to the [Contributors' Covenant](https://mitiq.readthedocs.io/en/latest/code_of_conduct.html).
 


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.

  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.

  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->
This removes the *Special Note for Windows Users Using Python 3.8* from CONTRIBUTING.md. The note was placed there as a temporary solution to Issue #689. Since then, the issue has resolved itself. I verified this morning that you can build the docs and run doctest on Windows with Python 3.8 without the mentioned change.

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [X] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file