### PR TITLE
Drop support for python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out mitiq
@@ -127,7 +127,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out mitiq
@@ -189,7 +189,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out mitiq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ The rest of this document describes the technical details of getting set up to d
 
 ## Development environment
 
-1. Ensure you have python 3.8 or greater installed. If not, you can find the downloads [here](https://www.python.org/downloads/).
+1. Ensure you have python 3.9 or greater installed. If not, you can find the downloads [here](https://www.python.org/downloads/).
 2. Set up a virtual environment to isolate dependencies. This can be done with many different tools including [Virtualenv](https://virtualenv.pypa.io/en/latest/), [Pipenv](https://pypi.org/project/pipenv/), [Poetry](https://python-poetry.org/), and [Anaconda](https://www.anaconda.com/products/distribution). In what follows we will use Anaconda, but if you're familiar with other tools feel free to use those.
 3. Set up a local version of the [Mitiq repository](https://github.com/unitaryfund/mitiq). To do this you will need to use `git` which is a version control system. If you're unfamiliar, check out the [docs](https://git-scm.com/), and learn about what the typical [`git` workflow](https://www.asmeurer.com/git-workflow/) looks like.
 4. Inside the Mitiq repository (`cd mitiq`), activate a virtual environment. With conda this is done using the following command.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,7 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.8", None),
+    "python": ("https://docs.python.org/3.9", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
     # Cirq is no longer using sphinx docs so interlinking is not possible.
@@ -364,7 +364,6 @@ nbsphinx_thumbnails = {
     "examples/quantum_simulation_scars_ibmq": "_static/qmbs_ibmq.png",
     "examples/zne_logical_rb_cirq_stim": "_static/mitiq_stim_logo.png",
     "examples/quantum_simulation_1d_ising": "_static/quantum_simulation.png",
-
     # default images if no thumbnail is specified
     "examples/*": "_static/mitiq-logo.png",
 }

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "Documentation": "https://mitiq.readthedocs.io/en/stable/",
         "Source": "https://github.com/unitaryfund/mitiq/",
     },
-    python_requires=">=3.8,<3.12",
+    python_requires=">=3.9,<3.12",
 )
 
 # restore _version.py to its previous state


### PR DESCRIPTION
## Description

Does what is says on the 🥫.

This is needed over https://github.com/unitaryfund/mitiq/pull/2066 as #2066 includes upgrading to 3.12 which it looks like we cannot do just yet due to some dependencies not supporting 3.12.