### PR TITLE
Speed up a few tests

### DIFF
--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -23,7 +23,6 @@ from mitiq.calibration.calibrator import (
 from mitiq.calibration.settings import (
     BenchmarkProblem,
     MitigationTechnique,
-    PECSettings,
     Strategy,
     ZNESettings,
 )
@@ -167,10 +166,10 @@ def test_ZNE_workflow():
 
 def test_PEC_workflow():
     cal = Calibrator(
-        depolarizing_execute, frontend="cirq", settings=PECSettings
+        depolarizing_execute, frontend="cirq", settings=light_pec_settings
     )
     cost = cal.get_cost()
-    assert cost == {"noisy_executions": 4 * 2 * 200, "ideal_executions": 0}
+    assert cost == {"noisy_executions": 2 * 200, "ideal_executions": 0}
 
     cal.run()
     assert isinstance(cal.results, ExperimentResults)

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -466,7 +466,7 @@ def decorated_serial_executor(circuit: QPROGRAM) -> float:
         [1.0],
     )
 
-    @pec_decorator(representations=[rep])
+    @pec_decorator(representations=[rep], precision=0.08)
     def decorated_executor(qp):
         return serial_executor(qp)
 

--- a/mitiq/qse/tests/test_qse.py
+++ b/mitiq/qse/tests/test_qse.py
@@ -95,47 +95,14 @@ def test_execute_with_qse():
     assert abs(mitigated_value.real - 0.5) < abs(unmitigated_value.real - 0.5)
 
 
-def test_mitigate_executor():
+def test_mitigate_executor_batched():
     qc = prepare_logical_0_state_for_5_1_3_code()
     (
         check_operators,
         code_hamiltonian,
     ) = get_5_1_3_code_check_operators_and_code_hamiltonian()
 
-    observable = get_observable_in_code_space(PauliString("ZZZZZ"))
-    mitigated_executor = mitigate_executor(
-        execute_with_depolarized_noise,
-        check_operators,
-        code_hamiltonian,
-        observable,
-    )
-    batched_mitigated_executor = mitigate_executor(
-        batched_execute_with_depolarized_noise,
-        check_operators,
-        code_hamiltonian,
-        observable,
-    )
-    unmitigated_value = observable.expectation(
-        qc, execute_with_depolarized_noise
-    )
-    mitigated_value = mitigated_executor(qc)
-    assert abs(mitigated_value.real - 1) < abs(unmitigated_value.real - 1)
-
-    batched_mitigated_values = batched_mitigated_executor([qc] * 3)
-    assert all(
-        [
-            abs(mitigated_value.real - 1) < abs(unmitigated_value.real - 1)
-            for mitigated_value in batched_mitigated_values
-        ]
-    )
-
     observable = get_observable_in_code_space(PauliString("XXXXX"))
-    mitigated_executor = mitigate_executor(
-        execute_with_depolarized_noise,
-        check_operators,
-        code_hamiltonian,
-        observable,
-    )
     batched_mitigated_executor = mitigate_executor(
         batched_execute_with_depolarized_noise,
         check_operators,
@@ -145,15 +112,11 @@ def test_mitigate_executor():
     unmitigated_value = observable.expectation(
         qc, execute_with_depolarized_noise
     )
-    mitigated_value = mitigated_executor(qc)
-    assert abs(mitigated_value.real - 0.5) < abs(unmitigated_value.real - 0.5)
 
     batched_mitigated_values = batched_mitigated_executor([qc] * 3)
     assert all(
-        [
-            abs(mitigated_value.real - 0.5) < abs(unmitigated_value.real - 0.5)
-            for mitigated_value in batched_mitigated_values
-        ]
+        abs(mitigated_value.real - 0.5) < abs(unmitigated_value.real - 0.5)
+        for mitigated_value in batched_mitigated_values
     )
 
 


### PR DESCRIPTION
## Description

As part of https://github.com/unitaryfund/mitiq/issues/1427 we are trying to speed up tests by removing unnecessary or redundant workloads.

On my machine this brought execution time of `make test` down from 553s to 343s!

### Reviewer notes

This PR is likely best reviewed commit by commit. Further work needs to be done, but good to make progress over time.

Assigning Nathan + Andrea since Misty and I both worked on this.