### PR TITLE
Add `isort` to organize dependency imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ check-all: check-format check-style check-types
 
 .PHONY: check-format
 check-format:
+	isort --check mitiq
 	black --check --diff mitiq
 
 .PHONY: check-style
@@ -48,6 +49,7 @@ linkcheck:
 
 .PHONY: format
 format:
+	isort mitiq
 	black mitiq
 
 .PHONY: install

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -14,6 +14,7 @@ pytest-cov==4.0.0
 flake8==6.0.0
 black==22.10
 mypy==1.0.0
+isort==5.12.0
 
 # Documentation and examples.
 Sphinx==5.2.3

--- a/mitiq/benchmarks/ghz_circuits.py
+++ b/mitiq/benchmarks/ghz_circuits.py
@@ -7,6 +7,7 @@
 from typing import Optional
 
 import cirq
+
 from mitiq import QPROGRAM
 from mitiq.interface import convert_from_mitiq
 

--- a/mitiq/benchmarks/mirror_circuits.py
+++ b/mitiq/benchmarks/mirror_circuits.py
@@ -8,14 +8,13 @@
 (with error mitigation)."""
 from typing import List, Optional, Tuple
 
-from numpy import random
-import networkx as nx
-
 import cirq
+import networkx as nx
 from cirq.experiments.qubit_characterizations import _single_qubit_cliffords
-from mitiq.interface import convert_from_mitiq
-from mitiq import QPROGRAM, Bitstring
+from numpy import random
 
+from mitiq import QPROGRAM, Bitstring
+from mitiq.interface import convert_from_mitiq
 
 single_q_cliffords = _single_qubit_cliffords()
 cliffords = single_q_cliffords.c1_in_xy

--- a/mitiq/benchmarks/mirror_qv_circuits.py
+++ b/mitiq/benchmarks/mirror_qv_circuits.py
@@ -8,15 +8,13 @@ as defined in https://arxiv.org/abs/2303.02108."""
 
 from typing import Optional
 
+import cirq
 
 from mitiq import QPROGRAM
-from mitiq.interface.conversions import convert_to_mitiq, convert_from_mitiq
-
-
 from mitiq.benchmarks.quantum_volume_circuits import (
     generate_quantum_volume_circuit,
 )
