### PR TITLE
Remove "binder" remnants

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,1 +1,0 @@
-.[development]


### PR DESCRIPTION
## Description

Since we no longer use/advertise the use of mybinder (#1970), we can remove the `binder` directory. Support for binder was originally added in https://github.com/unitaryfund/mitiq/pull/841.