### PR TITLE
Improve cost estimation for Calibrator

### DIFF
--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -181,7 +181,9 @@ class Calibrator:
             A summary of the number of circuits to be run.
         """
         num_circuits = len(self.problems)
-        num_options = len(self.settings.technique_params)
+        num_options = 0
+        for strategy in self.settings.make_strategies():
+            num_options += strategy.num_circuit_required()
 
         noisy = num_circuits * num_options
         ideal = 0  # TODO: ideal executor is currently unused

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -182,7 +182,7 @@ class Calibrator:
         """
         num_circuits = len(self.problems)
         num_options = sum(
-            strategy.num_circuit_required() for strategy in self.strategies
+            strategy.num_circuits_required() for strategy in self.strategies
         )
 
         noisy = num_circuits * num_options

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -181,9 +181,9 @@ class Calibrator:
             A summary of the number of circuits to be run.
         """
         num_circuits = len(self.problems)
-        num_options = 0
-        for strategy in self.settings.make_strategies():
-            num_options += strategy.num_circuit_required()
+        num_options = sum(
+            strategy.num_circuit_required() for strategy in self.strategies
+        )
 
         noisy = num_circuits * num_options
         ideal = 0  # TODO: ideal executor is currently unused

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -203,9 +203,7 @@ class Strategy:
         if self.technique is MitigationTechnique.ZNE:
             inference_func = self.technique_params["factory"]
             summary["factory"] = inference_func.__class__.__name__
-
             summary["scale_factors"] = inference_func._scale_factors
-
             summary["scale_method"] = self.technique_params[
                 "scale_noise"
             ].__name__

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -245,6 +245,8 @@ class Strategy:
             return len(summary["scale_factors"])
         elif self.technique is MitigationTechnique.PEC:
             return summary["num_samples"]
+        elif self.technique is MitigationTechnique.RAW:
+            return 1
         return 0
 
 

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -218,6 +218,7 @@ class Strategy:
             summary["is_qubit_dependent"] = self.technique_params[
                 "is_qubit_dependent"
             ]
+            summary["num_samples"] = self.technique_params["num_samples"]
         return summary
 
     def print_line(self, performance: str, circuit_type: str) -> None:
@@ -244,7 +245,9 @@ class Strategy:
         summary = self.to_dict()
         if self.technique is MitigationTechnique.ZNE:
             return len(summary["scale_factors"])
-        # TODO: elif self.technique is MitigationTechnique.PEC:
+        elif self.technique is MitigationTechnique.PEC:
+            return summary["num_samples"]
+            
 
 
 class Settings:

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -247,6 +247,7 @@ class Strategy:
             return len(summary["scale_factors"])
         elif self.technique is MitigationTechnique.PEC:
             return summary["num_samples"]
+        return 0
             
 
 

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -154,7 +154,7 @@ class Strategy:
             summary["factory"] = inference_func.__class__.__name__
             summary[
                 "scale_factors"
-            ] = inference_func.get_scale_factors().tolist()
+            ] = inference_func._scale_factors
             summary["scale_method"] = self.technique_params[
                 "scale_noise"
             ].__name__
@@ -180,6 +180,12 @@ class Strategy:
 
     def __repr__(self) -> str:
         return str(self.to_dict())
+    
+    def num_circuit_required(self) -> int:
+        summary = self.to_dict()
+        if self.technique is MitigationTechnique.ZNE:
+            return len(summary["scale_factors"])
+        # TODO: elif self.technique is MitigationTechnique.PEC:
 
 
 class Settings:

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -241,7 +241,7 @@ class Strategy:
     def __repr__(self) -> str:
         return str(self.to_dict())
 
-    def num_circuit_required(self) -> int:
+    def num_circuits_required(self) -> int:
         summary = self.to_dict()
         if self.technique is MitigationTechnique.ZNE:
             return len(summary["scale_factors"])

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -247,7 +247,7 @@ class Strategy:
             return summary["num_samples"]
         elif self.technique is MitigationTechnique.RAW:
             return 1
-        return 0
+        return None
 
 
 class Settings:

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -240,7 +240,7 @@ class Strategy:
 
     def __repr__(self) -> str:
         return str(self.to_dict())
-    
+
     def num_circuit_required(self) -> int:
         summary = self.to_dict()
         if self.technique is MitigationTechnique.ZNE:
@@ -248,7 +248,6 @@ class Strategy:
         elif self.technique is MitigationTechnique.PEC:
             return summary["num_samples"]
         return 0
-            
 
 
 class Settings:

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -173,7 +173,7 @@ def test_PEC_workflow():
         depolarizing_execute, frontend="cirq", settings=PECSettings
     )
     cost = cal.get_cost()
-    assert cost == {"noisy_executions": 1600, "ideal_executions": 0}
+    assert cost == {"noisy_executions": 4 * 2 * 200, "ideal_executions": 0}
 
     cal.run()
     assert isinstance(cal.results, ExperimentResults)
@@ -193,7 +193,7 @@ def test_ZNE_workflow_multi_platform(circuit_type):
         settings=light_zne_settings,
     )
     cost = cal.get_cost()
-    assert cost == {"noisy_executions": 4, "ideal_executions": 0}
+    assert cost == {"noisy_executions": 2 * 2, "ideal_executions": 0}
     cal.run()
     assert isinstance(cal.results, ExperimentResults)
     assert isinstance(cal.best_strategy(), Strategy)
@@ -212,7 +212,7 @@ def test_PEC_workflow_multi_platform(circuit_type):
         settings=light_pec_settings,
     )
     cost = cal.get_cost()
-    assert cost == {"noisy_executions": 400, "ideal_executions": 0}
+    assert cost == {"noisy_executions": 2 * 200, "ideal_executions": 0}
     cal.run()
     assert isinstance(cal.results, ExperimentResults)
     assert isinstance(cal.best_strategy(), Strategy)

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -174,12 +174,10 @@ def test_PEC_workflow():
         depolarizing_execute, frontend="cirq", settings=PECSettings
     )
     cost = cal.get_cost()
-    assert cost == {"noisy_executions": 8, "ideal_executions": 0}
+    assert cost == {"noisy_executions": 1600, "ideal_executions": 0}
 
     cal.run()
-    num_strategies, num_problems = cal.results.mitigated.shape
-    num_results = num_strategies * num_problems
-    assert num_results == cost["noisy_executions"]
+    
     assert isinstance(cal.results, ExperimentResults)
     assert isinstance(cal.best_strategy(), Strategy)
 
@@ -197,11 +195,9 @@ def test_ZNE_workflow_multi_platform(circuit_type):
         settings=light_zne_settings,
     )
     cost = cal.get_cost()
-    assert cost == {"noisy_executions": 2, "ideal_executions": 0}
+    assert cost == {"noisy_executions": 4, "ideal_executions": 0}
     cal.run()
-    num_strategies, num_problems = cal.results.mitigated.shape
-    num_results = num_strategies * num_problems
-    assert num_results == cost["noisy_executions"]
+    
     assert isinstance(cal.results, ExperimentResults)
     assert isinstance(cal.best_strategy(), Strategy)
 
@@ -219,7 +215,7 @@ def test_PEC_workflow_multi_platform(circuit_type):
         settings=light_pec_settings,
     )
     cost = cal.get_cost()
-    assert cost == {"noisy_executions": 4, "ideal_executions": 0}
+    assert cost == {"noisy_executions": 400, "ideal_executions": 0}
     cal.run()
     
     assert isinstance(cal.results, ExperimentResults)

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -112,9 +112,7 @@ def test_ZNE_workflow():
     assert cost == {"noisy_executions": 96, "ideal_executions": 0}
 
     cal.run()
-    num_strategies, num_problems = cal.results.mitigated.shape
-    num_results = num_strategies * num_problems
-    assert num_results == cost["noisy_executions"]
+    
     assert isinstance(cal.results, ExperimentResults)
     assert isinstance(cal.best_strategy(), Strategy)
 
@@ -134,9 +132,7 @@ def test_ZNE_workflow_multi_platform(circuit_type):
     cost = cal.get_cost()
     assert cost == {"noisy_executions": 4, "ideal_executions": 0}
     cal.run()
-    num_strategies, num_problems = cal.results.mitigated.shape
-    num_results = num_strategies * num_problems
-    assert num_results == cost["noisy_executions"]
+    
     assert isinstance(cal.results, ExperimentResults)
     assert isinstance(cal.best_strategy(), Strategy)
 

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -164,7 +164,6 @@ def test_ZNE_workflow():
     assert cost == {"noisy_executions": 96, "ideal_executions": 0}
 
     cal.run()
-    
     assert isinstance(cal.results, ExperimentResults)
     assert isinstance(cal.best_strategy(), Strategy)
 
@@ -177,7 +176,6 @@ def test_PEC_workflow():
     assert cost == {"noisy_executions": 1600, "ideal_executions": 0}
 
     cal.run()
-    
     assert isinstance(cal.results, ExperimentResults)
     assert isinstance(cal.best_strategy(), Strategy)
 
@@ -197,7 +195,6 @@ def test_ZNE_workflow_multi_platform(circuit_type):
     cost = cal.get_cost()
     assert cost == {"noisy_executions": 4, "ideal_executions": 0}
     cal.run()
-    
     assert isinstance(cal.results, ExperimentResults)
     assert isinstance(cal.best_strategy(), Strategy)
 
@@ -217,7 +214,6 @@ def test_PEC_workflow_multi_platform(circuit_type):
     cost = cal.get_cost()
     assert cost == {"noisy_executions": 400, "ideal_executions": 0}
     cal.run()
-    
     assert isinstance(cal.results, ExperimentResults)
     assert isinstance(cal.best_strategy(), Strategy)
 

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -161,7 +161,7 @@ def non_cirq_depolarizing_execute(circuit):
 def test_ZNE_workflow():
     cal = Calibrator(damping_execute, frontend="cirq")
     cost = cal.get_cost()
-    assert cost == {"noisy_executions": 96, "ideal_executions": 0}
+    assert cost == {"noisy_executions": 8 * 3 * 4, "ideal_executions": 0}
 
     cal.run()
     assert isinstance(cal.results, ExperimentResults)

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -109,7 +109,7 @@ def non_cirq_execute(circuit):
 def test_ZNE_workflow():
     cal = Calibrator(execute, frontend="cirq")
     cost = cal.get_cost()
-    assert cost == {"noisy_executions": 32, "ideal_executions": 0}
+    assert cost == {"noisy_executions": 96, "ideal_executions": 0}
 
     cal.run()
     num_strategies, num_problems = cal.results.mitigated.shape
@@ -132,7 +132,7 @@ def test_ZNE_workflow_multi_platform(circuit_type):
         settings=light_settings,
     )
     cost = cal.get_cost()
-    assert cost == {"noisy_executions": 2, "ideal_executions": 0}
+    assert cost == {"noisy_executions": 4, "ideal_executions": 0}
     cal.run()
     num_strategies, num_problems = cal.results.mitigated.shape
     num_results = num_strategies * num_problems
@@ -144,7 +144,7 @@ def test_ZNE_workflow_multi_platform(circuit_type):
 def test_get_cost():
     cal = Calibrator(execute, frontend="cirq", settings=settings)
     cost = cal.get_cost()
-    expected_cost = 2 * 4  # circuits * num_experiments
+    expected_cost = 2 * 12  # circuits * num_experiments
     assert cost["noisy_executions"] == expected_cost
     assert cost["ideal_executions"] == 0
 

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -305,3 +305,12 @@ def test_to_dict():
         "factory": "LinearFactory",
         "scale_factors": [1.0, 2.0],
     }
+
+
+def test_num_circuits_required():
+    undefine_strategy = Strategy(
+            id = 1,
+            technique = MitigationTechnique.RAW,
+            technique_params = {},
+    )
+    assert undefine_strategy.num_circuits_required() == 0

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -309,8 +309,8 @@ def test_to_dict():
 
 def test_num_circuits_required():
     undefine_strategy = Strategy(
-            id = 1,
-            technique = MitigationTechnique.RAW,
-            technique_params = {},
+        id=1,
+        technique=MitigationTechnique.RAW,
+        technique_params={},
     )
     assert undefine_strategy.num_circuits_required() == 0

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -295,7 +295,7 @@ def test_to_dict():
         ],
         "is_qubit_dependent": False,
         "noise_level": 0.001,
-        "num_samples": 200
+        "num_samples": 200,
     }
 
     zne_strategy = light_zne_settings.make_strategies()[0]

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -295,6 +295,7 @@ def test_to_dict():
         ],
         "is_qubit_dependent": False,
         "noise_level": 0.001,
+        "num_samples": 200
     }
 
     zne_strategy = light_zne_settings.make_strategies()[0]

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -307,10 +307,10 @@ def test_to_dict():
     }
 
 
-def test_num_circuits_required():
+def test_num_circuits_required_raw_execution():
     undefine_strategy = Strategy(
         id=1,
         technique=MitigationTechnique.RAW,
         technique_params={},
     )
-    assert undefine_strategy.num_circuits_required() == 0
+    assert undefine_strategy.num_circuits_required() == 1


### PR DESCRIPTION
Link to the issue:
Fixes #1715 Improve the cost estimation to run a Calibrator


## Description
1 Add `num_circuits_required()` method to Strategy to count the number of circuits for ZNE and PEC

2 Modify `get_cost()` in calibrator using `num_circuits_required()`

3 Modify `to_dict` in Strategy so that it can actually return scale_factors for ZNE and return num_samples for PEC
<!-- Please explain the changes you made here. -->

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] Added myself / the copyright holder to the AUTHORS file