-import cirq
+from mitiq.interface.conversions import convert_from_mitiq, convert_to_mitiq
 
 
 def generate_mirror_qv_circuit(

--- a/mitiq/benchmarks/qpe_circuits.py
+++ b/mitiq/benchmarks/qpe_circuits.py
@@ -6,7 +6,9 @@
 """Functions to create a QPE circuit."""
 
 from typing import Optional
+
 import cirq
+
 from mitiq import QPROGRAM
 from mitiq.interface import convert_from_mitiq
 

--- a/mitiq/benchmarks/quantum_volume_circuits.py
+++ b/mitiq/benchmarks/quantum_volume_circuits.py
@@ -13,21 +13,18 @@ Cirq implementation of quantum volume circuits:
 cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
 """
 
-from typing import Optional, Tuple, Sequence
-
-from numpy import random
+from typing import Optional, Sequence, Tuple
 
 from cirq import decompose as cirq_decompose
 from cirq.circuits import Circuit
 from cirq.contrib.quantum_volume import (
-    generate_model_circuit,
     compute_heavy_set,
+    generate_model_circuit,
 )
 from cirq.value import big_endian_int_to_bits
+from numpy import random
 
-
-from mitiq import QPROGRAM
-from mitiq import Bitstring
+from mitiq import QPROGRAM, Bitstring
 from mitiq.interface import convert_from_mitiq
 
 

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -7,15 +7,15 @@
 from typing import List, Optional
 
 import numpy as np
-
+from cirq import LineQubit
 from cirq.experiments.qubit_characterizations import (
-    _single_qubit_cliffords,
+    _gate_seq_to_mats,
     _random_single_q_clifford,
     _random_two_q_clifford,
-    _gate_seq_to_mats,
+    _single_qubit_cliffords,
     _two_qubit_clifford_matrices,
 )
-from cirq import LineQubit
+
 from mitiq import QPROGRAM
 from mitiq.interface import convert_from_mitiq
 

--- a/mitiq/benchmarks/tests/test_ghz_circuits.py
+++ b/mitiq/benchmarks/tests/test_ghz_circuits.py
@@ -5,11 +5,11 @@
 
 """Tests for GHZ circuits."""
 
-import pytest
 import numpy as np
+import pytest
 
-from mitiq.benchmarks import ghz_circuits
 from mitiq import SUPPORTED_PROGRAM_TYPES
+from mitiq.benchmarks import ghz_circuits
 
 
 @pytest.mark.parametrize("nqubits", [1, 5])

--- a/mitiq/benchmarks/tests/test_mirror_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_circuits.py
@@ -5,13 +5,14 @@
 
 """Tests for mirror circuits."""
 
-from mitiq.benchmarks import mirror_circuits
-from mitiq import SUPPORTED_PROGRAM_TYPES
-from mitiq.utils import _equal
-from numpy import random
-import networkx as nx
 import cirq
+import networkx as nx
 import pytest
+from numpy import random
+
+from mitiq import SUPPORTED_PROGRAM_TYPES
+from mitiq.benchmarks import mirror_circuits
+from mitiq.utils import _equal
 
 paulis = mirror_circuits.paulis
 cliffords = mirror_circuits.cliffords

--- a/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
@@ -9,8 +9,8 @@
 import cirq
 import pytest
 
-from mitiq.benchmarks.mirror_qv_circuits import generate_mirror_qv_circuit
 from mitiq import SUPPORTED_PROGRAM_TYPES
+from mitiq.benchmarks.mirror_qv_circuits import generate_mirror_qv_circuit
 
 
 @pytest.mark.parametrize(

--- a/mitiq/benchmarks/tests/test_qpe_circuits.py
+++ b/mitiq/benchmarks/tests/test_qpe_circuits.py
@@ -6,11 +6,12 @@
 
 """Tests for QPE benchmarking circuits."""
 
-import pytest
 import cirq
-from mitiq.utils import _equal
-from mitiq.benchmarks.qpe_circuits import generate_qpe_circuit
+import pytest
+
 from mitiq import SUPPORTED_PROGRAM_TYPES
+from mitiq.benchmarks.qpe_circuits import generate_qpe_circuit
+from mitiq.utils import _equal
 
 
 def test_bad_qubit_number():

--- a/mitiq/benchmarks/tests/test_quantum_volume_circuits.py
+++ b/mitiq/benchmarks/tests/test_quantum_volume_circuits.py
@@ -11,17 +11,15 @@ Tests below check that generate_quantum_volume_circuit() works as a wrapper and
 fits with Mitiq's interface.
 """
 
-import pytest
-
 import cirq
+import pytest
 from cirq import protocols
 
-from mitiq.benchmarks.quantum_volume_circuits import (
-    generate_quantum_volume_circuit,
-    compute_heavy_bitstrings,
-)
-
 from mitiq import SUPPORTED_PROGRAM_TYPES
+from mitiq.benchmarks.quantum_volume_circuits import (
+    compute_heavy_bitstrings,
+    generate_quantum_volume_circuit,
+)
 
 
 def test_generate_model_circuit_no_seed():

--- a/mitiq/benchmarks/tests/test_randomized_benchmarking.py
+++ b/mitiq/benchmarks/tests/test_randomized_benchmarking.py
@@ -5,11 +5,11 @@
 
 """Tests for randomized benchmarking circuits."""
 
-import pytest
 import numpy as np
+import pytest
 
-from mitiq.benchmarks.randomized_benchmarking import generate_rb_circuits
 from mitiq import SUPPORTED_PROGRAM_TYPES
+from mitiq.benchmarks.randomized_benchmarking import generate_rb_circuits
 
 
 @pytest.mark.parametrize("n_qubits", (1, 2))

--- a/mitiq/benchmarks/tests/test_w_state_circuits.py
+++ b/mitiq/benchmarks/tests/test_w_state_circuits.py
@@ -5,16 +5,13 @@
 
 """Tests for W-state benchmarking circuits."""
 
-import pytest
-import numpy as np
 import cirq
+import numpy as np
+import pytest
 
-from mitiq.utils import _equal
-
-from mitiq.benchmarks.w_state_circuits import (
-    generate_w_circuit,
-)
 from mitiq import SUPPORTED_PROGRAM_TYPES
+from mitiq.benchmarks.w_state_circuits import generate_w_circuit
+from mitiq.utils import _equal
 
 
 def test_bad_qubit_number():

--- a/mitiq/benchmarks/w_state_circuits.py
+++ b/mitiq/benchmarks/w_state_circuits.py
@@ -7,9 +7,9 @@
 as defined in :cite:`Cruz_2019_Efficient`."""
 
 from typing import Optional
-import numpy as np
-import cirq
 
+import cirq
+import numpy as np
 
 from mitiq import QPROGRAM
 from mitiq.interface import convert_from_mitiq

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -3,11 +3,12 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable, Dict, Optional, Union, cast, Sequence
 import warnings
+from typing import Callable, Dict, Optional, Sequence, Union, cast
+
+import cirq
 import numpy as np
 import numpy.typing as npt
-import cirq
 
 from mitiq import (
     QPROGRAM,
@@ -17,11 +18,11 @@ from mitiq import (
     QuantumResult,
 )
 from mitiq.calibration.settings import (
-    Settings,
-    ZNESettings,
-    Strategy,
     BenchmarkProblem,
     MitigationTechnique,
+    Settings,
+    Strategy,
+    ZNESettings,
 )
 from mitiq.interface import convert_from_mitiq
 

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -3,16 +3,15 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass, asdict
-from functools import partial
-from typing import Any, Callable, cast, List, Dict
+from dataclasses import asdict, dataclass
 from enum import Enum, auto
+from functools import partial
+from typing import Any, Callable, Dict, List, cast
 
-import networkx as nx
 import cirq
+import networkx as nx
 
 from mitiq import QPROGRAM, Executor
-from mitiq.interface import convert_from_mitiq
 from mitiq.benchmarks import (
     generate_ghz_circuit,
     generate_mirror_circuit,
@@ -20,18 +19,16 @@ from mitiq.benchmarks import (
     generate_rb_circuits,
     generate_w_circuit,
 )
+from mitiq.interface import convert_from_mitiq
 from mitiq.pec import execute_with_pec
 from mitiq.pec.representations import (
-    represent_operation_with_local_depolarizing_noise,
     represent_operation_with_local_biased_noise,
+    represent_operation_with_local_depolarizing_noise,
 )
 from mitiq.raw import execute
 from mitiq.zne import execute_with_zne
 from mitiq.zne.inference import LinearFactory, RichardsonFactory
-from mitiq.zne.scaling import (
-    fold_gates_at_random,
-    fold_global,
-)
+from mitiq.zne.scaling import fold_gates_at_random, fold_global
 
 
 class MitigationTechnique(Enum):

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -5,39 +5,35 @@
 
 """Tests for the Clifford data regression top-level API."""
 from functools import partial
-import pytest
 
 import cirq
 import numpy as np
+import pytest
 
-from mitiq import Executor, MeasurementResult, SUPPORTED_PROGRAM_TYPES
+from mitiq import SUPPORTED_PROGRAM_TYPES, Executor, MeasurementResult
 from mitiq.benchmarks import generate_rb_circuits
-from mitiq.calibration import (
-    Calibrator,
-    Settings,
-    execute_with_mitigation,
-)
+from mitiq.calibration import Calibrator, Settings, execute_with_mitigation
 from mitiq.calibration.calibrator import (
     PEC_TABLE_HEADER_STR,
     ZNE_TABLE_HEADER_STR,
-    convert_to_expval_executor,
     ExperimentResults,
     MissingResultsError,
+    convert_to_expval_executor,
 )
 from mitiq.calibration.settings import (
+    BenchmarkProblem,
+    MitigationTechnique,
     PECSettings,
     Strategy,
-    MitigationTechnique,
-    BenchmarkProblem,
     ZNESettings,
+)
+from mitiq.interface import convert_to_mitiq
+from mitiq.pec.representations import (
+    represent_operation_with_local_biased_noise,
+    represent_operation_with_local_depolarizing_noise,
 )
 from mitiq.zne.inference import LinearFactory, RichardsonFactory
 from mitiq.zne.scaling import fold_global
-from mitiq.interface import convert_to_mitiq
-from mitiq.pec.representations import (
-    represent_operation_with_local_depolarizing_noise,
-    represent_operation_with_local_biased_noise,
-)
 
 light_zne_settings = Settings(
     [

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -2,25 +2,26 @@
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
-import pytest
 import json
+
 import cirq
+import pytest
 import qiskit
 
 from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES
-from mitiq.calibration import ZNESettings, PECSettings, Settings
+from mitiq.calibration import PECSettings, Settings, ZNESettings
 from mitiq.calibration.settings import (
-    MitigationTechnique,
     BenchmarkProblem,
+    MitigationTechnique,
     Strategy,
 )
-from mitiq.raw import execute
 from mitiq.pec import (
     execute_with_pec,
     represent_operation_with_local_depolarizing_noise,
 )
+from mitiq.raw import execute
+from mitiq.zne.inference import LinearFactory, RichardsonFactory
 from mitiq.zne.scaling import fold_global
-from mitiq.zne.inference import RichardsonFactory, LinearFactory
 
 light_pec_settings = Settings(
     [

--- a/mitiq/cdr/_testing.py
+++ b/mitiq/cdr/_testing.py
@@ -3,8 +3,8 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-import numpy as np
 import cirq
+import numpy as np
 
 
 def random_x_z_circuit(qubits, n_moments, random_state) -> cirq.Circuit:

--- a/mitiq/cdr/cdr.py
+++ b/mitiq/cdr/cdr.py
@@ -5,12 +5,13 @@
 
 """API for using Clifford Data Regression (CDR) error mitigation."""
 
-from typing import Any, Callable, Optional, Sequence, Union, List
 from functools import wraps
+from typing import Any, Callable, List, Optional, Sequence, Union
+
 import numpy as np
 from scipy.optimize import curve_fit
 
-from mitiq import Executor, Observable, QPROGRAM, QuantumResult
+from mitiq import QPROGRAM, Executor, Observable, QuantumResult
 from mitiq.cdr import (
     generate_training_circuits,
     linear_fit_function,

--- a/mitiq/cdr/clifford_training_data.py
+++ b/mitiq/cdr/clifford_training_data.py
@@ -4,20 +4,19 @@
 # LICENSE file in the root directory of this source tree.
 
 """Functions for mapping circuits to (near) Clifford circuits."""
-from typing import List, Optional, Sequence, Union, Any, cast
-
-import numpy as np
+from typing import Any, List, Optional, Sequence, Union, cast
 
 import cirq
+import numpy as np
 from cirq.circuits import Circuit
 
-from mitiq.interface import atomic_one_to_many_converter
 from mitiq.cdr.clifford_utils import (
     angle_to_proximity,
     closest_clifford,
-    random_clifford,
     probabilistic_angle_to_clifford,
+    random_clifford,
 )
+from mitiq.interface import atomic_one_to_many_converter
 
 
 @atomic_one_to_many_converter

--- a/mitiq/cdr/clifford_utils.py
+++ b/mitiq/cdr/clifford_utils.py
@@ -6,10 +6,9 @@
 """Functions for mapping circuits to (near) Clifford circuits."""
 from typing import List
 
+import cirq
 import numpy as np
 import numpy.typing as npt
-
-import cirq
 from cirq.circuits import Circuit
 
 from mitiq.interface import accept_any_qprogram_as_input

--- a/mitiq/cdr/tests/test_cdr.py
+++ b/mitiq/cdr/tests/test_cdr.py
@@ -4,28 +4,23 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests for the Clifford data regression top-level API."""
-import pytest
-
 from typing import List
 
-import numpy as np
-
 import cirq
+import numpy as np
+import pytest
 from cirq import LineQubit
 
-from mitiq import PauliString, Observable, QPROGRAM
-from mitiq import SUPPORTED_PROGRAM_TYPES
+from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES, Observable, PauliString
 from mitiq.cdr import (
-    execute_with_cdr,
-    linear_fit_function_no_intercept,
-    linear_fit_function,
-    mitigate_executor,
     cdr_decorator,
+    execute_with_cdr,
+    linear_fit_function,
+    linear_fit_function_no_intercept,
+    mitigate_executor,
 )
-
-from mitiq.interface import convert_from_mitiq, convert_to_mitiq
-
 from mitiq.cdr._testing import random_x_z_cnot_circuit
+from mitiq.interface import convert_from_mitiq, convert_to_mitiq
 from mitiq.interface.mitiq_cirq import compute_density_matrix
 
 

--- a/mitiq/cdr/tests/test_clifford_training_data.py
+++ b/mitiq/cdr/tests/test_clifford_training_data.py
@@ -4,26 +4,21 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests for generating (near) Clifford circuits."""
-import pytest
-import numpy as np
-
 import cirq
+import numpy as np
+import pytest
 from cirq.circuits import Circuit
 
 from mitiq import SUPPORTED_PROGRAM_TYPES
-from mitiq.interface import convert_from_mitiq
+from mitiq.cdr._testing import random_x_z_cnot_circuit
 from mitiq.cdr.clifford_training_data import (
-    _select,
     _map_to_near_clifford,
     _replace,
+    _select,
     generate_training_circuits,
 )
-
-from mitiq.cdr.clifford_utils import (
-    is_clifford,
-    count_non_cliffords,
-)
-from mitiq.cdr._testing import random_x_z_cnot_circuit
+from mitiq.cdr.clifford_utils import count_non_cliffords, is_clifford
+from mitiq.interface import convert_from_mitiq
 
 
 def test_generate_training_circuits():

--- a/mitiq/cdr/tests/test_clifford_utils.py
+++ b/mitiq/cdr/tests/test_clifford_utils.py
@@ -4,25 +4,24 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests for generating (near) Clifford circuits."""
-import pytest
-import numpy as np
-
 import cirq
+import numpy as np
+import pytest
 from cirq.circuits import Circuit
 
 from mitiq import SUPPORTED_PROGRAM_TYPES
-from mitiq.interface import convert_from_mitiq
 from mitiq.cdr.clifford_utils import (
-    is_clifford_angle,
-    is_clifford,
-    closest_clifford,
-    random_clifford,
-    angle_to_proximity,
-    angle_to_proximities,
-    probabilistic_angle_to_clifford,
-    count_non_cliffords,
     _CLIFFORD_ANGLES,
+    angle_to_proximities,
+    angle_to_proximity,
+    closest_clifford,
+    count_non_cliffords,
+    is_clifford,
+    is_clifford_angle,
+    probabilistic_angle_to_clifford,
+    random_clifford,
 )
+from mitiq.interface import convert_from_mitiq
 
 
 @pytest.mark.parametrize("circuit_type", SUPPORTED_PROGRAM_TYPES.keys())

--- a/mitiq/cdr/tests/test_data_regression.py
+++ b/mitiq/cdr/tests/test_data_regression.py
@@ -4,8 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests for the data regression portion of Clifford data regression."""
-import pytest
 import numpy as np
+import pytest
 
 from mitiq.cdr.data_regression import linear_fit_function
 

--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -5,21 +5,12 @@
 
 """High-level digital dynamical decoupling (DDD) tools."""
 
-from typing import (
-    Optional,
-    Callable,
-    Union,
-    Tuple,
-    Dict,
-    Any,
-    List,
-)
+from functools import partial, wraps
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-from functools import wraps, partial
 import numpy as np
 
-from mitiq import Executor, Observable, QPROGRAM, QuantumResult
-
+from mitiq import QPROGRAM, Executor, Observable, QuantumResult
 from mitiq.ddd.insertion import insert_ddd_sequences
 
 

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -4,12 +4,14 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tools to determine slack windows in circuits and to insert DDD sequences."""
-from cirq import Circuit, LineQubit, synchronize_terminal_measurements, I
+from typing import Callable
+
 import numpy as np
 import numpy.typing as npt
-from typing import Callable
-from mitiq.interface import noise_scaling_converter
+from cirq import Circuit, I, LineQubit, synchronize_terminal_measurements
+
 from mitiq import QPROGRAM
+from mitiq.interface import noise_scaling_converter
 
 
 def _get_circuit_mask(circuit: Circuit) -> npt.NDArray[np.int64]:

--- a/mitiq/ddd/rules/rules.py
+++ b/mitiq/ddd/rules/rules.py
@@ -6,19 +6,20 @@
 """Built-in rules determining what DDD sequence should be applied in a given
 slack window.
 """
+from itertools import cycle
+from typing import List
+
+import numpy as np
 from cirq import (
     Circuit,
-    X,
-    Y,
+    Gate,
     I,
     LineQubit,
-    Gate,
-    unitary,
+    X,
+    Y,
     allclose_up_to_global_phase,
+    unitary,
 )
-from typing import List
-from itertools import cycle
-import numpy as np
 
 
 def general_rule(

--- a/mitiq/ddd/rules/tests/test_rules.py
+++ b/mitiq/ddd/rules/tests/test_rules.py
@@ -4,9 +4,10 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for DDD rules."""
-from mitiq.ddd.rules.rules import general_rule, xx, xyxy, yy, repeated_rule
 import pytest
-from cirq import X, Y, Z, I, Circuit, LineQubit, CNOT, bit_flip
+from cirq import CNOT, Circuit, I, LineQubit, X, Y, Z, bit_flip
+
+from mitiq.ddd.rules.rules import general_rule, repeated_rule, xx, xyxy, yy
 from mitiq.utils import _equal
 
 

--- a/mitiq/ddd/tests/test_ddd.py
+++ b/mitiq/ddd/tests/test_ddd.py
@@ -6,22 +6,21 @@
 """Unit tests for high-level DDD tools."""
 
 from typing import List
+
+import cirq
 import numpy as np
 from pytest import mark
-import cirq
 
 from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES, Executor
-from mitiq.interface import convert_to_mitiq, convert_from_mitiq
+from mitiq.ddd import ddd_decorator, execute_with_ddd, mitigate_executor
+from mitiq.ddd.rules import xx, xyxy, yy
+from mitiq.interface import convert_from_mitiq, convert_to_mitiq
 from mitiq.interface.mitiq_cirq import compute_density_matrix
-
-from mitiq.ddd.rules import xx, yy, xyxy
-from mitiq.ddd import execute_with_ddd, mitigate_executor, ddd_decorator
 from mitiq.pec.tests.test_pec import (
-    serial_executor,
     batched_executor,
     noiseless_serial_executor,
+    serial_executor,
 )
-
 
 # A layer of X gates is useful otherwise amplitude damping is not effective
 x_layer = cirq.Circuit(cirq.X.on_each(cirq.LineQubit.range(7)))

--- a/mitiq/ddd/tests/test_insertion.py
+++ b/mitiq/ddd/tests/test_insertion.py
@@ -5,16 +5,17 @@
 
 """Unit tests for DDD slack windows and DDD insertion tools."""
 
-import numpy as np
 import cirq
+import numpy as np
+import pyquil
+import pytest
+import qiskit
+
 from mitiq.ddd.insertion import (
     _get_circuit_mask,
     get_slack_matrix_from_circuit_mask,
     insert_ddd_sequences,
 )
-import pytest
-import qiskit
-import pyquil
 from mitiq.ddd.rules import xx, xyxy
 
 circuit_cirq_one = cirq.Circuit(

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -6,30 +6,28 @@
 """Defines utilities for efficiently running collections of circuits generated
 by error mitigation techniques to compute expectation values."""
 
-from collections import Counter
-import warnings
 import inspect
+import warnings
+from collections import Counter
 from typing import (
     Any,
     Callable,
-    cast,
     Iterable,
     List,
     Optional,
     Sequence,
     Tuple,
     Union,
+    cast,
 )
 
 import numpy as np
 import numpy.typing as npt
 
 from mitiq import QPROGRAM, MeasurementResult, QuantumResult
-
-from mitiq.observable.observable import Observable
 from mitiq.interface import convert_from_mitiq, convert_to_mitiq
+from mitiq.observable.observable import Observable
 from mitiq.observable.pauli import PauliString
-
 
 DensityMatrixLike = [
     np.ndarray,

--- a/mitiq/executor/tests/test_executor.py
+++ b/mitiq/executor/tests/test_executor.py
@@ -4,22 +4,21 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for Collector."""
-import pytest
-from typing import List
 from random import choices
-
-import numpy as np
+from typing import List
 
 import cirq
+import numpy as np
 import pyquil
+import pytest
 
 from mitiq import MeasurementResult
 from mitiq.executor.executor import Executor
-from mitiq.observable import Observable, PauliString
 from mitiq.interface.mitiq_cirq import (
     compute_density_matrix,
     sample_bitstrings,
 )
+from mitiq.observable import Observable, PauliString
 
 
 # Serial / batched executors which return floats.

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, Iterable, Tuple, cast
 
 from cirq import Circuit
 
-from mitiq import SUPPORTED_PROGRAM_TYPES, QPROGRAM
+from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES
 
 
 class UnsupportedCircuitError(Exception):

--- a/mitiq/interface/mitiq_braket/conversions.py
+++ b/mitiq/interface/mitiq_braket/conversions.py
@@ -2,22 +2,21 @@
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
-from typing import cast, List, Optional, Union
+from typing import List, Optional, Union, cast
 from warnings import warn
 
+import cirq_ionq.ionq_native_gates as cirq_ionq_ops
 import numpy as np
 import numpy.typing as npt
-
-from cirq import Circuit, LineQubit, ops as cirq_ops, protocols
+from braket.circuits import Circuit as BKCircuit
+from braket.circuits import Instruction
+from braket.circuits import gates as braket_gates
+from cirq import Circuit, LineQubit
+from cirq import ops as cirq_ops
+from cirq import protocols
 from cirq.linalg.decompositions import (
     deconstruct_single_qubit_matrix_into_angles,
     kak_decomposition,
-)
-import cirq_ionq.ionq_native_gates as cirq_ionq_ops
-from braket.circuits import (
-    gates as braket_gates,
-    Circuit as BKCircuit,
-    Instruction,
 )
 
 

--- a/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
+++ b/mitiq/interface/mitiq_braket/tests/test_conversions_braket.py
@@ -3,16 +3,13 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-import pytest
-import numpy as np
-
-from braket.circuits import (
-    Circuit as BKCircuit,
-    Instruction,
-    gates as braket_gates,
-)
-from cirq import Circuit, LineQubit, ops, protocols, testing
 import cirq_ionq.ionq_native_gates as cirq_ionq_ops
+import numpy as np
+import pytest
+from braket.circuits import Circuit as BKCircuit
+from braket.circuits import Instruction
+from braket.circuits import gates as braket_gates
+from cirq import Circuit, LineQubit, ops, protocols, testing
 
 from mitiq.interface.mitiq_braket.conversions import from_braket, to_braket
 from mitiq.utils import _equal

--- a/mitiq/interface/mitiq_cirq/cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/cirq_utils.py
@@ -4,11 +4,12 @@
 # LICENSE file in the root directory of this source tree.
 """Cirq utility functions."""
 
-from typing import Tuple, Callable
+from typing import Callable, Tuple
 
+import cirq
 import numpy as np
 import numpy.typing as npt
-import cirq
+
 from mitiq import MeasurementResult
 
 

--- a/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
@@ -4,15 +4,15 @@
 # LICENSE file in the root directory of this source tree.
 """ Tests for Cirq executors defined in cirq_utils.py"""
 
-import numpy as np
 import cirq
+import numpy as np
 
+from mitiq import MeasurementResult
 from mitiq.interface.mitiq_cirq import (
-    sample_bitstrings,
     compute_density_matrix,
     execute_with_depolarizing_noise,
+    sample_bitstrings,
 )
-from mitiq import MeasurementResult
 
 
 def test_sample_bitstrings():

--- a/mitiq/interface/mitiq_pennylane/conversions.py
+++ b/mitiq/interface/mitiq_pennylane/conversions.py
@@ -8,14 +8,13 @@ Pennylane's circuit representation.
 """
 
 from cirq import Circuit
-
-from pennylane.wires import Wires
-from pennylane.tape import QuantumTape
 from pennylane import from_qasm as pennylane_from_qasm
+from pennylane.tape import QuantumTape
+from pennylane.wires import Wires
 from pennylane_qiskit.qiskit_device import QISKIT_OPERATION_MAP
 
-from mitiq.interface.mitiq_qiskit import from_qasm as cirq_from_qasm, to_qasm
-
+from mitiq.interface.mitiq_qiskit import from_qasm as cirq_from_qasm
+from mitiq.interface.mitiq_qiskit import to_qasm
 
 SUPPORTED_PL = set(QISKIT_OPERATION_MAP.keys())
 UNSUPPORTED = {"CRX", "CRY", "CRZ", "S", "T"}

--- a/mitiq/interface/mitiq_pennylane/tests/test_conversions_pennylane.py
+++ b/mitiq/interface/mitiq_pennylane/tests/test_conversions_pennylane.py
@@ -5,16 +5,15 @@
 
 """Unit tests for Pennylane <-> Cirq conversions."""
 
-import pytest
-import numpy as np
-
 import cirq
+import numpy as np
 import pennylane as qml
+import pytest
 
 from mitiq.interface.mitiq_pennylane import (
+    UnsupportedQuantumTapeError,
     from_pennylane,
     to_pennylane,
-    UnsupportedQuantumTapeError,
 )
 from mitiq.utils import _equal
 

--- a/mitiq/interface/mitiq_pyquil/compiler.py
+++ b/mitiq/interface/mitiq_pyquil/compiler.py
@@ -11,14 +11,12 @@ and modified to support a larger gateset (e.g. CPHASE).
 """
 
 from math import pi
-from typing import Any, cast, Union
+from typing import Any, Union, cast
 
 import numpy as np
-
-from pyquil.gates import RX, RZ, CZ, I, XY
-from pyquil.quil import Program, Qubit, QubitPlaceholder, FormalArgument
-from pyquil.quilbase import Gate, Expression
-
+from pyquil.gates import CZ, RX, RZ, XY, I
+from pyquil.quil import FormalArgument, Program, Qubit, QubitPlaceholder
+from pyquil.quilbase import Expression, Gate
 
 QubitLike = Union[Qubit, QubitPlaceholder, FormalArgument]
 AngleLike = Union[Expression, Any, complex]

--- a/mitiq/interface/mitiq_pyquil/tests/test_conversions_pyquil.py
+++ b/mitiq/interface/mitiq_pyquil/tests/test_conversions_pyquil.py
@@ -6,7 +6,7 @@
 """Tests conversions to/from pyQuil circuits."""
 import numpy as np
 from pyquil import Program
-from pyquil.gates import CNOT, CZ, H, RZ, X, Y, Z
+from pyquil.gates import CNOT, CZ, RZ, H, X, Y, Z
 
 from mitiq.interface.mitiq_pyquil.conversions import from_pyquil, to_pyquil
 

--- a/mitiq/interface/mitiq_pyquil/tests/test_pyquil_compiler.py
+++ b/mitiq/interface/mitiq_pyquil/tests/test_pyquil_compiler.py
@@ -8,13 +8,12 @@ and modified to test a larger gateset.
 """
 
 import inspect
-import random
 import itertools
+import random
 from math import pi
 
 import numpy as np
 import pytest
-
 from cirq import equal_up_to_global_phase
 from pyquil.gates import (
     CCNOT,
@@ -22,18 +21,18 @@ from pyquil.gates import (
     CPHASE,
     CSWAP,
     CZ,
-    H,
-    I,
     ISWAP,
     PHASE,
     RX,
     RY,
     RZ,
-    S,
     SWAP,
+    XY,
+    H,
+    I,
+    S,
     T,
     X,
-    XY,
     Y,
     Z,
 )
@@ -41,7 +40,6 @@ from pyquil.quil import Program
 from pyquil.simulation.tools import program_unitary
 
 from mitiq.interface.mitiq_pyquil.compiler import (
-    basic_compile,
     _CCNOT,
     _CNOT,
     _CPHASE,
@@ -54,6 +52,7 @@ from mitiq.interface.mitiq_pyquil.compiler import (
     _X,
     _Y,
     _Z,
+    basic_compile,
 )
 
 

--- a/mitiq/interface/mitiq_pyquil/tests/test_zne_mitiq_pyquil.py
+++ b/mitiq/interface/mitiq_pyquil/tests/test_zne_mitiq_pyquil.py
@@ -5,7 +5,6 @@
 
 """Tests for zne.py with PyQuil backend."""
 import numpy as np
-
 import pyquil
 
 from mitiq import benchmarks, zne

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -7,17 +7,15 @@
 Qiskit's circuit representation.
 """
 import copy
-from typing import List, Optional, Tuple, Any, Set
 import re
-
-import numpy as np
+from typing import Any, List, Optional, Set, Tuple
 
 import cirq
-from cirq.contrib.qasm_import import circuit_from_qasm
+import numpy as np
 import qiskit
+from cirq.contrib.qasm_import import circuit_from_qasm
 
 from mitiq.utils import _simplify_circuit_exponents
-
 
 QASMType = str
 

--- a/mitiq/interface/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/qiskit_utils.py
@@ -4,23 +4,21 @@
 # LICENSE file in the root directory of this source tree.
 
 """Qiskit utility functions."""
-from typing import Tuple
 from functools import partial
+from typing import Optional, Tuple
+
 import numpy as np
 import numpy.typing as npt
 import qiskit
 from qiskit import QuantumCircuit
+from qiskit.providers import Backend
 from qiskit_aer import AerSimulator
-from typing import Optional
 
 # Noise simulation packages
 from qiskit_aer.noise import NoiseModel
-from qiskit_aer.noise.errors.standard_errors import (
-    depolarizing_error,
-)
-from qiskit.providers import Backend
+from qiskit_aer.noise.errors.standard_errors import depolarizing_error
 
-from mitiq import MeasurementResult, Observable, Executor
+from mitiq import Executor, MeasurementResult, Observable
 
 
 def initialized_depolarizing_noise(noise_level: float) -> NoiseModel:

--- a/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -6,26 +6,25 @@
 """Unit tests for conversions between Mitiq circuits and Qiskit circuits."""
 import copy
 
+import cirq
 import numpy as np
 import pytest
-
-import cirq
 import qiskit
 
-from mitiq.utils import _equal
+from mitiq.interface import convert_to_mitiq
 from mitiq.interface.mitiq_qiskit.conversions import (
-    to_qasm,
-    to_qiskit,
+    _add_identity_to_idle,
+    _map_bit_index,
+    _measurement_order,
+    _remove_identity_from_idle,
+    _remove_qasm_barriers,
+    _transform_registers,
     from_qasm,
     from_qiskit,
-    _map_bit_index,
-    _transform_registers,
-    _measurement_order,
-    _remove_qasm_barriers,
-    _add_identity_to_idle,
-    _remove_identity_from_idle,
+    to_qasm,
+    to_qiskit,
 )
-from mitiq.interface import convert_to_mitiq
+from mitiq.utils import _equal
 
 
 def _multi_reg_circuits():

--- a/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
@@ -4,22 +4,21 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for qiskit executors (qiskit_utils.py)."""
-import pytest
 import numpy as np
+import pytest
 from qiskit import QuantumCircuit
 from qiskit.providers.fake_provider import FakeLima
 
+from mitiq import MeasurementResult, Observable, PauliString
 from mitiq.interface.mitiq_qiskit.qiskit_utils import (
+    compute_expectation_value_on_noisy_backend,
     execute,
-    execute_with_shots,
     execute_with_noise,
+    execute_with_shots,
     execute_with_shots_and_noise,
     initialized_depolarizing_noise,
     sample_bitstrings,
-    compute_expectation_value_on_noisy_backend,
 )
-
-from mitiq import Observable, PauliString, MeasurementResult
 
 NOISE = 0.007
 ONE_QUBIT_GS_PROJECTOR = np.array([[1, 0], [0, 0]])

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -4,16 +4,16 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
-from typing import Callable, cast, List, Optional, Set, Union, Any, Iterable
-
-import numpy as np
-import numpy.typing as npt
-import cirq
-
 from collections import defaultdict
 from numbers import Number
+from typing import Any, Callable, Iterable, List, Optional, Set, Union, cast
+
+import cirq
+import numpy as np
+import numpy.typing as npt
+
+from mitiq import QPROGRAM, MeasurementResult, QuantumResult
 from mitiq.observable.pauli import PauliString, PauliStringCollection
-from mitiq import MeasurementResult, QuantumResult, QPROGRAM
 
 
 class Observable:

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -4,23 +4,15 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import Counter
-from typing import (
-    Any,
-    cast,
-    Counter as TCounter,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Union,
-)
+from numbers import Number
+from typing import Any
+from typing import Counter as TCounter
+from typing import Dict, List, Optional, Sequence, Set, Union, cast
 
+import cirq
 import numpy as np
 import numpy.typing as npt
-import cirq
 
-from numbers import Number
 from mitiq import QPROGRAM, MeasurementResult
 from mitiq.interface import atomic_converter
 from mitiq.utils import _cirq_pauli_to_string

--- a/mitiq/observable/tests/test_observable.py
+++ b/mitiq/observable/tests/test_observable.py
@@ -4,20 +4,19 @@
 # LICENSE file in the root directory of this source tree.
 
 import functools
+
+import cirq
+import numpy as np
 import pytest
 
-import numpy as np
-import cirq
-
-from mitiq.observable.observable import Observable
-from mitiq.observable.pauli import PauliString, PauliStringCollection
 from mitiq import MeasurementResult
 from mitiq.interface.mitiq_cirq.cirq_utils import (
-    sample_bitstrings,
     compute_density_matrix,
+    sample_bitstrings,
 )
+from mitiq.observable.observable import Observable
+from mitiq.observable.pauli import PauliString, PauliStringCollection
 from mitiq.utils import _equal
-
 
 # Basis rotations to measure Pauli X and Y.
 xrotation = cirq.SingleQubitCliffordGate.Y_nsqrt

--- a/mitiq/observable/tests/test_pauli.py
+++ b/mitiq/observable/tests/test_pauli.py
@@ -4,16 +4,15 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import Counter
+
+import cirq
+import numpy as np
 import pytest
 
-import numpy as np
-import cirq
-
-from mitiq.interface import mitiq_qiskit, mitiq_pyquil
-from mitiq.observable.pauli import PauliString, PauliStringCollection
 from mitiq import MeasurementResult
+from mitiq.interface import mitiq_pyquil, mitiq_qiskit
+from mitiq.observable.pauli import PauliString, PauliStringCollection
 from mitiq.utils import _equal
-
 
 # Basis rotations to measure Pauli X and Y.
 xrotation = cirq.SingleQubitCliffordGate.Y_nsqrt

--- a/mitiq/pec/channels.py
+++ b/mitiq/pec/channels.py
@@ -9,19 +9,12 @@
 
 """Utilities for manipulating matrix representations of quantum channels."""
 
-from typing import List
 from copy import deepcopy
+from typing import List
+
 import numpy as np
 import numpy.typing as npt
-
-from cirq import (
-    Circuit,
-    OP_TREE,
-    H,
-    CNOT,
-    LineQubit,
-    DensityMatrixSimulator,
-)
+from cirq import CNOT, OP_TREE, Circuit, DensityMatrixSimulator, H, LineQubit
 
 
 def _max_ent_state_circuit(num_qubits: int) -> Circuit:

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -5,23 +5,24 @@
 
 """High-level probabilistic error cancellation tools."""
 
+import warnings
+from functools import wraps
 from typing import (
-    Optional,
+    Any,
     Callable,
-    Union,
+    Dict,
+    List,
+    Optional,
     Sequence,
     Tuple,
-    Dict,
-    Any,
+    Union,
     cast,
-    List,
 )
-from functools import wraps
-import warnings
+
 import numpy as np
 
-from mitiq import Executor, Observable, QPROGRAM, QuantumResult
-from mitiq.pec import sample_circuit, OperationRepresentation
+from mitiq import QPROGRAM, Executor, Observable, QuantumResult
+from mitiq.pec import OperationRepresentation, sample_circuit
 
 
 class LargeSampleWarning(Warning):

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -6,20 +6,14 @@
 import copy
 from typing import List
 
-from cirq import (
-    Circuit,
-    Operation,
-    X,
-    Y,
-    Z,
-)
+from cirq import Circuit, Operation, X, Y, Z
 
 from mitiq import QPROGRAM
-from mitiq.pec import OperationRepresentation, NoisyOperation
 from mitiq.interface.conversions import (
-    convert_to_mitiq,
     append_cirq_circuit_to_qprogram,
+    convert_to_mitiq,
 )
+from mitiq.pec import NoisyOperation, OperationRepresentation
 
 
 def represent_operation_with_local_biased_noise(

--- a/mitiq/pec/representations/damping.py
+++ b/mitiq/pec/representations/damping.py
@@ -4,23 +4,15 @@
 # LICENSE file in the root directory of this source tree.
 """Functions related to representations with amplitude damping noise."""
 
-from typing import List
 from itertools import product
+from typing import List
 
 import numpy as np
 import numpy.typing as npt
-
-from cirq import (
-    Circuit,
-    Z,
-    kraus,
-    AmplitudeDampingChannel,
-    reset,
-)
-
-from mitiq.pec.types import OperationRepresentation, NoisyOperation
+from cirq import AmplitudeDampingChannel, Circuit, Z, kraus, reset
 
 from mitiq.pec.channels import tensor_product
+from mitiq.pec.types import NoisyOperation, OperationRepresentation
 
 
 # TODO: this may be extended to an arbitrary QPROGRAM (GitHub issue gh-702).

--- a/mitiq/pec/representations/depolarizing.py
+++ b/mitiq/pec/representations/depolarizing.py
@@ -5,31 +5,29 @@
 """Functions related to representations with depolarizing noise."""
 
 import copy
-from typing import List
 from itertools import product
+from typing import List
+
 import numpy as np
 import numpy.typing as npt
-
 from cirq import (
+    Circuit,
+    DepolarizingChannel,
     Operation,
     X,
     Y,
     Z,
-    Circuit,
     is_measurement,
-    DepolarizingChannel,
     kraus,
 )
 
 from mitiq import QPROGRAM
 from mitiq.interface.conversions import (
-    convert_to_mitiq,
     append_cirq_circuit_to_qprogram,
+    convert_to_mitiq,
 )
-from mitiq.pec.types import OperationRepresentation, NoisyOperation
-
-
 from mitiq.pec.channels import tensor_product
+from mitiq.pec.types import NoisyOperation, OperationRepresentation
 
 
 def represent_operation_with_global_depolarizing_noise(

--- a/mitiq/pec/representations/learning.py
+++ b/mitiq/pec/representations/learning.py
@@ -5,18 +5,20 @@
 """Functions to calculate parameters for depolarizing noise and biased noise
 models via a learning-based technique."""
 
-from typing import Optional, Dict, Any, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
+
 import numpy as np
 import numpy.typing as npt
 from scipy.optimize import minimize
+
 from mitiq import QPROGRAM, Executor, Observable
 from mitiq.cdr import generate_training_circuits
 from mitiq.pec import execute_with_pec
-from mitiq.pec.representations.depolarizing import (
-    represent_operation_with_local_depolarizing_noise,
-)
 from mitiq.pec.representations.biased_noise import (
     represent_operation_with_local_biased_noise,
+)
+from mitiq.pec.representations.depolarizing import (
+    represent_operation_with_local_depolarizing_noise,
 )
 
 

--- a/mitiq/pec/representations/optimal.py
+++ b/mitiq/pec/representations/optimal.py
@@ -5,18 +5,17 @@
 
 """Functions for finding optimal representations given a noisy basis."""
 
-from typing import cast, List, Optional
+from typing import List, Optional, cast
 
 import numpy as np
 import numpy.typing as npt
-from scipy.optimize import minimize, LinearConstraint
-
 from cirq import kraus
+from scipy.optimize import LinearConstraint, minimize
 
 from mitiq import QPROGRAM
 from mitiq.interface import convert_to_mitiq
+from mitiq.pec.channels import kraus_to_super, matrix_to_vector
 from mitiq.pec.types import NoisyOperation, OperationRepresentation
-from mitiq.pec.channels import matrix_to_vector, kraus_to_super
 
 
 def minimize_one_norm(

--- a/mitiq/pec/representations/tests/test_biased_noise.py
+++ b/mitiq/pec/representations/tests/test_biased_noise.py
@@ -10,25 +10,23 @@ from cirq import (
     CNOT,
     CZ,
     ISWAP,
+    SWAP,
+    Circuit,
+    Gate,
+    H,
     I,
+    LineQubit,
     X,
     Y,
     Z,
-    H,
-    SWAP,
-    Gate,
-    LineQubit,
-    Circuit,
     ops,
     unitary,
 )
 
-
+from mitiq.pec.channels import _circuit_to_choi, _operation_to_choi
 from mitiq.pec.representations.biased_noise import (
     represent_operation_with_local_biased_noise,
 )
-
-from mitiq.pec.channels import _operation_to_choi, _circuit_to_choi
 
 
 def single_qubit_biased_noise_overhead(epsilon: float, eta: float) -> float:

--- a/mitiq/pec/representations/tests/test_damping.py
+++ b/mitiq/pec/representations/tests/test_damping.py
@@ -5,24 +5,14 @@
 
 import numpy as np
 import pytest
-from cirq import (
-    X,
-    Y,
-    Z,
-    H,
-    Gate,
-    LineQubit,
-    Circuit,
-    AmplitudeDampingChannel,
-)
+from cirq import AmplitudeDampingChannel, Circuit, Gate, H, LineQubit, X, Y, Z
 
+from mitiq.interface import convert_from_mitiq
+from mitiq.pec.channels import _circuit_to_choi, _operation_to_choi
 from mitiq.pec.representations.damping import (
     _represent_operation_with_amplitude_damping_noise,
     amplitude_damping_kraus,
 )
-
-from mitiq.pec.channels import _operation_to_choi, _circuit_to_choi
-from mitiq.interface import convert_from_mitiq
 
 
 @pytest.mark.parametrize("noise", [0, 0.1, 0.7])

--- a/mitiq/pec/representations/tests/test_depolarizing.py
+++ b/mitiq/pec/representations/tests/test_depolarizing.py
@@ -10,33 +10,31 @@ from cirq import (
     CNOT,
     CZ,
     ISWAP,
+    SWAP,
+    Circuit,
+    DepolarizingChannel,
+    Gate,
+    H,
+    LineQubit,
+    MeasurementGate,
     X,
     Y,
     Z,
-    H,
-    SWAP,
-    Gate,
-    LineQubit,
-    Circuit,
-    DepolarizingChannel,
-    MeasurementGate,
 )
 
+from mitiq.interface import convert_from_mitiq, convert_to_mitiq
+from mitiq.pec.channels import _circuit_to_choi, _operation_to_choi
 from mitiq.pec.representations import (
     represent_operation_with_global_depolarizing_noise,
     represent_operation_with_local_depolarizing_noise,
     represent_operations_in_circuit_with_global_depolarizing_noise,
     represent_operations_in_circuit_with_local_depolarizing_noise,
 )
-
 from mitiq.pec.representations.depolarizing import (
     global_depolarizing_kraus,
     local_depolarizing_kraus,
 )
-
-from mitiq.pec.channels import _operation_to_choi, _circuit_to_choi
 from mitiq.utils import _equal
-from mitiq.interface import convert_to_mitiq, convert_from_mitiq
 
 
 def single_qubit_depolarizing_overhead(noise_level: float) -> float:

--- a/mitiq/pec/representations/tests/test_learning.py
+++ b/mitiq/pec/representations/tests/test_learning.py
@@ -4,36 +4,38 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+
 import numpy as np
 import pytest
+import qiskit
 from cirq import (
+    Circuit,
     CXPowGate,
     DepolarizingChannel,
+    I,
+    LineQubit,
     MixedUnitaryChannel,
     Rx,
     Rz,
-    I,
     X,
     Y,
     Z,
-    LineQubit,
-    Circuit,
     ops,
     unitary,
 )
-import qiskit
+
 from mitiq import Executor, Observable, PauliString
-from mitiq.interface.mitiq_qiskit import qiskit_utils
-from mitiq.interface.mitiq_qiskit.conversions import to_qiskit
-from mitiq.interface.mitiq_cirq import compute_density_matrix
 from mitiq.cdr import generate_training_circuits
 from mitiq.cdr._testing import random_x_z_cnot_circuit
+from mitiq.interface.mitiq_cirq import compute_density_matrix
+from mitiq.interface.mitiq_qiskit import qiskit_utils
+from mitiq.interface.mitiq_qiskit.conversions import to_qiskit
 from mitiq.pec.representations.learning import (
-    depolarizing_noise_loss_function,
-    biased_noise_loss_function,
-    learn_depolarizing_noise_parameter,
-    learn_biased_noise_parameters,
     _parse_learning_kwargs,
+    biased_noise_loss_function,
+    depolarizing_noise_loss_function,
+    learn_biased_noise_parameters,
+    learn_depolarizing_noise_parameter,
 )
 
 rng = np.random.RandomState(1)

--- a/mitiq/pec/representations/tests/test_optimal.py
+++ b/mitiq/pec/representations/tests/test_optimal.py
@@ -3,49 +3,46 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-from pytest import mark, raises
-import numpy as np
 from itertools import product
 
+import numpy as np
 from cirq import (
-    LineQubit,
+    CNOT,
+    CZ,
+    AmplitudeDampingChannel,
+    Circuit,
+    DepolarizingChannel,
+    H,
     I,
+    LineQubit,
+    ResetChannel,
     X,
     Y,
     Z,
-    H,
-    CNOT,
-    CZ,
-    Circuit,
-    DepolarizingChannel,
     kraus,
-    AmplitudeDampingChannel,
-    ResetChannel,
     reset,
 )
+from pytest import mark, raises
 
-from mitiq.pec.representations.optimal import (
-    minimize_one_norm,
-    find_optimal_representation,
-)
-
-from mitiq.pec.representations import (
-    represent_operation_with_local_depolarizing_noise,
-    global_depolarizing_kraus,
-    amplitude_damping_kraus,
-    _represent_operation_with_amplitude_damping_noise,
-)
-
-from mitiq.pec.channels import (
-    _operation_to_choi,
-    _circuit_to_choi,
-    kraus_to_super,
-    kraus_to_choi,
-    choi_to_super,
-)
-
-from mitiq.pec.types import NoisyOperation
 from mitiq.interface import convert_from_mitiq
+from mitiq.pec.channels import (
+    _circuit_to_choi,
+    _operation_to_choi,
+    choi_to_super,
+    kraus_to_choi,
+    kraus_to_super,
+)
+from mitiq.pec.representations import (
+    _represent_operation_with_amplitude_damping_noise,
+    amplitude_damping_kraus,
+    global_depolarizing_kraus,
+    represent_operation_with_local_depolarizing_noise,
+)
+from mitiq.pec.representations.optimal import (
+    find_optimal_representation,
+    minimize_one_norm,
+)
+from mitiq.pec.types import NoisyOperation
 
 
 def test_minimize_one_norm_failure_error():

--- a/mitiq/pec/sampling.py
+++ b/mitiq/pec/sampling.py
@@ -5,16 +5,15 @@
 
 """Tools for sampling from the noisy representations of ideal operations."""
 
-from typing import List, Optional, Tuple, Sequence, Union
-from copy import deepcopy
 import warnings
-
-import numpy as np
+from copy import deepcopy
+from typing import List, Optional, Sequence, Tuple, Union
 
 import cirq
+import numpy as np
 
 from mitiq import QPROGRAM
-from mitiq.interface import convert_to_mitiq, convert_from_mitiq
+from mitiq.interface import convert_from_mitiq, convert_to_mitiq
 from mitiq.pec.types import OperationRepresentation
 from mitiq.utils import _equal
 

--- a/mitiq/pec/tests/test_channels.py
+++ b/mitiq/pec/tests/test_channels.py
@@ -5,30 +5,29 @@
 
 """Tests related to the functions contained in `mitiq.pec.channels`."""
 
-from pytest import raises
 import numpy as np
 from cirq import (
-    LineQubit,
-    depolarize,
-    Circuit,
-    kraus,
     AmplitudeDampingChannel,
+    Circuit,
+    LineQubit,
     Y,
+    depolarize,
+    kraus,
 )
+from pytest import raises
 
 from mitiq.pec.channels import (
+    _circuit_to_choi,
     _max_ent_state_circuit,
     _operation_to_choi,
-    _circuit_to_choi,
-    vector_to_matrix,
-    matrix_to_vector,
-    kraus_to_super,
     choi_to_super,
-    super_to_choi,
     kraus_to_choi,
+    kraus_to_super,
+    matrix_to_vector,
+    super_to_choi,
     tensor_product,
+    vector_to_matrix,
 )
-
 from mitiq.pec.representations.damping import amplitude_damping_kraus
 
 

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -5,21 +5,25 @@
 
 """Unit tests for PEC."""
 import warnings
-from typing import List, Optional
 from functools import partial
-import pytest
+from typing import List, Optional
 
-import numpy as np
 import cirq
+import numpy as np
 import pyquil
+import pytest
 import qiskit
 
-from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES, PauliString, Observable
-from mitiq.interface import convert_to_mitiq, convert_from_mitiq, mitiq_cirq
+from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES, Observable, PauliString
+from mitiq.interface import convert_from_mitiq, convert_to_mitiq, mitiq_cirq
 from mitiq.interface.mitiq_cirq import compute_density_matrix
-
-from mitiq.pec import execute_with_pec, NoisyOperation, OperationRepresentation
-from mitiq.pec import mitigate_executor, pec_decorator
+from mitiq.pec import (
+    NoisyOperation,
+    OperationRepresentation,
+    execute_with_pec,
+    mitigate_executor,
+    pec_decorator,
+)
 from mitiq.pec.representations import (
     represent_operations_in_circuit_with_local_depolarizing_noise,
 )

--- a/mitiq/pec/tests/test_pec_sampling.py
+++ b/mitiq/pec/tests/test_pec_sampling.py
@@ -5,41 +5,34 @@
 
 """Tests for mitiq.pec.sampling functions."""
 
+import cirq
 import numpy as np
 import pytest
-
-import cirq
 from cirq import (
     Circuit,
     Gate,
     LineQubit,
     NamedQubit,
-    ops,
     depolarize,
     measure,
     measure_each,
+    ops,
 )
-
-from pyquil import (
-    Program,
-    gates,
-)
-
-from qiskit import QuantumRegister, QuantumCircuit
+from pyquil import Program, gates
+from qiskit import QuantumCircuit, QuantumRegister
 
 from mitiq.pec import (
-    sample_sequence,
-    sample_circuit,
     NoisyOperation,
     OperationRepresentation,
+    sample_circuit,
+    sample_sequence,
 )
-from mitiq.utils import _equal
+from mitiq.pec.channels import _circuit_to_choi, _operation_to_choi
 from mitiq.pec.representations import (
     represent_operation_with_local_depolarizing_noise,
     represent_operations_in_circuit_with_local_depolarizing_noise,
 )
-from mitiq.pec.channels import _operation_to_choi, _circuit_to_choi
-
+from mitiq.utils import _equal
 
 xcirq = Circuit(cirq.X(cirq.LineQubit(0)))
 zcirq = Circuit(cirq.Z(cirq.LineQubit(0)))

--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -3,20 +3,15 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-import numpy as np
-import pytest
-
 import cirq
-from cirq import Circuit
+import numpy as np
 import pyquil
+import pytest
 import qiskit
+from cirq import Circuit
 
+from mitiq.pec.types import NoisyBasis, NoisyOperation, OperationRepresentation
 from mitiq.utils import _equal
-from mitiq.pec.types import (
-    NoisyBasis,
-    NoisyOperation,
-    OperationRepresentation,
-)
 
 icirq = Circuit(cirq.I(cirq.LineQubit(0)))
 xcirq = Circuit(cirq.X(cirq.LineQubit(0)))

--- a/mitiq/pec/types/types.py
+++ b/mitiq/pec/types/types.py
@@ -4,21 +4,20 @@
 # LICENSE file in the root directory of this source tree.
 
 """Types used in probabilistic error cancellation."""
+import warnings
 from copy import deepcopy
 from typing import Any, List, Optional, Tuple, Union
-import warnings
-
-import numpy as np
-import numpy.typing as npt
 
 import cirq
+import numpy as np
+import numpy.typing as npt
 from cirq.value.linear_dict import _format_coefficient
 
 from mitiq import QPROGRAM
 from mitiq.interface import (
-    convert_to_mitiq,
     CircuitConversionError,
     UnsupportedCircuitError,
+    convert_to_mitiq,
 )
 
 

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -3,9 +3,9 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
+import random
 from typing import Callable, List, Optional, Union, cast
 
-import random
 import cirq
 import numpy as np
 

--- a/mitiq/pt/tests/test_pt.py
+++ b/mitiq/pt/tests/test_pt.py
@@ -6,19 +6,19 @@
 import random
 
 import cirq
-import qiskit
-import numpy as np
 import networkx as nx
+import numpy as np
+import qiskit
 
+from mitiq.benchmarks import generate_mirror_circuit
+from mitiq.interface.mitiq_cirq import compute_density_matrix
 from mitiq.pt.pt import (
-    twirl_CNOT_gates,
-    twirl_CZ_gates,
-    execute_with_pauli_twirling,
     CNOT_twirling_gates,
     CZ_twirling_gates,
+    execute_with_pauli_twirling,
+    twirl_CNOT_gates,
+    twirl_CZ_gates,
 )
-from mitiq.interface.mitiq_cirq import compute_density_matrix
-from mitiq.benchmarks import generate_mirror_circuit
 
 num_qubits = 2
 qubits = cirq.LineQubit.range(num_qubits)

--- a/mitiq/qse/qse.py
+++ b/mitiq/qse/qse.py
@@ -7,12 +7,12 @@
 """High-level Quantum Susbapce Expansion tools."""
 
 from functools import wraps
-from typing import Callable, Sequence, Dict, List, Union
+from typing import Callable, Dict, List, Sequence, Union
 
-from mitiq import Executor, Observable, QPROGRAM, QuantumResult, PauliString
+from mitiq import QPROGRAM, Executor, Observable, PauliString, QuantumResult
 from mitiq.qse.qse_utils import (
-    get_projector,
     get_expectation_value_for_observable,
+    get_projector,
 )
 
 

--- a/mitiq/qse/qse_utils.py
+++ b/mitiq/qse/qse_utils.py
@@ -5,12 +5,14 @@
 
 """Functions for computing the projector for subspace expansion."""
 
-from typing import Callable, Sequence, Union, Dict, List
-from mitiq import Observable, QPROGRAM, QuantumResult, PauliString, Executor
+from typing import Callable, Dict, List, Sequence, Union
+
 import numpy as np
 import numpy.typing as npt
-from scipy.linalg import eigh
 from numpy.linalg import pinv
+from scipy.linalg import eigh
+
+from mitiq import QPROGRAM, Executor, Observable, PauliString, QuantumResult
 
 
 def get_projector(

--- a/mitiq/qse/tests/test_qse.py
+++ b/mitiq/qse/tests/test_qse.py
@@ -6,21 +6,23 @@
 """Tests for the Quantum Subspace Expansion top level API."""
 
 from typing import List
-import numpy as np
+
 import cirq
-from mitiq import PauliString, Observable, QPROGRAM
+import numpy as np
+
+from mitiq import QPROGRAM, Observable, PauliString
+from mitiq.interface import convert_to_mitiq
+from mitiq.interface.mitiq_cirq import compute_density_matrix
 from mitiq.qse import (
-    get_projector,
     execute_with_qse,
+    get_projector,
     mitigate_executor,
     qse_decorator,
 )
 from mitiq.qse.qse_utils import (
-    _compute_overlap_matrix,
     _compute_hamiltonian_overlap_matrix,
+    _compute_overlap_matrix,
 )
-from mitiq.interface import convert_to_mitiq
-from mitiq.interface.mitiq_cirq import compute_density_matrix
 
 
 def execute_with_depolarized_noise(circuit: QPROGRAM) -> np.ndarray:

--- a/mitiq/raw/raw.py
+++ b/mitiq/raw/raw.py
@@ -6,7 +6,7 @@
 """Run experiments without error mitigation."""
 from typing import Callable, Optional, Union
 
-from mitiq import Executor, Observable, QPROGRAM, QuantumResult
+from mitiq import QPROGRAM, Executor, Observable, QuantumResult
 
 
 def execute(

--- a/mitiq/raw/tests/test_raw.py
+++ b/mitiq/raw/tests/test_raw.py
@@ -7,9 +7,8 @@
 
 import functools
 
-import numpy as np
-
 import cirq
+import numpy as np
 
 from mitiq import Executor, Observable, PauliString, raw
 from mitiq.interface import mitiq_cirq

--- a/mitiq/rem/inverse_confusion_matrix.py
+++ b/mitiq/rem/inverse_confusion_matrix.py
@@ -5,11 +5,12 @@
 
 from functools import reduce
 from typing import List, Sequence
+
 import numpy as np
 import numpy.typing as npt
 import scipy
 
-from mitiq import MeasurementResult, Bitstring
+from mitiq import Bitstring, MeasurementResult
 
 
 def sample_probability_vector(

--- a/mitiq/rem/rem.py
+++ b/mitiq/rem/rem.py
@@ -5,9 +5,10 @@
 
 """Readout Confusion Inversion."""
 
-from typing import Callable, Union, List, Sequence, cast
-from types import MethodType
 from functools import wraps
+from types import MethodType
+from typing import Callable, List, Sequence, Union, cast
+
 import numpy as np
 import numpy.typing as npt
 

--- a/mitiq/rem/tests/test_inverse_confusion_matrix.py
+++ b/mitiq/rem/tests/test_inverse_confusion_matrix.py
@@ -7,17 +7,18 @@
 
 from functools import reduce
 from math import isclose
+
 import numpy as np
 import pytest
 
 from mitiq import MeasurementResult
 from mitiq.rem.inverse_confusion_matrix import (
     bitstrings_to_probability_vector,
+    closest_positive_distribution,
     generate_inverse_confusion_matrix,
     generate_tensored_inverse_confusion_matrix,
     mitigate_measurements,
     sample_probability_vector,
-    closest_positive_distribution,
 )
 
 

--- a/mitiq/rem/tests/test_post_select.py
+++ b/mitiq/rem/tests/test_post_select.py
@@ -6,8 +6,8 @@
 """Unit tests for postselection of measurement results."""
 import pytest
 
-from mitiq.rem import post_select
 from mitiq import MeasurementResult
+from mitiq.rem import post_select
 
 
 def test_post_select():

--- a/mitiq/rem/tests/test_rem.py
+++ b/mitiq/rem/tests/test_rem.py
@@ -4,23 +4,23 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for readout confusion inversion."""
-from typing import List
 from functools import partial
-import numpy as np
-import pytest
+from typing import List
 
 import cirq
+import numpy as np
+import pytest
 from cirq.experiments.single_qubit_readout_calibration_test import (
     NoisySingleQubitReadoutSampler,
 )
 
-from mitiq import MeasurementResult, Executor, Observable, PauliString
+from mitiq import Executor, MeasurementResult, Observable, PauliString
+from mitiq.interface.mitiq_cirq import sample_bitstrings
+from mitiq.raw import execute as raw_execute
+from mitiq.rem import execute_with_rem, mitigate_executor, rem_decorator
 from mitiq.rem.inverse_confusion_matrix import (
     generate_inverse_confusion_matrix,
 )
-from mitiq.rem import execute_with_rem, mitigate_executor, rem_decorator
-from mitiq.raw import execute as raw_execute
-from mitiq.interface.mitiq_cirq import sample_bitstrings
 
 # Default qubit register and circuit for unit tests
 qreg = [cirq.LineQubit(i) for i in range(2)]

--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Quantum processing functions for classical shadows."""
-from typing import Tuple, Callable, List, Optional, Sequence
+from typing import Callable, List, Optional, Sequence, Tuple
 
 import cirq
 import numpy as np

--- a/mitiq/shadows/shadows_utils.py
+++ b/mitiq/shadows/shadows_utils.py
@@ -8,15 +8,15 @@
 # LICENSE file in the root directory of this source tree.
 
 """Defines utility functions for classical shadows protocol."""
-from typing import Tuple, List, Any
+from itertools import product
+from typing import Any, List, Tuple
 
+import cirq
 import numpy as np
 from numpy.typing import NDArray
-import cirq
 from scipy.linalg import sqrtm
-import mitiq
 
-from itertools import product
+import mitiq
 
 PAULIS = [
     cirq.I._unitary_(),

--- a/mitiq/shadows/test/test_shadows_utils.py
+++ b/mitiq/shadows/test/test_shadows_utils.py
@@ -5,18 +5,19 @@
 
 """Defines utility functions for classical shadows protocol."""
 
-import numpy as np
 import cirq
+import numpy as np
+
 import mitiq
 from mitiq.shadows.shadows_utils import (
-    kronecker_product,
-    operator_ptm_vector_rep,
-    eigenvalues_to_bitstring,
     bitstring_to_eigenvalues,
     create_string,
-    n_measurements_tomography_bound,
-    n_measurements_opts_expectation_bound,
+    eigenvalues_to_bitstring,
     fidelity,
+    kronecker_product,
+    n_measurements_opts_expectation_bound,
+    n_measurements_tomography_bound,
+    operator_ptm_vector_rep,
 )
 
 

--- a/mitiq/tests/test_conversions.py
+++ b/mitiq/tests/test_conversions.py
@@ -5,31 +5,27 @@
 
 """Tests for circuit conversions."""
 
-import pytest
-
-import numpy as np
-
 import cirq
-from pyquil import Program, gates
-import qiskit
-from braket.circuits import (
-    Circuit as BKCircuit,
-    gates as braket_gates,
-    Instruction,
-)
+import numpy as np
 import pennylane as qml
+import pytest
+import qiskit
+from braket.circuits import Circuit as BKCircuit
+from braket.circuits import Instruction
+from braket.circuits import gates as braket_gates
+from pyquil import Program, gates
 
 from mitiq import SUPPORTED_PROGRAM_TYPES
 from mitiq.interface import (
-    convert_to_mitiq,
-    convert_from_mitiq,
+    UnsupportedCircuitError,
     accept_any_qprogram_as_input,
     atomic_one_to_many_converter,
+    convert_from_mitiq,
+    convert_to_mitiq,
     noise_scaling_converter,
     register_mitiq_converters,
-    UnsupportedCircuitError,
 )
-from mitiq.interface.mitiq_qiskit import to_qasm, from_qasm
+from mitiq.interface.mitiq_qiskit import from_qasm, to_qasm
 from mitiq.utils import _equal
 
 QASMType = str

--- a/mitiq/tests/test_measurement_result.py
+++ b/mitiq/tests/test_measurement_result.py
@@ -4,9 +4,9 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for measurement results."""
+import numpy as np
 import pytest
 
-import numpy as np
 from mitiq import MeasurementResult
 
 

--- a/mitiq/tests/test_utils.py
+++ b/mitiq/tests/test_utils.py
@@ -5,37 +5,37 @@
 
 """Tests for utility functions."""
 from copy import deepcopy
-import pytest
 
-import numpy as np
 import cirq
+import numpy as np
+import pytest
 from cirq import (
-    LineQubit,
+    CNOT,
     Circuit,
     ControlledGate,
+    H,
+    LineQubit,
+    MeasurementGate,
+    S,
+    T,
     X,
     Y,
     Z,
-    H,
-    CNOT,
-    S,
-    T,
-    MeasurementGate,
-    ops,
     depolarize,
+    ops,
 )
 
 from mitiq.utils import (
     _append_measurements,
     _are_close_dict,
+    _circuit_to_choi,
     _equal,
     _is_measurement,
-    _simplify_gate_exponent,
-    _simplify_circuit_exponents,
     _max_ent_state_circuit,
-    _circuit_to_choi,
     _operation_to_choi,
     _pop_measurements,
+    _simplify_circuit_exponents,
+    _simplify_gate_exponent,
 )
 
 

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -13,16 +13,13 @@
        a quantum program from which expectation values to be mitigated can be
        computed. Note this includes expectation values themselves.
 """
+from collections import Counter
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, Union, Sequence, Dict, Any
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
-
 from cirq import Circuit as _Circuit
-
-from collections import Counter
-
 
 # Supported quantum programs.
 SUPPORTED_PROGRAM_TYPES = {

--- a/mitiq/utils.py
+++ b/mitiq/utils.py
@@ -7,22 +7,21 @@
 from copy import deepcopy
 from typing import Any, Dict, List, Tuple
 
+import cirq
 import numpy as np
 import numpy.typing as npt
-
-import cirq
 from cirq import (
-    LineQubit,
+    CNOT,
+    OP_TREE,
     Circuit,
+    DensityMatrixSimulator,
     EigenGate,
     Gate,
     GateOperation,
-    Moment,
-    CNOT,
     H,
-    DensityMatrixSimulator,
+    LineQubit,
+    Moment,
     ops,
-    OP_TREE,
 )
 from cirq.ops.measurement_gate import MeasurementGate
 

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -4,35 +4,34 @@
 # LICENSE file in the root directory of this source tree.
 
 """Classes corresponding to different zero-noise extrapolation methods."""
+import warnings
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import (
     Any,
     Callable,
-    cast,
     Dict,
     List,
     Optional,
     Sequence,
     Tuple,
     Union,
+    cast,
 )
-import warnings
 
-from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
-from numpy.lib.polynomial import RankWarning
-from scipy.optimize import curve_fit, OptimizeWarning
 from cirq import Circuit
+from matplotlib.figure import Figure
+from numpy.lib.polynomial import RankWarning
+from scipy.optimize import OptimizeWarning, curve_fit
 
 from mitiq import QPROGRAM, QuantumResult
-from mitiq.observable import Observable
 from mitiq.executor import Executor
-from mitiq.zne.scaling import fold_gates_at_random
 from mitiq.interface import accept_any_qprogram_as_input
-
+from mitiq.observable import Observable
+from mitiq.zne.scaling import fold_gates_at_random
 
 ExtrapolationResult = Union[
     float,  # The zero-noise value.

--- a/mitiq/zne/scaling/folding.py
+++ b/mitiq/zne/scaling/folding.py
@@ -4,12 +4,12 @@
 # LICENSE file in the root directory of this source tree.
 
 """Functions for local and global unitary folding on supported circuits."""
+import warnings
 from copy import deepcopy
 from typing import Any, Dict, FrozenSet, List, Optional, cast
-import warnings
 
 import numpy as np
-from cirq import Circuit, InsertStrategy, inverse, ops, has_unitary, Moment
+from cirq import Circuit, InsertStrategy, Moment, has_unitary, inverse, ops
 
 from mitiq.interface import noise_scaling_converter
 from mitiq.utils import (

--- a/mitiq/zne/scaling/identity_insertion.py
+++ b/mitiq/zne/scaling/identity_insertion.py
@@ -5,14 +5,13 @@
 """Functions for scaling supported circuits by inserting layers of identity
 gates."""
 
-import numpy as np
 import random
 from typing import Tuple
-from cirq import Circuit, ops, Moment
-from mitiq.utils import (
-    _append_measurements,
-    _pop_measurements,
-)
+
+import numpy as np
+from cirq import Circuit, Moment, ops
+
+from mitiq.utils import _append_measurements, _pop_measurements
 
 
 class UnscalableCircuitError(Exception):

--- a/mitiq/zne/scaling/layer_scaling.py
+++ b/mitiq/zne/scaling/layer_scaling.py
@@ -5,18 +5,16 @@
 
 """Functions for layer-wise unitary folding on supported circuits."""
 from copy import deepcopy
-import numpy as np
 from typing import Callable, List
+
 import cirq
+import numpy as np
 from cirq import Moment, inverse
 
 from mitiq import QPROGRAM
-from mitiq.zne.scaling.folding import _check_foldable
 from mitiq.interface import noise_scaling_converter
-from mitiq.utils import (
-    _append_measurements,
-    _pop_measurements,
-)
+from mitiq.utils import _append_measurements, _pop_measurements
+from mitiq.zne.scaling.folding import _check_foldable
 
 
 @noise_scaling_converter

--- a/mitiq/zne/scaling/parameter.py
+++ b/mitiq/zne/scaling/parameter.py
@@ -3,24 +3,26 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, Callable, List, cast
-import numpy as np
-
 import copy
+from typing import Callable, List, Optional, cast
 
-from cirq import Circuit, EigenGate, Moment
+import numpy as np
 from cirq import (
-    ZPowGate,
-    YPowGate,
-    XPowGate,
-    HPowGate,
+    Circuit,
     CXPowGate,
     CZPowGate,
+    EigenGate,
+    HPowGate,
     MeasurementGate,
+    Moment,
     Qid,
+    XPowGate,
+    YPowGate,
+    ZPowGate,
 )
-from mitiq.interface import noise_scaling_converter
+
 from mitiq import QPROGRAM
+from mitiq.interface import noise_scaling_converter
 
 
 class GateTypeException(Exception):

--- a/mitiq/zne/scaling/tests/test_folding.py
+++ b/mitiq/zne/scaling/tests/test_folding.py
@@ -9,41 +9,41 @@ import pytest
 from cirq import (
     Circuit,
     GridQubit,
-    LineQubit,
-    ops,
-    inverse,
-    equal_up_to_global_phase,
     InsertStrategy,
-    testing,
+    LineQubit,
+    equal_up_to_global_phase,
+    inverse,
+    ops,
     ry,
     rz,
+    testing,
 )
-from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.quantum_info.operators import Operator
 from pyquil import Program, gates
 from pyquil.quilbase import Pragma
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit.quantum_info.operators import Operator
+from sympy import Symbol
 
-from mitiq.utils import _equal
 from mitiq.interface import (
     CircuitConversionError,
-    convert_to_mitiq,
     convert_from_mitiq,
+    convert_to_mitiq,
 )
+from mitiq.utils import _equal
 from mitiq.zne.scaling.folding import (
     UnfoldableCircuitError,
-    _squash_moments,
+    _apply_fold_mask,
+    _create_fold_mask,
+    _create_weight_mask,
     _default_weight,
     _fold_all,
+    _squash_moments,
     fold_all,
+    fold_gates_at_random,
     fold_gates_from_left,
     fold_gates_from_right,
-    fold_gates_at_random,
     fold_global,
-    _create_weight_mask,
-    _create_fold_mask,
-    _apply_fold_mask,
 )
-from sympy import Symbol
 
 
 def test_squash_moments_two_qubits():

--- a/mitiq/zne/scaling/tests/test_identity_insertion.py
+++ b/mitiq/zne/scaling/tests/test_identity_insertion.py
@@ -5,13 +5,14 @@
 
 """Unit tests for scaling noise by inserting identity layers."""
 import pytest
+from cirq import Circuit, LineQubit, ops
+
+from mitiq.utils import _equal
 from mitiq.zne.scaling.identity_insertion import (
     UnscalableCircuitError,
     _calculate_id_layers,
     insert_id_layers,
 )
-from cirq import Circuit, ops, LineQubit
-from mitiq.utils import _equal
 
 
 @pytest.mark.parametrize("scale_factor", (1, 2, 3, 4, 5, 6))

--- a/mitiq/zne/scaling/tests/test_layer_scaling.py
+++ b/mitiq/zne/scaling/tests/test_layer_scaling.py
@@ -4,11 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for scaling by layer."""
-from cirq import (
-    Circuit,
-    LineQubit,
-    ops,
-)
+from cirq import Circuit, LineQubit, ops
+
 from mitiq.zne.scaling import layer_folding
 
 

--- a/mitiq/zne/scaling/tests/test_parameter.py
+++ b/mitiq/zne/scaling/tests/test_parameter.py
@@ -6,19 +6,18 @@
 """Unit tests for parameter scaling."""
 from copy import deepcopy
 
-import pytest
 import numpy as np
-from cirq import Circuit, LineQubit, ops, CSWAP, ZPowGate
-
+import pytest
+from cirq import CSWAP, Circuit, LineQubit, ZPowGate, ops
 
 from mitiq.utils import _equal
 from mitiq.zne.scaling.parameter import (
-    scale_parameters,
-    _get_base_gate,
     CircuitMismatchException,
     GateTypeException,
     _generate_parameter_calibration_circuit,
+    _get_base_gate,
     compute_parameter_variance,
+    scale_parameters,
 )
 
 

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -7,25 +7,25 @@
 classically generated data.
 """
 from typing import Callable, List
-from pytest import mark, raises, warns
-
-import numpy as np
-from numpy.random import RandomState
 
 import cirq
+import numpy as np
+from cirq import H, LineQubit, X
+from numpy.random import RandomState
+from pytest import mark, raises, warns
+
 from mitiq.zne.inference import (
+    AdaExpFactory,
+    ConvergenceWarning,
+    ExpFactory,
     ExtrapolationError,
     ExtrapolationWarning,
-    ConvergenceWarning,
-    RichardsonFactory,
     FakeNodesFactory,
     LinearFactory,
-    PolyFactory,
-    ExpFactory,
     PolyExpFactory,
-    AdaExpFactory,
+    PolyFactory,
+    RichardsonFactory,
 )
-from cirq import LineQubit, X, H
 
 # Constant parameters for test functions:
 A = 0.5

--- a/mitiq/zne/tests/test_zne.py
+++ b/mitiq/zne/tests/test_zne.py
@@ -4,20 +4,32 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for zero-noise extrapolation."""
-from typing import List
 import functools
-import pytest
+from typing import List
 
-import numpy as np
 import cirq
+import numpy as np
+import pytest
 import qiskit
 from qiskit_aer import AerSimulator
 
+from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES
+from mitiq.benchmarks.randomized_benchmarking import generate_rb_circuits
+from mitiq.interface import accept_any_qprogram_as_input, convert_from_mitiq
+from mitiq.interface.mitiq_cirq import (
+    compute_density_matrix,
+    sample_bitstrings,
+)
+from mitiq.interface.mitiq_qiskit import (
+    execute_with_shots_and_noise,
+    initialized_depolarizing_noise,
+)
+from mitiq.observable import Observable, PauliString
 from mitiq.zne import (
-    inference,
-    scaling,
     execute_with_zne,
+    inference,
     mitigate_executor,
+    scaling,
     zne_decorator,
 )
 from mitiq.zne.inference import (
@@ -27,27 +39,12 @@ from mitiq.zne.inference import (
     RichardsonFactory,
 )
 from mitiq.zne.scaling import (
+    fold_gates_at_random,
     fold_gates_from_left,
     fold_gates_from_right,
-    fold_gates_at_random,
+    get_layer_folding,
     insert_id_layers,
 )
-from mitiq.zne.scaling import get_layer_folding
-from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES
-from mitiq.benchmarks.randomized_benchmarking import generate_rb_circuits
-
-from mitiq.interface.mitiq_qiskit import (
-    execute_with_shots_and_noise,
-    initialized_depolarizing_noise,
-)
-
-from mitiq.interface import convert_from_mitiq, accept_any_qprogram_as_input
-from mitiq.interface.mitiq_cirq import (
-    sample_bitstrings,
-    compute_density_matrix,
-)
-from mitiq.observable import Observable, PauliString
-
 
 BASE_NOISE = 0.007
 TEST_DEPTH = 30

--- a/mitiq/zne/zne.py
+++ b/mitiq/zne/zne.py
@@ -4,10 +4,10 @@
 # LICENSE file in the root directory of this source tree.
 
 """High-level zero-noise extrapolation tools."""
-from typing import Callable, Optional, Union, List
 from functools import wraps
+from typing import Callable, List, Optional, Union
 
-from mitiq import Executor, Observable, QPROGRAM, QuantumResult
+from mitiq import QPROGRAM, Executor, Observable, QuantumResult
 from mitiq.zne.inference import Factory, RichardsonFactory
 from mitiq.zne.scaling import fold_gates_at_random
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,12 @@
 line-length = 79
 target-version = ['py311']
 
+[tool.isort]
+profile = "black"
+skip_glob = ["**/__init__.py"]
+line_length = 79
+skip_gitignore = "True"
+
 [tool.pytest.ini_options]
 addopts = "--color=yes"
 filterwarnings = [


### PR DESCRIPTION
## Description

This PR adds [`isort`](https://pycqa.github.io/isort/index.html) as a dependency. `isort` is short for "import sort" and sorts dependencies (both alphabetically in each import statement, and groups them according to standard library -> 3rd party -> 1st party imports) in each python file. In addition this PR adds `isort` to run both as part of CI via the makefile and adds config for it to run properly in our `pyproject.toml` file.

### Motivation

I've made some version of [this](https://github.com/unitaryfund/mitiq/pull/1902#discussion_r1260587256) comment more than twice now, so easiest just to automate away the conversation!