### PR TITLE
Pauli Transfer Matrix for Pauli Twirling

### DIFF
--- a/mitiq/pt/tests/test_utils.py
+++ b/mitiq/pt/tests/test_utils.py
@@ -51,9 +51,25 @@ def test_size_of_pauli_vec():
 
 def test_ptm_matrix_size():
     """Checks the output of the PTM matrix function."""
+    # one qubit circuit
     q0 = cirq.LineQubit(0)
     circuit = cirq.Circuit()
     circuit.append(cirq.Rz(rads=0.25 * np.pi)(q0))
     expected_ptm_matrix = ptm_matrix(circuit, 1)
     assert expected_ptm_matrix.shape == (4**1, 4**1)
-    assert np.isclose(expected_ptm_matrix[0, 1], 0.0, rtol=1e-05)
+    expected_array = np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.7071, -0.7071, 0.0],
+            [0.0, 0.7071, 0.7071, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    np.allclose(expected_ptm_matrix, expected_array, atol=1e-08)
+
+    # two qubit circuit
+    q1 = cirq.LineQubit(1)
+    circuit.append(cirq.Rz(rads=0.25 * np.pi)(q1))
+    expected_ptm_matrix2 = ptm_matrix(circuit, 2)
+    assert expected_ptm_matrix2.shape == (4**2, 4**2)
+    assert np.isclose(expected_ptm_matrix2[0, 1], 0.0, rtol=1e-05)

--- a/mitiq/pt/tests/test_utils.py
+++ b/mitiq/pt/tests/test_utils.py
@@ -7,9 +7,16 @@
 
 import random
 
+import cirq
 import numpy as np
 
-from mitiq.pt.utils import _matrix_no_vec, _matrix_vec, _pauli_vectorized_list
+from mitiq.pt.utils import (
+    _get_n_qubit_paulis,
+    _matrix_no_vec,
+    _matrix_vec,
+    _pauli_vectorized_list,
+    ptm_matrix,
+)
 
 
 def test_matrix_to_vec():
@@ -34,8 +41,19 @@ def test_size_of_pauli_vec():
     Size of each matrix should be 2**num_qubits.
     """
     for i in range(1, 5):
+        assert len(_get_n_qubit_paulis(i)) == 4**i
         expected_output_pauli_vec_list = _pauli_vectorized_list(i)
         assert len(expected_output_pauli_vec_list) == 4**i
         # randomly check 1 entry in the output is a column vector
-        j = random.randrange(len(expected_output_pauli_vec_list) + 1)
+        j = random.randrange(len(expected_output_pauli_vec_list))
         assert expected_output_pauli_vec_list[j].shape[-1] == 1
+
+
+def test_ptm_matrix_size():
+    """Checks the output of the PTM matrix function."""
+    q0 = cirq.LineQubit(0)
+    circuit = cirq.Circuit()
+    circuit.append(cirq.Rz(rads=0.25 * np.pi)(q0))
+    expected_ptm_matrix = ptm_matrix(circuit, 1)
+    assert expected_ptm_matrix.shape == (4**1, 4**1)
+    assert np.isclose(expected_ptm_matrix[0, 1], 0.0, rtol=1e-05)

--- a/mitiq/pt/tests/test_utils.py
+++ b/mitiq/pt/tests/test_utils.py
@@ -4,3 +4,38 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests for Pauli Twirling Utility functions."""
+
+import random
+
+import numpy as np
+
+from mitiq.pt.utils import _matrix_no_vec, _matrix_vec, _pauli_vectorized_list
+
+
+def test_matrix_to_vec():
+    """Check a square matrix is vectorized into a column vector."""
+    for i in range(1, 5):
+        func_output = _matrix_vec(np.random.rand(2**i, 2**i))
+        assert func_output.shape[-1] == 1
+
+
+def test_matrix_no_vec():
+    """Check a vec (column vector) is turned back into a square matrix."""
+    for i in range(1, 5):
+        vec_output = _matrix_vec(np.random.rand(2**i, 2**i))
+        vec_to_matrix = _matrix_no_vec(vec_output, i)
+        assert vec_to_matrix.shape[0] == vec_to_matrix.shape[-1]
+
+
+def test_size_of_pauli_vec():
+    """Check the output size of a list of n-qubit vec Paulis.
+
+    Number of n-qubit Paulis should be  4**num_qubits.
+    Size of each matrix should be 2**num_qubits.
+    """
+    for i in range(1, 5):
+        expected_output_pauli_vec_list = _pauli_vectorized_list(i)
+        assert len(expected_output_pauli_vec_list) == 4**i
+        # randomly check 1 entry in the output is a column vector
+        j = random.randrange(len(expected_output_pauli_vec_list) + 1)
+        assert expected_output_pauli_vec_list[j].shape[-1] == 1

--- a/mitiq/pt/tests/test_utils.py
+++ b/mitiq/pt/tests/test_utils.py
@@ -1,0 +1,6 @@
+# Copyright (C) Unitary Fund
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for Pauli Twirling Utility functions."""

--- a/mitiq/pt/utils.py
+++ b/mitiq/pt/utils.py
@@ -29,13 +29,8 @@ def _matrix_no_vec(vec_matrix, num_qubits):
     return np.transpose(vec_to_matrix)
 
 
-def _pauli_vectorized_list(num_qubits):
-    """Define a function to create a list of vectorized matrices.
-
-    If the density matrix of interest has more than n>1 qubits, the
-    Pauli group is used to generate n-fold tensor products before
-    vectorizing the unitaries.
-    """
+def _get_n_qubit_paulis(num_qubits):
+    """Get list of n-qubit Pauli unitaries."""
     pauli_unitary_list = [
         cirq.unitary((cirq.I)),
         cirq.unitary((cirq.X)),
@@ -54,8 +49,44 @@ def _pauli_vectorized_list(num_qubits):
                 new_pauli = np.kron(j, k)
                 empty_pauli_list.append(new_pauli)
         n_qubit_paulis = empty_pauli_list
+    return n_qubit_paulis
 
+
+def _pauli_vectorized_list(num_qubits):
+    """Define a function to create a list of vectorized matrices.
+
+    If the density matrix of interest has more than n>1 qubits, the
+    Pauli group is used to generate n-fold tensor products before
+    vectorizing the unitaries.
+    """
+    n_qubit_paulis = _get_n_qubit_paulis(num_qubits)
     output_pauli_vec_list = []
     for i in n_qubit_paulis:
         output_pauli_vec_list.append(_matrix_vec(i))
     return output_pauli_vec_list
+
+
+def ptm_matrix(circuit, num_qubits):
+    """Find the Pauli Transfer Matrix (PTM) of a circuit."""
+    superop = cirq.kraus_to_superoperator(cirq.kraus(circuit))
+    ptm_matrix = np.zeros([4**num_qubits, 4**num_qubits], dtype=complex)
+    vec_pauli = _pauli_vectorized_list(num_qubits)
+
+    for i in range(4**num_qubits):
+        superop_on_pauli_vec = np.matmul(superop, vec_pauli[i])
+        superop_on_pauli_matrix = _matrix_no_vec(
+            superop_on_pauli_vec, num_qubits
+        )
+        ptm_matrix_row = []
+
+        n_qubit_paulis = _get_n_qubit_paulis(num_qubits)
+        for j in range(4**num_qubits):
+            pauli_superop_pauli = np.matmul(
+                n_qubit_paulis[j], superop_on_pauli_matrix
+            )
+            ptm_matrix_row.append(
+                (0.5**num_qubits) * np.trace(pauli_superop_pauli)
+            )
+
+        ptm_matrix[i] = ptm_matrix_row
+        return ptm_matrix

--- a/mitiq/pt/utils.py
+++ b/mitiq/pt/utils.py
@@ -1,0 +1,60 @@
+# Copyright (C) Unitary Fund
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Utility functions for Pauli Twirling of CZ & CNOT gates."""
+
+import numpy as np
+import cirq
+
+
+pauli_unitary_list = [cirq.unitary((cirq.I)), cirq.unitary((cirq.X)),
+                      cirq.unitary((cirq.Y)), cirq.unitary((cirq.Z))]
+
+
+def _matrix_vec(matrix):
+    """Define the vectorized form of an array.
+
+    Transpose of a valid density matrix is converted into a
+    column vector such that some superoperator can act on the
+    vectorized form.
+    """
+    matrix_transpose = np.transpose(matrix)
+    return (np.reshape(matrix_transpose, (-1, 1)))
+
+
+def _matrix_no_vec(vec_matrix):
+    """Define the matrix form of a vectorized array.
+
+    Converts a column vector (vec) to a square matrix.
+    """
+    vec_to_matrix = np.reshape(vec_matrix, (2, 2))
+    return (np.transpose(vec_to_matrix))
+
+
+def _pauli_vectorized_list(num_qubits, pauli_unitary_list):
+    """Define a function to create a list of vectorized matrices.
+
+    If the density matrix of interest has more than n>1 qubits, the
+    Pauli group is used to generate n-fold tensor products before
+    vectorizing the unitaries.
+    """
+    # get the n-qubit paulis from the Pauli group
+    # diregard the n-qubit paulis with complex phase
+    n_qubit_paulis = pauli_unitary_list
+    for i in range(num_qubits - 1):
+        n_qubit_paulis = n_qubit_paulis
+        empty_pauli_list = []
+        for j in pauli_unitary_list:
+            for k in n_qubit_paulis:
+                new_pauli = np.kron(j, k)
+                empty_pauli_list.append(new_pauli)
+        n_qubit_paulis = empty_pauli_list
+
+    output_pauli_vec_list = []
+    for i in n_qubit_paulis:
+        output_pauli_vec_list.appen(_matrix_vec[i])
+    return (output_pauli_vec_list)
+
+

--- a/mitiq/pt/utils.py
+++ b/mitiq/pt/utils.py
@@ -69,24 +69,22 @@ def _pauli_vectorized_list(num_qubits):
 def ptm_matrix(circuit, num_qubits):
     """Find the Pauli Transfer Matrix (PTM) of a circuit."""
     superop = cirq.kraus_to_superoperator(cirq.kraus(circuit))
-    ptm_matrix = np.zeros([4**num_qubits, 4**num_qubits], dtype=complex)
     vec_pauli = _pauli_vectorized_list(num_qubits)
+    n_qubit_paulis = _get_n_qubit_paulis(num_qubits)
+    ptm_matrix = np.zeros([4**num_qubits, 4**num_qubits], dtype=complex)
 
-    for i in range(4**num_qubits):
+    for i in range(len(vec_pauli)):
         superop_on_pauli_vec = np.matmul(superop, vec_pauli[i])
         superop_on_pauli_matrix = _matrix_no_vec(
             superop_on_pauli_vec, num_qubits
         )
-        ptm_matrix_row = []
 
-        n_qubit_paulis = _get_n_qubit_paulis(num_qubits)
-        for j in range(4**num_qubits):
-            pauli_superop_pauli = np.matmul(
-                n_qubit_paulis[j], superop_on_pauli_matrix
-            )
+        ptm_matrix_row = []
+        for j in n_qubit_paulis:
+            pauli_superop_pauli = np.matmul(j, superop_on_pauli_matrix)
             ptm_matrix_row.append(
                 (0.5**num_qubits) * np.trace(pauli_superop_pauli)
             )
-
         ptm_matrix[i] = ptm_matrix_row
-        return ptm_matrix
+
+    return ptm_matrix

--- a/mitiq/pt/utils.py
+++ b/mitiq/pt/utils.py
@@ -5,12 +5,8 @@
 
 """Utility functions for Pauli Twirling of CZ & CNOT gates."""
 
-import numpy as np
 import cirq
-
-
-pauli_unitary_list = [cirq.unitary((cirq.I)), cirq.unitary((cirq.X)),
-                      cirq.unitary((cirq.Y)), cirq.unitary((cirq.Z))]
+import numpy as np
 
 
 def _matrix_vec(matrix):
@@ -21,27 +17,34 @@ def _matrix_vec(matrix):
     vectorized form.
     """
     matrix_transpose = np.transpose(matrix)
-    return (np.reshape(matrix_transpose, (-1, 1)))
+    return np.reshape(matrix_transpose, (-1, 1))
 
 
-def _matrix_no_vec(vec_matrix):
+def _matrix_no_vec(vec_matrix, num_qubits):
     """Define the matrix form of a vectorized array.
 
     Converts a column vector (vec) to a square matrix.
     """
-    vec_to_matrix = np.reshape(vec_matrix, (2, 2))
-    return (np.transpose(vec_to_matrix))
+    vec_to_matrix = np.reshape(vec_matrix, (2**num_qubits, 2**num_qubits))
+    return np.transpose(vec_to_matrix)
 
 
-def _pauli_vectorized_list(num_qubits, pauli_unitary_list):
+def _pauli_vectorized_list(num_qubits):
     """Define a function to create a list of vectorized matrices.
 
     If the density matrix of interest has more than n>1 qubits, the
     Pauli group is used to generate n-fold tensor products before
     vectorizing the unitaries.
     """
+    pauli_unitary_list = [
+        cirq.unitary((cirq.I)),
+        cirq.unitary((cirq.X)),
+        cirq.unitary((cirq.Y)),
+        cirq.unitary((cirq.Z)),
+    ]
+
     # get the n-qubit paulis from the Pauli group
-    # diregard the n-qubit paulis with complex phase
+    # disregard the n-qubit paulis with complex phase
     n_qubit_paulis = pauli_unitary_list
     for i in range(num_qubits - 1):
         n_qubit_paulis = n_qubit_paulis
@@ -54,7 +57,5 @@ def _pauli_vectorized_list(num_qubits, pauli_unitary_list):
 
     output_pauli_vec_list = []
     for i in n_qubit_paulis:
-        output_pauli_vec_list.appen(_matrix_vec[i])
-    return (output_pauli_vec_list)
-
-
+        output_pauli_vec_list.append(_matrix_vec(i))
+    return output_pauli_vec_list


### PR DESCRIPTION
Fixes #1914

- [x] Tests for the private functions converting from/to a square matrix to/from column vector: square matrix is a column vector, a column vector is a square matrix. 
- [x] Tests for the private function `_pauli_vectorized_list`: the size of the output list should be a power of 4^num_qubits, size of each matrix in the output array should be a power of 2^num_qubits
- [x] Main function for the PTM matrix
- [x] Test for the main function: TBD
- [ ] Use Pauli twirling on a circuit of CNOT/CZ & show the off-diagonal terms in the PTM matrix have disappeared after pauli twirling. 
- [ ] Formatting, type annotation, update docstrings etc. 