### PR TITLE
Fix typos in theory section of ddd guide

### DIFF
--- a/docs/source/guide/ddd-5-theory.md
+++ b/docs/source/guide/ddd-5-theory.md
@@ -32,7 +32,7 @@ In the context of quantum computing, DD can be considered as an error mitigation
 With respect to other error mitigation techniques, DD has very peculiar features:
 
 - It maps a noisy quantum computation to a _single_ error-mitigated computation (no need to take linear combinations
-of noisy results as in [ZNE](zne-5-theory.md [PEC](pec-5-theory.md) and [CDR](cdr-5-theory.md)).
+of noisy results as in [ZNE](zne-5-theory.md) [PEC](pec-5-theory.md) and [CDR](cdr-5-theory.md)).
 
 - As a consequence of the previous point, there is not a fundamental error mitigation overhead or
 increase in statistical uncertainty in the final result.

--- a/docs/source/guide/ddd-5-theory.md
+++ b/docs/source/guide/ddd-5-theory.md
@@ -32,7 +32,7 @@ In the context of quantum computing, DD can be considered as an error mitigation
 With respect to other error mitigation techniques, DD has very peculiar features:
 
 - It maps a noisy quantum computation to a _single_ error-mitigated computation (no need to take linear combinations
-of noisy results as in [ZNE](zne-5-theory.md) [PEC](pec-5-theory.md) and [CDR](cdr-5-theory.md)).
+of noisy results as in [ZNE](zne-5-theory.md), [PEC](pec-5-theory.md), and [CDR](cdr-5-theory.md)).
 
 - As a consequence of the previous point, there is not a fundamental error mitigation overhead or
 increase in statistical uncertainty in the final result.


### PR DESCRIPTION

## Description

Fix typos in theory section of ddd guide

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file