### PR TITLE
Adds subspace expansion utils

### DIFF
--- a/mitiq/qse/__init__.py
+++ b/mitiq/qse/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from mitiq.qse.qse_utils import get_projector

--- a/mitiq/qse/qse_utils.py
+++ b/mitiq/qse/qse_utils.py
@@ -1,0 +1,134 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Functions for computing the projector for subspace expansion."""
+
+from typing import Callable, Sequence, Union
+from mitiq import Observable, QPROGRAM, QuantumResult, PauliString
+from typing import Dict
+import numpy as np
+import numpy.typing as npt
+from scipy.linalg import eigh
+from numpy.linalg import pinv
+
+
+def get_projector(
+    circuit: QPROGRAM,
+    executor: Callable[[QPROGRAM], QuantumResult],
+    check_operators: Sequence[PauliString],
+    code_hamiltonian: Observable,
+) -> Observable:
+    """Computes the projector onto the code space defined by the
+    check_operators provided that minimizes the code_hamiltonian.
+
+    Returns: Projector as an Observable.
+    """
+    pauli_string_to_expectation_cache: Dict[PauliString, complex] = {}
+    S = _compute_overlap_matrix(
+        circuit, executor, check_operators, pauli_string_to_expectation_cache
+    )
+    H = _compute_hamiltonian_overlap_matrix(
+        circuit,
+        executor,
+        check_operators,
+        code_hamiltonian,
+        pauli_string_to_expectation_cache,
+    )
+    # We only want the smallest eigenvalue and corresponding eigenvector
+    _, C = eigh(pinv(S) @ H, subset_by_index=[0, 0])
+    # np float type: np.float64
+
+    Cs = C[:, 0]
+    projector = Observable(
+        *[check_operators[i] * Cs[i] for i in range(len(check_operators))]
+    )
+
+    return projector
+
+
+def _get_expectation_value_for_observable(
+    circuit: QPROGRAM,
+    executor: Callable[[QPROGRAM], QuantumResult],
+    observable: Union[PauliString, Observable],
+    pauli_string_to_expectation_cache: Dict[PauliString, complex] = {},
+) -> float:
+    def get_expectation_value_for_one_pauli(
+        pauli_string: PauliString,
+    ) -> float:
+        cache_key = pauli_string.with_coeff(1)
+        pauli_string_to_expectation_cache[cache_key] = Observable(
+            cache_key
+        ).expectation(circuit, executor)
+        return (
+            pauli_string_to_expectation_cache[cache_key] * pauli_string.coeff
+        ).real
+
+    total_expectation_value_for_observable = 0.0
+
+    if isinstance(observable, PauliString):
+        pauli_string = observable
+        total_expectation_value_for_observable += (
+            get_expectation_value_for_one_pauli(pauli_string)
+        )
+    elif isinstance(observable, Observable):
+        for pauli_string in observable.paulis:
+            total_expectation_value_for_observable += (
+                get_expectation_value_for_one_pauli(pauli_string)
+            )
+    return total_expectation_value_for_observable
+
+
+def _compute_overlap_matrix(
+    circuit: QPROGRAM,
+    executor: Callable[[QPROGRAM], QuantumResult],
+    check_operators: Sequence[PauliString],
+    pauli_string_to_expectation_cache: Dict[PauliString, complex] = {},
+) -> npt.NDArray[np.float64]:
+    S: list[list[float]] = []
+    # S_ij = <Ψ|Mi† Mj|Ψ>
+    for i in range(len(check_operators)):
+        S.append([])
+        for j in range(len(check_operators)):
+            sij = _get_expectation_value_for_observable(
+                circuit,
+                executor,
+                check_operators[i] * check_operators[j],
+                pauli_string_to_expectation_cache,
+            )
+            S[-1].append(sij)
+    return np.array(S)
+
+
+def _compute_hamiltonian_overlap_matrix(
+    circuit: QPROGRAM,
+    executor: Callable[[QPROGRAM], QuantumResult],
+    check_operators: Sequence[PauliString],
+    code_hamiltonian: Observable,
+    pauli_string_to_expectation_cache: Dict[PauliString, complex] = {},
+) -> npt.NDArray[np.float64]:
+    H: list[list[float]] = []
+    # H_ij = <Ψ|Mi† H Mj|Ψ>
+    for i in range(len(check_operators)):
+        H.append([])
+        for j in range(len(check_operators)):
+            H[-1].append(
+                _get_expectation_value_for_observable(
+                    circuit,
+                    executor,
+                    check_operators[i] * code_hamiltonian * check_operators[j],
+                    pauli_string_to_expectation_cache,
+                )
+            )
+    return np.array(H)

--- a/mitiq/qse/tests/test_subspace_expansion.py
+++ b/mitiq/qse/tests/test_subspace_expansion.py
@@ -1,0 +1,224 @@
+# Copyright (C) 2021 Unitary Fund
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for the Quantum Subspace Expansion top level API."""
+
+from typing import List
+
+import numpy as np
+
+import cirq
+
+from mitiq import PauliString, Observable, QPROGRAM
+
+from mitiq.qse import get_projector
+from mitiq.qse.qse_utils import (
+    _compute_overlap_matrix,
+    _compute_hamiltonian_overlap_matrix,
+)
+
+from mitiq.interface import convert_to_mitiq
+
+from mitiq.interface.mitiq_cirq import compute_density_matrix
+
+
+def execute_with_depolarized_noise(circuit: QPROGRAM) -> np.ndarray:
+    return compute_density_matrix(
+        convert_to_mitiq(circuit)[0],
+        noise_model=cirq.depolarize,
+        noise_level=(0.01,),
+    )
+
+
+def execute_no_noise(circuit: QPROGRAM) -> np.ndarray:
+    return compute_density_matrix(
+        convert_to_mitiq(circuit)[0], noise_level=(0,)
+    )
+
+
+def test_get_projector():
+    qc, _ = prepare_logical_0_state_for_5_1_3_code()
+    (
+        check_operators,
+        code_hamiltonian,
+    ) = get_5_1_3_code_check_operators_and_code_hamiltonian()
+    P = get_projector(qc, execute_no_noise, check_operators, code_hamiltonian)
+    uniform_projector = Observable(*[-0.25 * c for c in check_operators])
+    assert P == uniform_projector
+
+
+def test_compute_overlap_matrix():
+    qc, _ = prepare_logical_0_state_for_5_1_3_code()
+    (
+        check_operators,
+        _,
+    ) = get_5_1_3_code_check_operators_and_code_hamiltonian()
+    S = _compute_overlap_matrix(qc, execute_no_noise, check_operators, {})
+    assert np.allclose(S, np.ones(16))
+
+    S = _compute_overlap_matrix(
+        qc, execute_with_depolarized_noise, check_operators, {}
+    )
+    # assert that S's diagonal is all ones but the off-diagonal elements
+    #  are less than 1.
+    # Diagonal terms are all 1's because we are computing
+    # <Ψ|C_i C_i|Ψ> = <Ψ|Ψ> = 1
+    assert np.allclose(np.diag(np.diag(S)), np.eye(16))
+    # Check that all off diagonal entries of S are the same and less than 1
+    # Off diagonal terms are less than 1 because we are computing <Ψ|C_i C_j|Ψ>
+    # = <Ψ|C_k|Ψ> < 1 (since |Ψ> was rotated a bit from the logical subspace)
+    # All off diagonal terms are the same because of the symmetry of the
+    # total depolarizing noise.
+    off_diag_elements = S[np.where(~np.eye(16, dtype=bool))]
+    np.allclose(off_diag_elements, off_diag_elements[0])
+    assert off_diag_elements[0] < 1
+
+
+def test_compute_hamiltonian_overlap_matrix():
+    qc, _ = prepare_logical_0_state_for_5_1_3_code()
+    (
+        check_operators,
+        code_hamiltonian,
+    ) = get_5_1_3_code_check_operators_and_code_hamiltonian()
+
+    # If we have a full set of check operators that form a group then all
+    # entries of the H matrix should be the same.
+    # H_jk = sum over all i's <Ψ|C_i|Ψ>
+
+    H = _compute_hamiltonian_overlap_matrix(
+        qc, execute_no_noise, check_operators, code_hamiltonian, {}
+    )
+    assert np.allclose(H, -16 * np.ones(16))
+
+    H = _compute_hamiltonian_overlap_matrix(
+        qc,
+        execute_with_depolarized_noise,
+        check_operators,
+        code_hamiltonian,
+        {},
+    )
+    assert np.allclose(H, H[0][0])
+    assert H[0][0].real > -16
+
+
+def get_5_1_3_code_check_operators_and_code_hamiltonian() -> tuple:
+    """
+    Returns the check operators and code Hamiltonian for the [[5,1,3]] code
+    The check operators are computed from the stabilizer generators:
+    (1+G1)(1+G2)(1+G3)(1+G4)  G = [XZZXI, IXZZX, XIXZZ, ZXIXZ]
+    source: https://en.wikipedia.org/wiki/Five-qubit_error_correcting_code
+    """
+    Ms = [
+        "YIYXX",
+        "ZIZYY",
+        "IXZZX",
+        "ZXIXZ",
+        "YYZIZ",
+        "XYIYX",
+        "YZIZY",
+        "ZZXIX",
+        "XZZXI",
+        "ZYYZI",
+        "IYXXY",
+        "IZYYZ",
+        "YXXYI",
+        "XXYIY",
+        "XIXZZ",
+        "IIIII",
+    ]
+    Ms_as_pauliStrings = [
+        PauliString(M, coeff=1, support=range(5)) for M in Ms
+    ]
+    negative_Ms_as_pauliStrings = [
+        PauliString(M, coeff=-1, support=range(5)) for M in Ms
+    ]
+    Hc = Observable(*negative_Ms_as_pauliStrings)
+    return Ms_as_pauliStrings, Hc
+
+
+def prepare_logical_0_state_for_5_1_3_code():
+    """
+    To simplify the testing logic. We hardcode the the logical 0 and logical 1
+    states of the [[5,1,3]] code, copied from:
+    https://en.wikipedia.org/wiki/Five-qubit_error_correcting_code
+    We then use Gram-Schmidt orthogonalization to fill up the rest of the
+    matrix with orthonormal vectors.
+    Following this we construct a circuit that has this matrix as its gate.
+    """
+
+    def gram_schmidt(
+        orthogonal_vecs: List[np.ndarray],
+    ) -> np.ndarray:
+        # normalize input
+        orthonormalVecs = [
+            vec / np.sqrt(np.vdot(vec, vec)) for vec in orthogonal_vecs
+        ]
+        dim = np.shape(orthogonal_vecs[0])[0]  # get dim of vector space
+        for i in range(dim - len(orthogonal_vecs)):
+            new_vec = np.zeros(dim)
+            new_vec[i] = 1  # construct ith basis vector
+            projs = sum(
+                [
+                    np.vdot(new_vec, cached_vec) * cached_vec
+                    for cached_vec in orthonormalVecs
+                ]
+            )  # sum of projections of new vec with all existing vecs
+            new_vec -= projs
+            orthonormalVecs.append(
+                new_vec / np.sqrt(np.vdot(new_vec, new_vec))
+            )
+        return np.reshape(orthonormalVecs, (32, 32)).T
+
+    logical_0_state = np.zeros(32)
+    for z in ["00000", "10010", "01001", "10100", "01010", "00101"]:
+        logical_0_state[int(z, 2)] = 1 / 4
+    for z in [
+        "11011",
+        "00110",
+        "11000",
+        "11101",
+        "00011",
+        "11110",
+        "01111",
+        "10001",
+        "01100",
+        "10111",
+    ]:
+        logical_0_state[int(z, 2)] = -1 / 4
+
+    logical_1_state = np.zeros(32)
+    for z in ["11111", "01101", "10110", "01011", "10101", "11010"]:
+        logical_1_state[int(z, 2)] = 1 / 4
+    for z in [
+        "00100",
+        "11001",
+        "00111",
+        "00010",
+        "11100",
+        "00001",
+        "10000",
+        "01110",
+        "10011",
+        "01000",
+    ]:
+        logical_1_state[int(z, 2)] = -1 / 4
+
+    # Fill up the rest of the matrix with orthonormal vectors
+    matrix = gram_schmidt([logical_0_state, logical_1_state])
+    circuit = cirq.Circuit()
+    g = cirq.MatrixGate(matrix)
+    qubits = cirq.LineQubit.range(5)
+    circuit.append(g(*qubits))
+    return circuit, qubits


### PR DESCRIPTION
closes #1811 

## Description

Implements main utility functions for QSE. Mainly computing the projector that will be used to project the errored state onto the logical subspace.

More information on how the projector is computed can be found in the [RFC](https://docs.google.com/document/d/1JyQAwiw8BRT_oucZ6tQv0id6UhSdd3df1mNSPpOvu1I/edit#heading=h.4wr9qx2m833b)

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [X] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [X] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [X] Added myself / the copyright holder to the AUTHORS file