### PR TITLE
Add Calibration logging for PEC

### DIFF
--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -33,9 +33,9 @@ ZNE_TABLE_HEADER_STR = (
 )
 
 PEC_TABLE_HEADER_STR = (
-    "| performance | circuit | method | "
-    "representation function | operations to mitigate | noise level | "
-    " qubit dependent |\n"
+    "| performance | circuit | method "
+    "| representation function | operations to mitigate | noise level "
+    "| qubit dependent |\n"
     "| ----------- | ------- | ------ | ----------------------- "
     "| ---------------------- | ----------- | --------------- | "
 )
@@ -231,8 +231,10 @@ class Calibrator:
                 if (
                     log
                     and count
-                    and (strategy.technique
-                    is not self.strategies[count - 1].technique)
+                    and (
+                        strategy.technique
+                        is not self.strategies[count - 1].technique
+                    )
                 ):
                     if strategy.technique is MitigationTechnique.ZNE:
                         print(ZNE_TABLE_HEADER_STR)

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -34,10 +34,10 @@ TABLE_HEADER_STR_ZNE = (
 
 TABLE_HEADER_STR_PEC = (
     "| performance | circuit | method | "
-    "representation function | noise level | noise bias factor "
-    "| qubit dependent |\n"
-    "| ----------- | ------- | ------ | ----------------------- | ----------- "
-    "| ----------------- | --------------- | "
+    "representation function | operations to mitigate | noise level | "
+    " qubit dependent |\n"
+    "| ----------- | ------- | ------ | ----------------------- "
+    "| ---------------------- | ----------- | --------------- | "
 )
 
 

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -25,14 +25,14 @@ from mitiq.calibration.settings import (
 )
 from mitiq.interface import convert_from_mitiq
 
-TABLE_HEADER_STR_ZNE = (
+ZNE_TABLE_HEADER_STR = (
     "| performance | circuit | method | extrapolation | scale factors "
     "| scale_method         |\n"
     "| ----------- | ------- | ------ | ------------- | ------------- "
     "| -------------------- |"
 )
 
-TABLE_HEADER_STR_PEC = (
+PEC_TABLE_HEADER_STR = (
     "| performance | circuit | method | "
     "representation function | operations to mitigate | noise level | "
     " qubit dependent |\n"
@@ -208,9 +208,9 @@ class Calibrator:
 
         if log:
             if self.strategies[0].technique is MitigationTechnique.ZNE:
-                print(TABLE_HEADER_STR_ZNE)
+                print(ZNE_TABLE_HEADER_STR)
             elif self.strategies[0].technique is MitigationTechnique.PEC:
-                print(TABLE_HEADER_STR_PEC)
+                print(PEC_TABLE_HEADER_STR)
 
         for problem in self.problems:
             # Benchmark circuits have no measurements, so we append them.
@@ -231,13 +231,13 @@ class Calibrator:
                 if (
                     log
                     and count
-                    and strategy.technique
-                    is not self.strategies[count - 1].technique
+                    and (strategy.technique
+                    is not self.strategies[count - 1].technique)
                 ):
                     if strategy.technique is MitigationTechnique.ZNE:
-                        print(TABLE_HEADER_STR_ZNE)
+                        print(ZNE_TABLE_HEADER_STR)
                     elif strategy.technique is MitigationTechnique.PEC:
-                        print(TABLE_HEADER_STR_PEC)
+                        print(PEC_TABLE_HEADER_STR)
                 self.results.add_result(
                     strategy,
                     problem,

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -34,10 +34,9 @@ ZNE_TABLE_HEADER_STR = (
 
 PEC_TABLE_HEADER_STR = (
     "| performance | circuit | method "
-    "| representation function | operations to mitigate | noise level "
-    "| qubit dependent |\n"
+    "| representation function | operations to mitigate | noise level |\n"
     "| ----------- | ------- | ------ | ----------------------- "
-    "| ---------------------- | ----------- | --------------- | "
+    "| ---------------------- | ----------- | "
 )
 
 
@@ -206,12 +205,6 @@ class Calibrator:
         if not self.results.is_missing_data():
             self.results.reset_data()
 
-        if log:
-            if self.strategies[0].technique is MitigationTechnique.ZNE:
-                print(ZNE_TABLE_HEADER_STR)
-            elif self.strategies[0].technique is MitigationTechnique.PEC:
-                print(PEC_TABLE_HEADER_STR)
-
         for problem in self.problems:
             # Benchmark circuits have no measurements, so we append them.
             circuit = problem.circuit.copy()
@@ -228,13 +221,13 @@ class Calibrator:
                     mitigated_value = strategy.mitigation_function(
                         circuit, expval_executor
                     )
-                if (
-                    log
-                    and count
+                if log and (
+                    count
                     and (
                         strategy.technique
                         is not self.strategies[count - 1].technique
                     )
+                    or not count
                 ):
                     if strategy.technique is MitigationTechnique.ZNE:
                         print(ZNE_TABLE_HEADER_STR)

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -197,20 +197,17 @@ class Strategy:
             summary["scale_method"] = self.technique_params[
                 "scale_noise"
             ].__name__
+
         elif self.technique is MitigationTechnique.PEC:
             summary["representation_function"] = self.technique_params[
                 "representation_function"
             ]
             summary["noise_level"] = self.technique_params["noise_level"]
-            summary["is_qubit_dependent"] = self.technique_params[
-                "is_qubit_dependent"
-            ]
-            summary["num_samples"] = self.technique_params["num_samples"]
         return summary
 
     def print_line(self, performance: str, circuit_type: str) -> None:
-        summary = self.to_dict()
         if self.technique is MitigationTechnique.ZNE:
+            summary = self.to_dict()
             str_scale_factors = str(summary["scale_factors"])[1:-1]
             row = (
                 performance,
@@ -220,20 +217,22 @@ class Strategy:
                 str_scale_factors,
                 summary["scale_method"],
             )
+            print(
+                "| {:^10} | {:^7} | {:^6} | {:<13} | {:<13} | {:<20} |".format(
+                    *row
+                )
+            )
         elif self.technique is MitigationTechnique.PEC:
+            summary = self.to_dict()
             row = (
                 performance,
                 circuit_type,
                 self.technique.name,
-                str(summary["representation_function"])[35:54],
-                summary["noise_level"],
-                str(summary["num_samples"]),
+                summary["representation_function"],
+                str(summary["operations"]),
+                str(summary["noise_level"]),
             )
-        print(
-            "| {:^10} | {:^7} | {:^6} | {:<13} | {:<13} | {:<20} |".format(
-                *row
-            )
-        )
+            print(row)
 
     def __repr__(self) -> str:
         return str(self.to_dict())

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -232,8 +232,8 @@ class Strategy:
                 performance,
                 circuit_type,
                 self.technique.name,
-                summary["representation_function"],
-                str(summary["operations"]),
+                str(summary["representation_function"].__name__),
+                str(list(s.all_operations() for s in summary["operations"])),
                 str(summary["noise_level"]),
             )
             print(row)

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -203,6 +203,10 @@ class Strategy:
                 "representation_function"
             ]
             summary["noise_level"] = self.technique_params["noise_level"]
+            summary["is_qubit_dependent"] = self.technique_params[
+                "is_qubit_dependent"
+            ]
+            summary["num_samples"] = self.technique_params["num_samples"]
         return summary
 
     def print_line(self, performance: str, circuit_type: str) -> None:

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -239,11 +239,10 @@ class Strategy:
                 str(summary["representation_function"].__name__),
                 str(ops),
                 summary["noise_level"],
-                str(summary["is_qubit_dependent"]),
             )
             print(
                 "| {:^10} | {:^7} | {:^6} | {:<13} | "
-                "{:<60} | {:<11} |  {:<13} |".format(*row)
+                "{:<60} | {:<11} |".format(*row)
             )
 
     def __repr__(self) -> str:

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -12,7 +12,7 @@ import networkx as nx
 import cirq
 
 from mitiq import QPROGRAM, Executor
-from mitiq.interface import convert_from_mitiq
+from mitiq.interface import convert_from_mitiq, convert_to_mitiq
 from mitiq.benchmarks import (
     generate_ghz_circuit,
     generate_mirror_circuit,
@@ -228,15 +228,23 @@ class Strategy:
             )
         elif self.technique is MitigationTechnique.PEC:
             summary = self.to_dict()
+            ops = list(
+                list(convert_to_mitiq(op)[0].all_operations())
+                for op in summary["operations"]
+            )
             row = (
                 performance,
                 circuit_type,
                 self.technique.name,
                 str(summary["representation_function"].__name__),
-                str(list(s.all_operations() for s in summary["operations"])),
-                str(summary["noise_level"]),
+                str(ops),
+                summary["noise_level"],
+                str(summary["is_qubit_dependent"]),
             )
-            print(row)
+            print(
+                "| {:^10} | {:^7} | {:^6} | {:<13} | "
+                "{:<60} | {:<11} |  {:<13} |".format(*row)
+            )
 
     def __repr__(self) -> str:
         return str(self.to_dict())

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -18,8 +18,8 @@ from mitiq.calibration import (
     execute_with_mitigation,
 )
 from mitiq.calibration.calibrator import (
-    TABLE_HEADER_STR_PEC,
-    TABLE_HEADER_STR_ZNE,
+    PEC_TABLE_HEADER_STR,
+    ZNE_TABLE_HEADER_STR,
     convert_to_expval_executor,
     ExperimentResults,
     MissingResultsError,
@@ -420,11 +420,11 @@ def test_logging(capfd, settings):
     assert "circuit" in captured.out
     assert settings.get_strategy(0).technique.name in captured.out
     if settings is ZNESettings:
-        assert TABLE_HEADER_STR_ZNE in captured.out
+        assert ZNE_TABLE_HEADER_STR in captured.out
     elif settings is light_pec_settings:
-        assert TABLE_HEADER_STR_PEC in captured.out
+        assert PEC_TABLE_HEADER_STR in captured.out
     elif settings is [light_combined_settings1, light_combined_settings2]:
-        assert TABLE_HEADER_STR_ZNE, TABLE_HEADER_STR_PEC in captured.out
+        assert ZNE_TABLE_HEADER_STR, PEC_TABLE_HEADER_STR in captured.out
 
 
 def test_ExperimentResults_reset_data():

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -18,6 +18,8 @@ from mitiq.calibration import (
     execute_with_mitigation,
 )
 from mitiq.calibration.calibrator import (
+    TABLE_HEADER_STR_PEC,
+    TABLE_HEADER_STR_ZNE,
     convert_to_expval_executor,
     ExperimentResults,
     MissingResultsError,
@@ -358,9 +360,14 @@ def test_ExtrapolationResults_best_strategy():
 def test_logging(capfd, settings):
     cal = Calibrator(damping_execute, frontend="cirq", settings=settings)
     cal.run(log=True)
-
     captured = capfd.readouterr()
+    if settings is ZNESettings:
+        table_header_str = TABLE_HEADER_STR_ZNE
+    elif settings is PECSettings:
+        table_header_str = TABLE_HEADER_STR_PEC
     assert "circuit" in captured.out
+    assert (table_header_str) in captured.out
+    assert settings.get_strategy(1).technique.name in captured.out
 
 
 def test_ExperimentResults_reset_data():

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -379,6 +379,7 @@ light_combined_settings1 = Settings(
         },
     ],
 )
+
 light_combined_settings2 = Settings(
     benchmarks=light_zne_settings.benchmarks,
     strategies=[

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -36,6 +36,7 @@ from mitiq.zne.scaling import fold_global
 from mitiq.interface import convert_to_mitiq
 from mitiq.pec.representations import (
     represent_operation_with_local_depolarizing_noise,
+    represent_operation_with_local_biased_noise,
 )
 
 light_zne_settings = Settings(
@@ -77,10 +78,11 @@ light_pec_settings = Settings(
         {
             "technique": "pec",
             "representation_function": (
-                represent_operation_with_local_depolarizing_noise
+                represent_operation_with_local_biased_noise
             ),
             "is_qubit_dependent": False,
-            "noise_level": 0.001,
+            "noise_level": 0.01,
+            "noise_bias": 0.1,
             "num_samples": 200,
         },
     ],

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -27,6 +27,7 @@ from mitiq.calibration.settings import (
     Strategy,
     MitigationTechnique,
     BenchmarkProblem,
+    ZNESettings,
 )
 from mitiq.zne.inference import LinearFactory, RichardsonFactory
 from mitiq.zne.scaling import fold_global
@@ -353,8 +354,9 @@ def test_ExtrapolationResults_best_strategy():
     assert er.best_strategy_id() == 4
 
 
-def test_logging(capfd):
-    cal = Calibrator(damping_execute, frontend="cirq")
+@pytest.mark.parametrize("settings", [ZNESettings, PECSettings])
+def test_logging(capfd, settings):
+    cal = Calibrator(damping_execute, frontend="cirq", settings=settings)
     cal.run(log=True)
 
     captured = capfd.readouterr()

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -279,6 +279,7 @@ def test_to_dict():
         ),
         "is_qubit_dependent": False,
         "noise_level": 0.001,
+        "noise_bias": 0,
         "num_samples": 200,
     }
 


### PR DESCRIPTION
## Description

Add Calibration logging for PEC. 

Fixes #1861 

A mixture of ZNE and PEC strategies is also supported in a simple way, as the appropriate header is printed initially and when the current technique is different from the previous technique. 

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [X] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [X] Added myself / the copyright holder to the AUTHORS file