### PR TITLE
fix `asv` benchmarks

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -152,7 +152,7 @@ def track_pec(
 
     compute_density_matrix = functools.partial(
         mitiq_cirq.compute_density_matrix,
-        noise_model=cirq.depolarize,
+        noise_model_function=cirq.depolarize,
         noise_level=(noise_level,),
     )
 


### PR DESCRIPTION
## Description

Does what it says on the 🥫.

### Log

In https://github.com/unitaryfund/mitiq/pull/1825 I renamed a keyword argument in [`mitiq_cirq.compute_density_matrix`](https://github.com/unitaryfund/mitiq/blob/9e8c6194b353dea03985976247fd2aca9d5c0167/mitiq/interface/mitiq_cirq/cirq_utils.py#L53). I missed this update when making the changes as I don't often check `asv`/benchmarks.

---

No need for double review, I've just assigned both of y'all since you will be on earlier than me. If this looks good, feel free to merge.