### PR TITLE
Use latest copyright notice

### DIFF
--- a/mitiq/benchmarks/qpe_circuits.py
+++ b/mitiq/benchmarks/qpe_circuits.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2023 Unitary Fund
+# Copyright (C) Unitary Fund
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions to create a QPE circuit."""
 

--- a/mitiq/benchmarks/tests/test_qpe_circuits.py
+++ b/mitiq/benchmarks/tests/test_qpe_circuits.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2023 Unitary Fund
+# Copyright (C) Unitary Fund
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 
 """Tests for QPE benchmarking circuits."""

--- a/mitiq/benchmarks/tests/test_w_state_circuits.py
+++ b/mitiq/benchmarks/tests/test_w_state_circuits.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2023 Unitary Fund
+# Copyright (C) Unitary Fund
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for W-state benchmarking circuits."""
 

--- a/mitiq/benchmarks/w_state_circuits.py
+++ b/mitiq/benchmarks/w_state_circuits.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2023 Unitary Fund
+# Copyright (C) Unitary Fund
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions for creating a linear complexity W-state benchmarking circuit
 as defined in :cite:`Cruz_2019_Efficient`."""

--- a/mitiq/qse/__init__.py
+++ b/mitiq/qse/__init__.py
@@ -1,16 +1,6 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright (C) Unitary Fund
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 from mitiq.qse.qse_utils import get_projector

--- a/mitiq/qse/qse_utils.py
+++ b/mitiq/qse/qse_utils.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright (C) Unitary Fund
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions for computing the projector for subspace expansion."""
 

--- a/mitiq/qse/tests/test_subspace_expansion.py
+++ b/mitiq/qse/tests/test_subspace_expansion.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2021 Unitary Fund
+# Copyright (C) Unitary Fund
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Tests for the Quantum Subspace Expansion top level API."""
 

--- a/mitiq/zne/scaling/layer_scaling.py
+++ b/mitiq/zne/scaling/layer_scaling.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2023 Unitary Fund
+# Copyright (C) Unitary Fund
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Functions for layer-wise unitary folding on supported circuits."""
 from copy import deepcopy

--- a/mitiq/zne/scaling/tests/test_layer_scaling.py
+++ b/mitiq/zne/scaling/tests/test_layer_scaling.py
@@ -1,17 +1,7 @@
-# Copyright (C) 2023 Unitary Fund
+# Copyright (C) Unitary Fund
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
 
 """Unit tests for scaling by layer."""
 from cirq import (


### PR DESCRIPTION
## Description

Looks like we had a few changes/files get added after https://github.com/unitaryfund/mitiq/pull/1738 that didn't see the latest copyright notice. This PR ensures all files are consistent in the copyright notice that is being used.