### PR TITLE
Non-linux draft tests failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,12 +159,12 @@ jobs:
         with:
           fail_ci_if_error: true
 
-  test-nonlinux-draft:
+  test-nonlinux-draft-mac:
     if: github.event.pull_request.draft == true
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -173,6 +173,69 @@ jobs:
         # Increase fetch depth to work around Codecov issue (https://github.com/codecov/codecov-action/issues/190).
         with:
           fetch-depth: 2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make install requirements
+
+      - name: Get changed directories (Linux and macOS)
+        id: changed_dirs
+        if: runner.os != 'Windows'
+        run: |
+          changed_directories=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '^mitiq/' | grep -v '/\.' | awk 'BEGIN{FS="/"}{print $2}' | uniq)
+          echo "Changed directories: $changed_directories"
+          echo "CHANGED_DIRECTORIES=$changed_directories" >> $GITHUB_ENV
+
+      - name: Get changed directories (Windows)
+        id: changed_dirs_windows
+        if: runner.os == 'Windows'
+        run: |
+          $changed_directories = git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | Select-String -Pattern '^mitiq/' | Select-String -NotMatch -Pattern '/\.' | ForEach-Object {($_ -split '/')[1]} | Select-Object -Unique
+          echo "Changed directories: $($changed_directories -join ' ')"
+          echo "cdirs=$changed_directories" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Run tests for changed directories
+        id: run_test_for_changed_dirs
+        if: runner.os != 'Windows'
+        run: |
+          echo $CHANGED_DIRECTORIES
+          for dir in $CHANGED_DIRECTORIES; do
+            make test-$dir
+          done
+
+      - name: Run tests for changed directories (Windows)
+        id: run_test_for_changed_dirs_windows
+        if: runner.os == 'Windows'
+        run: |
+          if (![string]::IsNullOrEmpty($env:cdirs)) {
+            $dirs = $env:cdirs -split " "
+            foreach ($dir in $dirs) {
+              echo "Running tests for directory: $dir"
+              make test-$dir
+            }
+          } else {
+            echo "No directories to test."
+          }
+
+  test-nonlinux-draft-windows:
+    if: github.event.pull_request.draft == true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out mitiq
+        uses: actions/checkout@v3
+        # Increase fetch depth to work around Codecov issue (https://github.com/codecov/codecov-action/issues/190).
+        # fetch depth set to 0 (https://stackoverflow.com/questions/71204693/git-diff-not-working-on-github-actions-fatal-bad-object-7100c3bbc34a9667ca9034/76769122#76769122).
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Fixes #1974

This is a quick workaround to fix the build failures in #1963. 

I am not too familiar with why `fetch_depth=2` works for mac while `fetch_depth=0` works for windows. 