### PR TITLE
Prep for ReadTheDocs deprecation

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -26,6 +26,8 @@ pydata-sphinx-theme==0.11.0
 jupytext==1.14.1
 sphinx-gallery==0.10.1
 nbsphinx==0.9.1
+matplotlib==3.7.2
+pandas==2.0.3
 pyscf==2.2.1; sys_platform != 'win32'
 openfermion==1.5.1; sys_platform != 'win32'
 openfermionpyscf==0.5; sys_platform != 'win32'


### PR DESCRIPTION
## Description

Read the Docs has stopped installing `matplotlib` and `pandas` by default on ubuntu-20 and ubuntu-22 images (along with `numpy` and `scipy`, but these are already tracked in our requirements files).  Adding `matlotlib` and `pandas` for explicitness to our developer requirements will help ensure consistent builds.

<details>
<summary>
Full Email
</summary>
<img width="623" alt="Screenshot 2023-08-10 at 4 24 54 PM" src="https://github.com/unitaryfund/mitiq/assets/12703123/bdd480e5-7289-4da9-818a-4e060a91d160">
</details>