### PR TITLE
[Classical Shadow 1] Minor Updates to the Quantum Processing Functions to adjust for robust shadow.

### DIFF
--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -103,9 +103,9 @@ def random_pauli_measurement(
     Returns:
         Tuple containing two lists of strings, each of length equal to
         ``n_total_measurements``. Strings in the first list are sequences of
-        0's and 1's, which represent qubit measurements in the computational
-        basis (e.g. "01001"). Strings in the second list are sequences of
-        Pauli-measurement performed on each qubit (e.g. "XZZYY").
+        0's and 1's, which represent qubit measurements outcomes in the
+        computational basis (e.g. "01001"). Strings in the second list are
+        sequences of Pauli-measurement performed on each qubit (e.g. "XZZYY").
     """
 
     qubits = sorted(list(circuit.all_qubits())) if qubits is None else qubits

--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Quantum processing functions for classical shadows."""
-from typing import Tuple, Callable, List, Optional
+from typing import Tuple, Callable, List, Optional, Sequence
 
 import cirq
 import numpy as np
@@ -84,30 +84,33 @@ def random_pauli_measurement(
     executor: Callable[[cirq.Circuit], MeasurementResult],
     qubits: Optional[List[cirq.Qid]] = None,
 ) -> Tuple[List[str], List[str]]:
-    r"""
-    Given a circuit, perform random Pauli measurements on the circuit and
-    return outcomes. The outcomes are represented as a tuple of two lists of
-    strings.
+    r"""This function performs random Pauli measurements on a given circuit and
+    returns the outcomes. These outcomes are represented as a tuple of two
+    lists of strings.
 
     Args:
-        circuit: Cirq circuit.
-        n_total_measurements: number of snapshots.
-        executor: A callable which runs a circuit and returns a single
+        circuit: A Cirq circuit.
+        n_total_measurements: The number of snapshots.
+        executor: A callable that runs a circuit and returns a single
             bitstring.
-        qubits: The qubits to measure. If None, all qubits in the circuit
+        qubits: The qubits to be measured. If None, all qubits in the circuit
+            will be measured.
 
     Warning:
-        The ``executor`` must return a ``MeasurementResult``
-        for a single shot (i.e. a single bitstring).
+        The `executor` must return a `MeasurementResult` for a single shot,
+        i.e., a single bitstring.
 
     Returns:
-        Tuple of two list of string of length equals to`n_total_meausrements`,
-        where each element in the list is a string, with the following format:
-        strs in the 1st list: Circuit qubits computational basis
-        e.g. :math:`"01..":=|0\rangle|1\rangle..`.
-        strs in the 2ed list: The local Pauli measurement performed on each
-        qubit. e.g."XY.." means perform local X-basis measurement on the
-        1st qubit, local Y-basis measurement the 2ed qubit in the circuit.
+        A tuple of two lists of strings, each of length equal to
+        `n_total_measurements`. Each element in the list is a string, formatted
+        as follows:
+        - First list: The computational basis of
+        circuit qubits, e.g.
+        "01...1"=:math:`|0\rangle |1\rangle...|1\rangle`.
+        - Second list: The local Pauli measurement performed on each qubit.
+        e.g. "XY...Z" signifies a local X-basis measurement on the
+        first qubit, a local Y-basis measurement on the second qubit,
+        and a local Z-basis measurement on the last qubit in the circuit.
     """
 
     qubits = sorted(list(circuit.all_qubits())) if qubits is None else qubits

--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -106,9 +106,9 @@ def random_pauli_measurement(
         as follows:
         - First list: The computational basis of
         circuit qubits, e.g.
-        "01...1"=:math:`|0\rangle |1\rangle...|1\rangle`.
+        '01...1'=:math:`|0\rangle |1\rangle...|1\rangle`.
         - Second list: The local Pauli measurement performed on each qubit.
-        e.g. "XY...Z" signifies a local X-basis measurement on the
+        e.g. 'XY...Z' signifies a local X-basis measurement on the
         first qubit, a local Y-basis measurement on the second qubit,
         and a local Z-basis measurement on the last qubit in the circuit.
     """

--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -97,20 +97,15 @@ def random_pauli_measurement(
             will be measured.
 
     Warning:
-        The `executor` must return a `MeasurementResult` for a single shot,
+        The ``executor`` must return a ``MeasurementResult`` for a single shot,
         i.e., a single bitstring.
 
     Returns:
-        A tuple of two lists of strings, each of length equal to
-        `n_total_measurements`. Each element in the list is a string, formatted
-        as follows:
-        - First list: The computational basis of
-        circuit qubits, e.g.
-        '01...1'=:math:`|0\rangle |1\rangle...|1\rangle`.
-        - Second list: The local Pauli measurement performed on each qubit.
-        e.g. 'XY...Z' signifies a local X-basis measurement on the
-        first qubit, a local Y-basis measurement on the second qubit,
-        and a local Z-basis measurement on the last qubit in the circuit.
+        Tuple containing two lists of strings, each of length equal to
+        ``n_total_measurements``. Strings in the first list are sequences of 0's
+        and 1's, which represent qubit measurements in the computational basis
+        (e.g. "01001"). Strings in the second list are sequences of Pauli
+        operators performed on the circuit (e.g. "XZZII").
     """
 
     qubits = sorted(list(circuit.all_qubits())) if qubits is None else qubits

--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -40,7 +40,7 @@ def get_rotated_circuits(
     circuit: cirq.Circuit,
     pauli_strings: List[str],
     add_measurements: bool = True,
-    qubits: Optional[List[cirq.Qid]] = None,
+    qubits: Optional[Sequence[cirq.Qid]] = None,
 ) -> List[cirq.Circuit]:
     """Returns a list of circuits that are identical to the input circuit,
     except that each one has single-qubit Clifford gates followed by

--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -93,8 +93,8 @@ def random_pauli_measurement(
         n_total_measurements: The number of snapshots.
         executor: A callable that runs a circuit and returns a single
             bitstring.
-        qubits: The qubits to be measured. If None, all qubits in the circuit
-            will be measured.
+        qubits: The qubits in the circuit to be measured. If None,
+            all qubits in the circuit will be measured.
 
     Warning:
         The ``executor`` must return a ``MeasurementResult`` for a single shot,
@@ -105,7 +105,7 @@ def random_pauli_measurement(
         ``n_total_measurements``. Strings in the first list are sequences of
         0's and 1's, which represent qubit measurements in the computational
         basis (e.g. "01001"). Strings in the second list are sequences of
-        Pauli operators performed on the circuit (e.g. "XZZII").
+        Pauli-measurement performed on each qubit (e.g. "XZZYY").
     """
 
     qubits = sorted(list(circuit.all_qubits())) if qubits is None else qubits

--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -4,7 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 """Quantum processing functions for classical shadows."""
-from typing import Tuple, Callable, Any, List, Optional
+from typing import Tuple, Callable, List, Optional
+
 import cirq
 import numpy as np
 

--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -102,10 +102,10 @@ def random_pauli_measurement(
 
     Returns:
         Tuple containing two lists of strings, each of length equal to
-        ``n_total_measurements``. Strings in the first list are sequences of 0's
-        and 1's, which represent qubit measurements in the computational basis
-        (e.g. "01001"). Strings in the second list are sequences of Pauli
-        operators performed on the circuit (e.g. "XZZII").
+        ``n_total_measurements``. Strings in the first list are sequences of
+        0's and 1's, which represent qubit measurements in the computational
+        basis (e.g. "01001"). Strings in the second list are sequences of
+        Pauli operators performed on the circuit (e.g. "XZZII").
     """
 
     qubits = sorted(list(circuit.all_qubits())) if qubits is None else qubits

--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -51,7 +51,7 @@ def get_rotated_circuits(
         circuit: The circuit to measure.
         pauli_strings: The Pauli strings to measure in each output circuit.
         add_measurements: Whether to add measurement gates to the circuit.
-        qubits: The qubits to measure. If None, all qubits in the circuit
+        qubits: The qubits to measure. If None, all qubits in the circuit.
     Returns:
          The list of circuits with rotation and measurement gates appended.
     """

--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -104,11 +104,12 @@ def random_pauli_measurement(
         Tuple of two list of string of length equals to`n_total_meausrements`,
         where each element in the list is a string, with the following format:
         strs in the 1st list: Circuit qubits computational basis
-            e.g. :math:`"01..":=|0\rangle|1\rangle..`.
-        strs in the 1st list: The local Pauli measurement performed on each
-            qubit. e.g."XY.." means perform local X-basis measurement on the
-            1st qubit, local Y-basis measurement the 2ed qubit in the circuit.
+        e.g. :math:`"01..":=|0\rangle|1\rangle..`.
+        strs in the 2ed list: The local Pauli measurement performed on each
+        qubit. e.g."XY.." means perform local X-basis measurement on the
+        1st qubit, local Y-basis measurement the 2ed qubit in the circuit.
     """
+
     qubits = sorted(list(circuit.all_qubits())) if qubits is None else qubits
     num_qubits = len(qubits)
     pauli_strings = generate_random_pauli_strings(

--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -10,7 +10,7 @@ import cirq
 import numpy as np
 
 try:
-    from tqdm.auto import tqdm
+    from tqdm import tqdm
 except ImportError:
     tqdm = None
 

--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -4,11 +4,9 @@
 # LICENSE file in the root directory of this source tree.
 
 """Quantum processing functions for classical shadows."""
-from typing import Tuple, Callable, Any, List
-
+from typing import Tuple, Callable, Any, List, Optional
 import cirq
 import numpy as np
-from numpy.typing import NDArray
 
 try:
     from tqdm.auto import tqdm
@@ -41,6 +39,7 @@ def get_rotated_circuits(
     circuit: cirq.Circuit,
     pauli_strings: List[str],
     add_measurements: bool = True,
+    qubits: Optional[List[cirq.Qid]] = None,
 ) -> List[cirq.Circuit]:
     """Returns a list of circuits that are identical to the input circuit,
     except that each one has single-qubit Clifford gates followed by
@@ -51,11 +50,11 @@ def get_rotated_circuits(
         circuit: The circuit to measure.
         pauli_strings: The Pauli strings to measure in each output circuit.
         add_measurements: Whether to add measurement gates to the circuit.
-
+        qubits: The qubits to measure. If None, all qubits in the circuit
     Returns:
          The list of circuits with rotation and measurement gates appended.
     """
-    qubits = sorted(list(circuit.all_qubits()))
+    qubits = sorted(list(circuit.all_qubits())) if qubits is None else qubits
     rotated_circuits = []
     for pauli_string in pauli_strings:
         rotated_circuit = circuit.copy()
@@ -82,44 +81,47 @@ def random_pauli_measurement(
     circuit: cirq.Circuit,
     n_total_measurements: int,
     executor: Callable[[cirq.Circuit], MeasurementResult],
-) -> Tuple[NDArray[Any], NDArray[Any]]:
+    qubits: Optional[List[cirq.Qid]] = None,
+) -> Tuple[List[str], List[str]]:
     r"""
     Given a circuit, perform random Pauli measurements on the circuit and
-    return outcomes. The outcomes are represented as a string where a
-    z-basis measurement outcome of :math:`|0\rangle` corresponds to 1, and
-    :math:`|1\rangle` corresponds to -1.
+    return outcomes. The outcomes are represented as a tuple of two lists of
+    strings.
 
     Args:
         circuit: Cirq circuit.
         n_total_measurements: number of snapshots.
         executor: A callable which runs a circuit and returns a single
             bitstring.
+        qubits: The qubits to measure. If None, all qubits in the circuit
 
     Warning:
         The ``executor`` must return a ``MeasurementResult``
         for a single shot (i.e. a single bitstring).
 
     Returns:
-        Tuple of two numpy arrays. The first array contains
-        measurement outcomes (-1, 1) while the second array contains the
-        indices for the sampled Pauli's ("X", "Y", "Z").
-        This implies that local Clifford rotations plus z-basis measurements
-        are effectively equivalent to random Pauli measurements.
-        Each row of the arrays corresponds to a distinct snapshot or sample,
-        while each column corresponds to measurement outcomes
-        and random Pauli measurement on a different qubit.
+        Tuple of two list of string of length equals to`n_total_meausrements`,
+        where each element in the list is a string, with the following format:
+        strs in the 1st list: Circuit qubits computational basis
+            e.g. :math:`"01..":=|0\rangle|1\rangle..`.
+        strs in the 1st list: The local Pauli measurement performed on each
+            qubit. e.g."XY.." means perform local X-basis measurement on the
+            1st qubit, local Y-basis measurement the 2ed qubit in the circuit.
     """
-
-    num_qubits = len(circuit.all_qubits())
+    qubits = sorted(list(circuit.all_qubits())) if qubits is None else qubits
+    num_qubits = len(qubits)
     pauli_strings = generate_random_pauli_strings(
         num_qubits, n_total_measurements
     )
 
     # Rotate and attach measurement gates to the circuit
     rotated_circuits = get_rotated_circuits(
-        circuit,
-        pauli_strings,
+        circuit=circuit,
+        pauli_strings=pauli_strings,
+        add_measurements=True,
+        qubits=qubits,
     )
+
     if tqdm is not None:
         rotated_circuits = tqdm(
             rotated_circuits,
@@ -130,7 +132,6 @@ def random_pauli_measurement(
         executor(rotated_circuit) for rotated_circuit in rotated_circuits
     ]
 
-    # Transform the outcomes into a numpy array 0 -> 1, 1 -> -1.
     shadow_outcomes = []
     for result in results:
         bitstring = list(result.get_counts().keys())[0]
@@ -139,11 +140,6 @@ def random_pauli_measurement(
                 "The `executor` must return a `MeasurementResult` "
                 "for a single shot"
             )
+        shadow_outcomes.append(bitstring)
 
-        outcome = [1 - int(i) * 2 for i in bitstring]
-        shadow_outcomes.append(outcome)
-
-    shadow_outcomes_np = np.asarray(shadow_outcomes, dtype=int)
-    pauli_strings_np = np.asarray(pauli_strings, dtype=str)
-
-    return shadow_outcomes_np, pauli_strings_np
+    return shadow_outcomes, pauli_strings

--- a/mitiq/shadows/test/test_quantum_processing.py
+++ b/mitiq/shadows/test/test_quantum_processing.py
@@ -159,17 +159,15 @@ def test_random_pauli_measurement_output_dimensions(
     shadow_outcomes, pauli_strings = random_pauli_measurement(
         circuit, n_total_measurements, executor=executor
     )
-    assert shadow_outcomes.shape == (n_total_measurements, n_qubits), (
+    shadow_outcomes_shape = len(shadow_outcomes), len(shadow_outcomes[0])
+    pauli_strings_shape = len(pauli_strings), len(pauli_strings[0])
+    assert shadow_outcomes_shape == (n_total_measurements, n_qubits), (
         f"Shadow outcomes have incorrect shape, expected "
-        f"{(n_total_measurements, n_qubits)}, got {shadow_outcomes.shape}"
+        f"{(n_total_measurements, n_qubits)}, got {shadow_outcomes_shape}"
     )
-    assert pauli_strings.shape == (n_total_measurements,), (
+    assert pauli_strings_shape == (n_total_measurements, n_qubits), (
         f"Pauli strings have incorrect shape, expected "
-        f"{(n_total_measurements, n_qubits)}, got {pauli_strings.shape}"
-    )
-    assert len(pauli_strings[0]) == n_qubits, (
-        f"Pauli strings have incorrect number of characters, "
-        f"expected {n_qubits}, got {len(pauli_strings[0])}"
+        f"{(n_total_measurements, n_qubits)}, got {pauli_strings_shape}"
     )
 
 
@@ -184,11 +182,5 @@ def test_random_pauli_measurement_output_types(
     shadow_outcomes, pauli_strings = random_pauli_measurement(
         circuit, n_total_measurements=10, executor=executor
     )
-    assert shadow_outcomes[0].dtype == int, (
-        f"Shadow outcomes have incorrect dtype, expected int, "
-        f"got {shadow_outcomes.dtype}"
-    )
-    assert isinstance(pauli_strings[0], str), (
-        f"Pauli strings have incorrect dtype, expected str, "
-        f"got {pauli_strings.dtype}"
-    )
+    assert isinstance(shadow_outcomes[0], str)
+    assert isinstance(pauli_strings[0], str)

--- a/mitiq/shadows/test/test_quantum_processing.py
+++ b/mitiq/shadows/test/test_quantum_processing.py
@@ -39,7 +39,7 @@ def test_tqdm_import_available():
 
 
 def test_tqdm_import_not_available():
-    with patch.dict("sys.modules", {"tqdm.auto": None}):
+    with patch.dict("sys.modules", {"tqdm": None}):
         importlib.reload(
             mitiq.shadows.quantum_processing
         )  # Reload the module to trigger the import


### PR DESCRIPTION

<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.

  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.

  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

Minor Updates to the Quantum Processing Functions to adjust for robust shadow.

Add optional qubits argument to shadow workflow.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file