### PR TITLE
Include calculated error in calibrator logs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -53,3 +53,4 @@ Abdulrahman Sahmoud
 Mohammad Zuhair Khan
 Brian Goldsmith
 Farzad Kianvash
+Vladimir Kozhukalov

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -381,6 +381,8 @@ def test_logging(capfd):
     assert "ZNE results:" in captured.out
     assert "PEC results:" in captured.out
     assert settings.get_strategy(0).technique.name in captured.out
+    assert "noisy error" in captured.out
+    assert "mitigated error" in captured.out
 
 
 def test_ExperimentResults_reset_data():


### PR DESCRIPTION
## Description

Calibration log table is extended with errors calculated
during calibration and sorted so that best
techniques are on the top of the table.


Fixes #2014

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file