### PR TITLE
Ensure `execute_with_rem` works with Executor object

### DIFF
--- a/mitiq/rem/rem.py
+++ b/mitiq/rem/rem.py
@@ -40,6 +40,8 @@ def execute_with_rem(
     """
     if not isinstance(executor, Executor):
         executor_obj = Executor(executor)
+    else:
+        executor_obj = executor
 
     executor_with_rem = mitigate_executor(
         executor_obj, inverse_confusion_matrix=inverse_confusion_matrix

--- a/mitiq/rem/rem.py
+++ b/mitiq/rem/rem.py
@@ -7,7 +7,6 @@
 
 from typing import Callable, Union, List, Sequence, cast
 from types import MethodType
-from copy import deepcopy
 from functools import wraps
 import numpy as np
 import numpy.typing as npt
@@ -76,7 +75,7 @@ def mitigate_executor(
     if not isinstance(executor, Executor):
         executor_obj = Executor(executor)
     else:
-        executor_obj = deepcopy(executor)
+        executor_obj = executor
 
     def post_run(
         self: Executor,

--- a/mitiq/rem/tests/test_rem.py
+++ b/mitiq/rem/tests/test_rem.py
@@ -102,7 +102,7 @@ def test_rem_with_matrix():
 
     mitigated = execute_with_rem(
         circ,
-        noisy_executor,
+        Executor(noisy_executor),
         observable,
         inverse_confusion_matrix=inverse_confusion_matrix,
     )


### PR DESCRIPTION
## Description

This PR adds support for using an `Executor` object with `execute_with_rem`. In addition we've removed a call to deepcopy which we think is unnecessary. We also ensured that tests cover both cases of using an `Executor` and a user defined python function.

fixes https://github.com/unitaryfund/mitiq/issues/1876