### PR TITLE
More fixes to docstring in qse.py

### DIFF
--- a/mitiq/qse/qse.py
+++ b/mitiq/qse/qse.py
@@ -25,7 +25,7 @@ def execute_with_qse(
     pauli_string_to_expectation_cache: Dict[PauliString, complex] = {},
 ) -> float:
     """Function for the calculation of an observable from some circuit of
-    interest to be mitigated with Quantum Subspace Expansion
+    interest to be mitigated with quantum subspace expansion (QSE).
 
     Args:
         circuit: Quantum program to execute with error mitigation.
@@ -72,10 +72,9 @@ def mitigate_executor(
     pauli_string_to_expectation_cache: Dict[PauliString, complex] = {},
 ) -> Callable[[QPROGRAM], float]:
     """Returns a modified version of the input 'executor' which is
-    error-mitigated with zero-noise extrapolation (ZNE).
+    error-mitigated with quantum subspace expansion (QSE).
 
     Args:
-        circuit: Quantum program to execute with error mitigation.
         executor: Executes a circuit and returns a `QuantumResult`.
         check_operators: List of check operators that define the
             stabilizer code space.


### PR DESCRIPTION

## Description

Checked the API doc for QSE after #1938 was merged and made some additional fixes.

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [X] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [X] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [X] Added myself / the copyright holder to the AUTHORS file