### PR TITLE
1988 contributing doc note for zsh shell

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,3 +50,4 @@ Dariel Mok
 Preksha Naik
 Abdulrahman Sahmoud
 Mohammad Zuhair Khan
+Brian Goldsmith

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,8 @@ conda activate myenv
 ```
 pip install -e .[development]
 ```
+**Note**: If the command above fails with the error: "zsh: no matches found: .[development]", this is a behavior of z shell and can be corrected by including quotes around .[development] like:
+pip install -e ".[development]"
 6. You should now have a development environment set up to work on Mitiq! 🎉 To go forward with making the desired changes, please consult the ["Making changes" section](https://www.asmeurer.com/git-workflow/#making-changes) of the `git` workflow article. If you've encountered any problems thus far, please let us know by opening an issue! More information about workflow can be found below in the [lifecycle](#lifecycle) section.
 
 What follows are recommendations/requirements to keep in mind while contributing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,8 @@ conda activate myenv
 ```
 5. Install the dependencies. First, to get an updated version of [`pip`](https://pypi.org/project/pip/) inside the virtual environment run `conda install pip` followed by
 ```
-pip install -e .[development]
-```
-**Note**: If the command above fails with the error: "zsh: no matches found: .[development]", this is a behavior of z shell and can be corrected by including quotes around .[development] like:
 pip install -e ".[development]"
+```
 6. You should now have a development environment set up to work on Mitiq! 🎉 To go forward with making the desired changes, please consult the ["Making changes" section](https://www.asmeurer.com/git-workflow/#making-changes) of the `git` workflow article. If you've encountered any problems thus far, please let us know by opening an issue! More information about workflow can be found below in the [lifecycle](#lifecycle) section.
 
 What follows are recommendations/requirements to keep in mind while contributing.


### PR DESCRIPTION
## Description
On step 5 of the Development environment section of the [Contributing to Mitiq](https://mitiq.readthedocs.io/en/latest/contributing.html) page, if [z shell](https://www.zsh.org/) (zsh) is used, the .[development] needs to have quotes around it. Since using quotes works for all shells, the docs have been changed to use quotes.

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [X] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [X] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [X] Added myself / the copyright holder to the AUTHORS file