### PR TITLE
Remove dependabot upgrade

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,6 +7,7 @@ pennylane-qiskit~=0.33.0
 pennylane~=0.32.0
 amazon-braket-sdk~=1.61.0
 
+
 # Unit tests, coverage, and formatting/style.
 pytest==7.1.3
 pytest-xdist[psutil]==3.0.2


### PR DESCRIPTION
3457774734f9759c2a828d84ad5af3801eab23e1 is causing test failures as noticed in 

https://github.com/purva-thakre/mitiq/actions/runs/7041305777/job/19163631827#step:6:13389 and https://github.com/unitaryfund/mitiq/actions/runs/7025805054/job/19117338257?pr=2099#step:6:13391.



