### PR TITLE
Fix docstring of initialized_depolarized_noise

### DIFF
--- a/mitiq/interface/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/qiskit_utils.py
@@ -27,7 +27,7 @@ def initialized_depolarizing_noise(noise_level: float) -> NoiseModel:
     """Initializes a depolarizing noise Qiskit NoiseModel.
 
     Args:
-        noise_level: The noise strength as a float, e.g., 0.01 is 0.1%.
+        noise_level: The noise strength as a float, e.g., 0.01 is 1%.
 
     Returns:
         A Qiskit depolarizing NoiseModel.


### PR DESCRIPTION
Fixes #1918


### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
