### PR TITLE
Add randomized clifford+T benchmarking circuits.

### DIFF
--- a/docs/source/apidoc.md
+++ b/docs/source/apidoc.md
@@ -12,24 +12,28 @@
 ### Classical Shadows
 
 #### Classical Shadows (High-Level Tools)
+
 ```{eval-rst}
 .. automodule:: mitiq.shadows.shadows
    :members:
 ```
 
 #### Quantum Processing
+
 ```{eval-rst}
 .. automodule:: mitiq.shadows.quantum_processing
    :members:
 ```
 
 #### Classical Post-Processing
+
 ```{eval-rst}
 .. automodule:: mitiq.shadows.classical_postprocessing
    :members:
 ```
 
 #### Utility Functions
+
 ```{eval-rst}
 .. automodule:: mitiq.shadows.shadows_utils
    :members:
@@ -38,18 +42,21 @@
 ### Clifford Data Regression
 
 #### Clifford Data Regression (High-Level Tools)
+
 ```{eval-rst}
 .. automodule:: mitiq.cdr.cdr
    :members:
 ```
 
 #### Clifford Training Data
+
 ```{eval-rst}
 .. automodule:: mitiq.cdr.clifford_training_data
    :members:
 ```
 
 #### Data Regression
+
 ```{eval-rst}
 .. automodule:: mitiq.cdr.data_regression
    :members:
@@ -60,25 +67,28 @@ See Ref. {cite}`Czarnik_2021_Quantum` for more details on these methods.
 ### Digital Dynamical Decoupling
 
 #### Digital Dynamical Decoupling (High-Level Tools)
+
 ```{eval-rst}
 .. automodule:: mitiq.ddd.ddd
    :members:
 ```
 
 #### Insertion
+
 ```{eval-rst}
 .. automodule:: mitiq.ddd.insertion
    :members:
 ```
 
 #### Rules
+
 ```{eval-rst}
 .. automodule:: mitiq.ddd.rules.rules
    :members:
 ```
 
-
 ### Pauli Twirling
+
 ```{eval-rst}
 .. automodule:: mitiq.pt.pt
    :members:
@@ -87,12 +97,14 @@ See Ref. {cite}`Czarnik_2021_Quantum` for more details on these methods.
 ### Probabilistic Error Cancellation
 
 #### Probabilistic Error Cancellation (High-Level Tools)
+
 ```{eval-rst}
 .. automodule:: mitiq.pec.pec
    :members:
 ```
 
 #### Quasi-Probability Representations
+
 ```{eval-rst}
 .. automodule:: mitiq.pec.representations.optimal
    :members:
@@ -105,6 +117,7 @@ See Ref. {cite}`Czarnik_2021_Quantum` for more details on these methods.
 ```
 
 #### Learning-based PEC
+
 ```{eval-rst}
 .. automodule:: mitiq.pec.representations.biased_noise
    :members:
@@ -114,37 +127,44 @@ See Ref. {cite}`Czarnik_2021_Quantum` for more details on these methods.
 ```
 
 #### Sampling from a Noisy Decomposition of an Ideal Operation
+
 ```{eval-rst}
 .. automodule:: mitiq.pec.sampling
    :members:
 ```
 
 #### Probabilistic Error Cancellation Types
+
 ```{eval-rst}
 .. automodule:: mitiq.pec.types.types
    :members:
 ```
 
 #### Utilities for Quantum Channels
+
 ```{eval-rst}
 .. automodule:: mitiq.pec.channels
    :members:
 ```
 
 ### Quantum Subspace Expansion
+
 ```{eval-rst}
 .. automodule:: mitiq.qse.qse
    :members:
 ```
+
 ### Readout-Error Mitigation
 
 #### Postselection
+
 ```{eval-rst}
 .. automodule:: mitiq.rem.post_select
    :members:
 ```
 
 #### REM Technique
+
 ```{eval-rst}
 .. automodule:: mitiq.rem.rem
    :members:
@@ -153,47 +173,53 @@ See Ref. {cite}`Czarnik_2021_Quantum` for more details on these methods.
 ### Zero Noise Extrapolation
 
 #### Zero Noise Extrapolation (High-Level Tools)
+
 ```{eval-rst}
 .. automodule:: mitiq.zne.zne
    :members:
 ```
 
 #### Inference and Extrapolation: Factories
+
 ```{eval-rst}
 .. automodule:: mitiq.zne.inference
    :members:
 ```
 
 #### Noise Scaling: Unitary Folding
+
 ```{eval-rst}
 .. automodule:: mitiq.zne.scaling.folding
    :members:
 ```
 
 #### Noise Scaling: Identity Insertion Scaling
+
 ```{eval-rst}
 .. automodule:: mitiq.zne.scaling.identity_insertion
    :members:
 ```
 
 #### Noise Scaling: Layerwise Folding
+
 ```{eval-rst}
 .. automodule:: mitiq.zne.scaling.layer_scaling
    :members:
 ```
 
 #### Noise Scaling: Parameter Calibration
+
 ```{eval-rst}
 .. automodule:: mitiq.zne.scaling.parameter
    :members:
 ```
-
 
 ## Tools For Error Mitigation
 
 ### Benchmarks
 
 #### GHZ Circuits
+
 ```{eval-rst}
 .. automodule:: mitiq.benchmarks.ghz_circuits
    :members:
@@ -206,26 +232,26 @@ See Ref. {cite}`Czarnik_2021_Quantum` for more details on these methods.
    :members:
 ```
 
-
 #### Mirror Quantum Volume Circuits
+
 ```{eval-rst}
 .. automodule:: mitiq.benchmarks.mirror_qv_circuits
    :members:
 ```
 
 #### Quantum Phase Estimation Circuits
+
 ```{eval-rst}
 .. automodule:: mitiq.benchmarks.qpe_circuits
    :members:
 ```
 
-
 #### Quantum Volume Circuits
+
 ```{eval-rst}
 .. automodule:: mitiq.benchmarks.quantum_volume_circuits
    :members:
 ```
-
 
 #### Randomized Benchmarking Circuits
 
@@ -241,8 +267,15 @@ See Ref. {cite}`Czarnik_2021_Quantum` for more details on these methods.
    :members:
 ```
 
+#### Randomized Clifford+T benchmarking Circuits
+
+```{eval-rst}
+.. automodule:: mitiq.benchmarks.randomized_clifford_t_circuit
+   :members:
+```
 
 #### W State Circuits
+
 ```{eval-rst}
 .. automodule:: mitiq.benchmarks.w_state_circuits
    :members:
@@ -259,6 +292,7 @@ See Ref. {cite}`Czarnik_2021_Quantum` for more details on these methods.
 ```
 
 ### Executors
+
 ```{eval-rst}
 .. automodule:: mitiq.executor.executor
    :members:
@@ -267,12 +301,14 @@ See Ref. {cite}`Czarnik_2021_Quantum` for more details on these methods.
 ### Observables
 
 #### Observable
+
 ```{eval-rst}
 .. automodule:: mitiq.observable.observable
    :members:
 ```
 
 #### Pauli Observable
+
 ```{eval-rst}
 .. automodule:: mitiq.observable.pauli
    :members:
@@ -281,6 +317,7 @@ See Ref. {cite}`Czarnik_2021_Quantum` for more details on these methods.
 ### Raw
 
 #### Run experiments without error mitigation (raw results)
+
 ```{eval-rst}
 .. automodule:: mitiq.raw.raw
 ```
@@ -309,32 +346,36 @@ See Ref. {cite}`Czarnik_2021_Quantum` for more details on these methods.
 ### Mitiq Interface
 
 #### Braket Conversions
+
 ```{eval-rst}
 .. automodule:: mitiq.interface.mitiq_braket.conversions
    :members:
 ```
 
 #### Cirq Utils
+
 ```{eval-rst}
 .. automodule:: mitiq.interface.mitiq_cirq.cirq_utils
    :members:
 ```
 
 #### PyQuil Conversions
+
 ```{eval-rst}
 .. automodule:: mitiq.interface.mitiq_pyquil.conversions
    :members:
 ```
 
 #### Qiskit Conversions
+
 ```{eval-rst}
 .. automodule:: mitiq.interface.mitiq_qiskit.conversions
    :members:
 ```
 
 #### Qiskit Utils
+
 ```{eval-rst}
 .. automodule:: mitiq.interface.mitiq_qiskit.qiskit_utils
    :members:
 ```
-

--- a/docs/source/apidoc.md
+++ b/docs/source/apidoc.md
@@ -267,7 +267,7 @@ See Ref. {cite}`Czarnik_2021_Quantum` for more details on these methods.
    :members:
 ```
 
-#### Randomized Clifford+T benchmarking Circuits
+#### Randomized Clifford+T Circuits
 
 ```{eval-rst}
 .. automodule:: mitiq.benchmarks.randomized_clifford_t_circuit

--- a/mitiq/benchmarks/__init__.py
+++ b/mitiq/benchmarks/__init__.py
@@ -14,3 +14,4 @@ from mitiq.benchmarks.quantum_volume_circuits import (
 )
 from mitiq.benchmarks.w_state_circuits import generate_w_circuit
 from mitiq.benchmarks.qpe_circuits import generate_qpe_circuit
+from mitiq.benchmarks import generate_random_clifford_t_circuit

--- a/mitiq/benchmarks/__init__.py
+++ b/mitiq/benchmarks/__init__.py
@@ -14,4 +14,6 @@ from mitiq.benchmarks.quantum_volume_circuits import (
 )
 from mitiq.benchmarks.w_state_circuits import generate_w_circuit
 from mitiq.benchmarks.qpe_circuits import generate_qpe_circuit
-from mitiq.benchmarks import generate_random_clifford_t_circuit
+from mitiq.benchmarks.randomized_clifford_t_circuit import (
+    generate_random_clifford_t_circuit,
+)

--- a/mitiq/benchmarks/randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/randomized_clifford_t_circuit.py
@@ -46,6 +46,11 @@ def generate_random_clifford_t_circuit(
         A list of the heavy bitstrings for the returned circuit.
     """
 
+    if num_qubits <= 0:
+        raise ValueError(
+            "Cannot prepare a circuit with {} qubits", num_qubits
+        )
+
     rnd_state = np.random.RandomState(seed)
 
     oneq_cliffords = [cirq.S, cirq.H]   # This list could be user-defined or not

--- a/mitiq/benchmarks/randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/randomized_clifford_t_circuit.py
@@ -1,0 +1,93 @@
+# Copyright (C) Unitary Fund
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Functions for generating rotated randomized benchmarking circuits."""
+from typing import Optional, Sequence, Tuple
+
+import cirq
+import numpy as np
+
+#from cirq import S, H, CNOT, T, Circuit
+from cirq.contrib.quantum_volume import compute_heavy_set
+from cirq.value import big_endian_int_to_bits
+
+from mitiq import QPROGRAM, Bitstring
+from mitiq.interface import convert_from_mitiq
+
+
+
+#def generate_random_clifford_t_circuit(seed, num_oneq_cliffords, num_twoq_cliffords, num_t):
+def generate_random_clifford_t_circuit(
+    num_qubits: int,
+    num_oneq_cliffords: int,
+    num_twoq_cliffords: int,
+    num_t_gates: int,
+    return_type: Optional[str] = None,
+    seed: Optional[int] = None,
+) -> Tuple[QPROGRAM, Sequence[Bitstring]]:
+    r"""Generate a random quantum circuit with the given number of qubits, number of one-qubit Cliffords,
+     number of two-qubit Cliffords and number of T gates.
+
+    Args:
+        num_qubits: The number of qubits in the generated circuit.
+        num_oneq_cliffords: Number of one-qubit Cliffords to be used.
+        num_twoq_cliffords: Number of two-qubit Cliffords to be used.
+        num_t_gates: Number of T gates to be used.
+        seed: Seed for generating random circuit.
+        return_type: String which specifies the type of the returned
+            circuits. See the keys of ``mitiq.SUPPORTED_PROGRAM_TYPES``
+            for options. If ``None``, the returned circuits have type
+            ``cirq.Circuit``.
+
+    Returns:
+        A quantum circuit acting on ``num_qubits`` qubits.
+        A list of the heavy bitstrings for the returned circuit.
+    """
+
+    rnd_state = np.random.RandomState(seed)
+
+    oneq_cliffords = [cirq.S, cirq.H]   # This list could be user-defined or not
+    twoq_cliffords = [cirq.CNOT, cirq.CZ]   # This list could be user-defined or not
+    oneq_list = [rnd_state.choice(oneq_cliffords) for _ in range(num_oneq_cliffords)]
+    twoq_list = [rnd_state.choice(twoq_cliffords) for _ in range(num_twoq_cliffords)]
+    t_list = [cirq.T for _ in range(num_t_gates)]
+
+    all_gates = oneq_list + twoq_list + t_list
+    rnd_state.shuffle(all_gates)
+
+    qubits = cirq.LineQubit.range(num_qubits)
+    circuit = cirq.Circuit()
+
+    for gate in all_gates:
+        qubits_for_gate = rnd_state.choice(qubits, size=gate.num_qubits(), replace=False)
+        operation = gate.on(*qubits_for_gate)
+        circuit.append(operation)
+
+    heavy_bitstrings = compute_heavy_bitstrings(circuit, num_qubits)
+
+    return_type = "cirq" if not return_type else return_type
+    return convert_from_mitiq(circuit, return_type), heavy_bitstrings
+
+def compute_heavy_bitstrings(
+    circuit: cirq.Circuit,
+    num_qubits: int,
+) -> Sequence[Bitstring]:
+    """Classically compute the heavy bitstrings of the provided circuit.
+
+    The heavy bitstrings are defined as the output bit-strings that have a
+    greater than median probability of being generated.
+
+    Args:
+        circuit: The circuit to classically simulate.
+
+    Returns:
+        A list containing the heavy bitstrings.
+    """
+    heavy_vals = compute_heavy_set(circuit)
+    # Convert base-10 ints to Bitstrings.
+    heavy_bitstrings = [
+        big_endian_int_to_bits(val, bit_count=num_qubits) for val in heavy_vals
+    ]
+    return heavy_bitstrings

--- a/mitiq/benchmarks/randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/randomized_clifford_t_circuit.py
@@ -4,16 +4,12 @@
 # LICENSE file in the root directory of this source tree.
 
 """Functions for generating rotated randomized benchmarking circuits."""
-from typing import Optional, Sequence, Tuple
+from typing import Optional
 
 import cirq
 import numpy as np
 
-# from cirq import S, H, CNOT, T, Circuit
-from cirq.contrib.quantum_volume import compute_heavy_set
-from cirq.value import big_endian_int_to_bits
-
-from mitiq import QPROGRAM, Bitstring
+from mitiq import QPROGRAM
 from mitiq.interface import convert_from_mitiq
 
 
@@ -24,7 +20,7 @@ def generate_random_clifford_t_circuit(
     num_t_gates: int,
     return_type: Optional[str] = None,
     seed: Optional[int] = None,
-) -> Tuple[QPROGRAM, Sequence[Bitstring]]:
+) -> QPROGRAM:
     r"""Generate a random quantum circuit with the given number of qubits,
     number of one-qubit Cliffords, number of two-qubit Cliffords and number
     of T gates.
@@ -79,30 +75,5 @@ def generate_random_clifford_t_circuit(
         operation = gate.on(*qubits_for_gate)
         circuit.append(operation)
 
-    heavy_bitstrings = compute_heavy_bitstrings(circuit, num_qubits)
-
     return_type = "cirq" if not return_type else return_type
-    return convert_from_mitiq(circuit, return_type), heavy_bitstrings
-
-
-def compute_heavy_bitstrings(
-    circuit: cirq.Circuit,
-    num_qubits: int,
-) -> Sequence[Bitstring]:
-    """Classically compute the heavy bitstrings of the provided circuit.
-
-    The heavy bitstrings are defined as the output bit-strings that have a
-    greater than median probability of being generated.
-
-    Args:
-        circuit: The circuit to classically simulate.
-
-    Returns:
-        A list containing the heavy bitstrings.
-    """
-    heavy_vals = compute_heavy_set(circuit)
-    # Convert base-10 ints to Bitstrings.
-    heavy_bitstrings = [
-        big_endian_int_to_bits(val, bit_count=num_qubits) for val in heavy_vals
-    ]
-    return heavy_bitstrings
+    return convert_from_mitiq(circuit, return_type)

--- a/mitiq/benchmarks/randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/randomized_clifford_t_circuit.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Functions for generating rotated randomized benchmarking circuits."""
 from typing import Optional
 
 import cirq

--- a/mitiq/benchmarks/randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/randomized_clifford_t_circuit.py
@@ -53,8 +53,8 @@ def generate_random_clifford_t_circuit(
 
     rnd_state = np.random.RandomState(seed)
 
-    oneq_cliffords = [cirq.S, cirq.H]   # This list could be user-defined or not
-    twoq_cliffords = [cirq.CNOT, cirq.CZ]   # This list could be user-defined or not
+    oneq_cliffords = [cirq.S, cirq.H]
+    twoq_cliffords = [cirq.CNOT, cirq.CZ]
     oneq_list = [rnd_state.choice(oneq_cliffords) for _ in range(num_oneq_cliffords)]
     twoq_list = [rnd_state.choice(twoq_cliffords) for _ in range(num_twoq_cliffords)]
     t_list = [cirq.T for _ in range(num_t_gates)]

--- a/mitiq/benchmarks/randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/randomized_clifford_t_circuit.py
@@ -48,7 +48,11 @@ def generate_random_clifford_t_circuit(
 
     if num_qubits <= 0:
         raise ValueError(
-            "Cannot prepare a circuit with {} qubits", num_qubits
+            "Cannot prepare a circuit with {} qubits.", num_qubits
+        )
+    elif num_qubits == 1 and num_twoq_cliffords > 0:
+        raise ValueError(
+            "Need more than 2 qubits for two-qubit Clifford gates."
         )
 
     rnd_state = np.random.RandomState(seed)

--- a/mitiq/benchmarks/randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/randomized_clifford_t_circuit.py
@@ -17,7 +17,6 @@ from mitiq import QPROGRAM, Bitstring
 from mitiq.interface import convert_from_mitiq
 
 
-
 #def generate_random_clifford_t_circuit(seed, num_oneq_cliffords, num_twoq_cliffords, num_t):
 def generate_random_clifford_t_circuit(
     num_qubits: int,

--- a/mitiq/benchmarks/randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/randomized_clifford_t_circuit.py
@@ -9,7 +9,7 @@ from typing import Optional, Sequence, Tuple
 import cirq
 import numpy as np
 
-#from cirq import S, H, CNOT, T, Circuit
+# from cirq import S, H, CNOT, T, Circuit
 from cirq.contrib.quantum_volume import compute_heavy_set
 from cirq.value import big_endian_int_to_bits
 
@@ -17,7 +17,7 @@ from mitiq import QPROGRAM, Bitstring
 from mitiq.interface import convert_from_mitiq
 
 
-#def generate_random_clifford_t_circuit(seed, num_oneq_cliffords, num_twoq_cliffords, num_t):
+# def generate_random_clifford_t_circuit(seed, num_oneq_cliffords, num_twoq_cliffords, num_t):
 def generate_random_clifford_t_circuit(
     num_qubits: int,
     num_oneq_cliffords: int,
@@ -58,8 +58,12 @@ def generate_random_clifford_t_circuit(
 
     oneq_cliffords = [cirq.S, cirq.H]
     twoq_cliffords = [cirq.CNOT, cirq.CZ]
-    oneq_list = [rnd_state.choice(oneq_cliffords) for _ in range(num_oneq_cliffords)]
-    twoq_list = [rnd_state.choice(twoq_cliffords) for _ in range(num_twoq_cliffords)]
+    oneq_list = [
+        rnd_state.choice(oneq_cliffords) for _ in range(num_oneq_cliffords)
+    ]
+    twoq_list = [
+        rnd_state.choice(twoq_cliffords) for _ in range(num_twoq_cliffords)
+    ]
     t_list = [cirq.T for _ in range(num_t_gates)]
 
     all_gates = oneq_list + twoq_list + t_list
@@ -69,7 +73,9 @@ def generate_random_clifford_t_circuit(
     circuit = cirq.Circuit()
 
     for gate in all_gates:
-        qubits_for_gate = rnd_state.choice(qubits, size=gate.num_qubits(), replace=False)
+        qubits_for_gate = rnd_state.choice(
+            qubits, size=gate.num_qubits(), replace=False
+        )
         operation = gate.on(*qubits_for_gate)
         circuit.append(operation)
 
@@ -77,6 +83,7 @@ def generate_random_clifford_t_circuit(
 
     return_type = "cirq" if not return_type else return_type
     return convert_from_mitiq(circuit, return_type), heavy_bitstrings
+
 
 def compute_heavy_bitstrings(
     circuit: cirq.Circuit,

--- a/mitiq/benchmarks/randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/randomized_clifford_t_circuit.py
@@ -38,7 +38,6 @@ def generate_random_clifford_t_circuit(
 
     Returns:
         A quantum circuit acting on ``num_qubits`` qubits.
-        A list of the heavy bitstrings for the returned circuit.
     """
 
     if num_qubits <= 0:
@@ -54,12 +53,9 @@ def generate_random_clifford_t_circuit(
 
     oneq_cliffords = [cirq.S, cirq.H]
     twoq_cliffords = [cirq.CNOT, cirq.CZ]
-    oneq_idx_list = [
-        rnd_state.choice(list(range(len(oneq_cliffords)))) for _ in range(3)
-    ]
-    twoq_idx_list = [
-        rnd_state.choice(list(range(len(twoq_cliffords)))) for _ in range(3)
-    ]
+
+    oneq_idx_list = rnd_state.choice(len(oneq_cliffords), num_oneq_cliffords)
+    twoq_idx_list = rnd_state.choice(len(twoq_cliffords), num_twoq_cliffords)
 
     oneq_list = [oneq_cliffords[i] for i in oneq_idx_list]
     twoq_list = [twoq_cliffords[i] for i in twoq_idx_list]

--- a/mitiq/benchmarks/randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/randomized_clifford_t_circuit.py
@@ -17,7 +17,6 @@ from mitiq import QPROGRAM, Bitstring
 from mitiq.interface import convert_from_mitiq
 
 
-# def generate_random_clifford_t_circuit(seed, num_oneq_cliffords, num_twoq_cliffords, num_t):
 def generate_random_clifford_t_circuit(
     num_qubits: int,
     num_oneq_cliffords: int,
@@ -26,8 +25,9 @@ def generate_random_clifford_t_circuit(
     return_type: Optional[str] = None,
     seed: Optional[int] = None,
 ) -> Tuple[QPROGRAM, Sequence[Bitstring]]:
-    r"""Generate a random quantum circuit with the given number of qubits, number of one-qubit Cliffords,
-     number of two-qubit Cliffords and number of T gates.
+    r"""Generate a random quantum circuit with the given number of qubits,
+    number of one-qubit Cliffords, number of two-qubit Cliffords and number
+    of T gates.
 
     Args:
         num_qubits: The number of qubits in the generated circuit.

--- a/mitiq/benchmarks/randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/randomized_clifford_t_circuit.py
@@ -54,12 +54,16 @@ def generate_random_clifford_t_circuit(
 
     oneq_cliffords = [cirq.S, cirq.H]
     twoq_cliffords = [cirq.CNOT, cirq.CZ]
-    oneq_list = [
-        rnd_state.choice(oneq_cliffords) for _ in range(num_oneq_cliffords)
+    oneq_idx_list = [
+        rnd_state.choice(list(range(len(oneq_cliffords)))) for _ in range(3)
     ]
-    twoq_list = [
-        rnd_state.choice(twoq_cliffords) for _ in range(num_twoq_cliffords)
+    twoq_idx_list = [
+        rnd_state.choice(list(range(len(twoq_cliffords)))) for _ in range(3)
     ]
+
+    oneq_list = [oneq_cliffords[i] for i in oneq_idx_list]
+    twoq_list = [twoq_cliffords[i] for i in twoq_idx_list]
+
     t_list = [cirq.T for _ in range(num_t_gates)]
 
     all_gates = oneq_list + twoq_list + t_list
@@ -68,10 +72,13 @@ def generate_random_clifford_t_circuit(
     qubits = cirq.LineQubit.range(num_qubits)
     circuit = cirq.Circuit()
 
+    qubits_idx = list(range(num_qubits))
+
     for gate in all_gates:
-        qubits_for_gate = rnd_state.choice(
-            qubits, size=gate.num_qubits(), replace=False
+        qubits_for_gate_idx = rnd_state.choice(
+            qubits_idx, size=gate.num_qubits(), replace=False
         )
+        qubits_for_gate = [qubits[i] for i in qubits_for_gate_idx]
         operation = gate.on(*qubits_for_gate)
         circuit.append(operation)
 

--- a/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
@@ -13,7 +13,6 @@ fits with Mitiq's interface.
 
 import cirq
 import pytest
-from cirq import protocols
 
 from mitiq import SUPPORTED_PROGRAM_TYPES
 from mitiq.benchmarks.randomized_clifford_t_circuit import (

--- a/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
@@ -1,0 +1,80 @@
+# Copyright (C) Unitary Fund
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for quantum volume circuits. The Cirq functions that do the main work
+are tested here:
+cirq-core/cirq/contrib/quantum_volume/quantum_volume_test.py
+
+Tests below check that generate_quantum_volume_circuit() works as a wrapper and
+fits with Mitiq's interface.
+"""
+
+import cirq
+import pytest
+from cirq import protocols
+
+from mitiq import SUPPORTED_PROGRAM_TYPES
+from mitiq.benchmarks.randomized_clifford_t_circuit import (
+    compute_heavy_bitstrings,
+    generate_random_clifford_t_circuit,
+)
+
+
+def test_generate_model_circuit_no_seed():
+    """Test that random circuit of the right length is generated."""
+    circuit, _ = generate_random_clifford_t_circuit(num_qubits=2, 
+                                                      num_oneq_cliffords=2,  
+                                                      num_twoq_cliffords=2, 
+                                                      num_t_gates=2, 
+                                                      seed=1)
+    assert len(circuit) == 3
+
+
+def test_generate_model_circuit_with_seed():
+    """Test that a model circuit is determined by its seed."""
+    circuit_1, _ = generate_random_clifford_t_circuit(num_qubits=2, 
+                                                      num_oneq_cliffords=2,  
+                                                      num_twoq_cliffords=2, 
+                                                      num_t_gates=2, 
+                                                      seed=1)
+    circuit_2, _ = generate_random_clifford_t_circuit(num_qubits=2, 
+                                                      num_oneq_cliffords=2,  
+                                                      num_twoq_cliffords=2, 
+                                                      num_t_gates=2, 
+                                                      seed=1)
+    circuit_3, _ = generate_random_clifford_t_circuit(num_qubits=2, 
+                                                      num_oneq_cliffords=2,  
+                                                      num_twoq_cliffords=2, 
+                                                      num_t_gates=2, 
+                                                      seed=3)
+
+    assert circuit_1 == circuit_2
+    assert circuit_2 != circuit_3
+
+
+def test_compute_heavy_bitstrings():
+    """Test that the heavy bitstrings can be computed from a given circuit."""
+    a, b, c = cirq.LineQubit.range(3)
+    model_circuit = cirq.Circuit(
+        [
+            cirq.Moment([]),
+            cirq.Moment([cirq.X(a), cirq.Y(b)]),
+            cirq.Moment([]),
+            cirq.Moment([cirq.CNOT(a, c)]),
+            cirq.Moment([cirq.Z(a), cirq.H(b)]),
+        ]
+    )
+    true_heavy_set = [[1, 0, 1], [1, 1, 1]]
+    computed_heavy_set = compute_heavy_bitstrings(model_circuit, 3)
+    assert computed_heavy_set == true_heavy_set
+
+@pytest.mark.parametrize("return_type", SUPPORTED_PROGRAM_TYPES.keys())
+def test_volume_conversion(return_type):
+    circuit, _ = generate_random_clifford_t_circuit(num_qubits=2, 
+                                                      num_oneq_cliffords=2,  
+                                                      num_twoq_cliffords=2, 
+                                                      num_t_gates=2, 
+                                                      seed=3)
+    assert return_type in circuit.__module__

--- a/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
@@ -76,5 +76,6 @@ def test_conversion(return_type):
                                                       num_oneq_cliffords=2,  
                                                       num_twoq_cliffords=2, 
                                                       num_t_gates=2, 
+                                                      return_type=return_type,
                                                       seed=3)
     assert return_type in circuit.__module__

--- a/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
@@ -11,7 +11,6 @@ Tests below check that generate_quantum_volume_circuit() works as a wrapper and
 fits with Mitiq's interface.
 """
 
-import cirq
 import pytest
 
 from mitiq import SUPPORTED_PROGRAM_TYPES
@@ -46,6 +45,7 @@ def test_generate_model_circuit_with_seed():
 
     assert circuit_1 == circuit_2
     assert circuit_2 != circuit_3
+
 
 @pytest.mark.parametrize("return_type", SUPPORTED_PROGRAM_TYPES.keys())
 def test_conversion(return_type):

--- a/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
@@ -3,13 +3,7 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Tests for quantum volume circuits. The Cirq functions that do the main work
-are tested here:
-cirq-core/cirq/contrib/quantum_volume/quantum_volume_test.py
-
-Tests below check that generate_quantum_volume_circuit() works as a wrapper and
-fits with Mitiq's interface.
-"""
+"""Tests for randomized Clifford+T benchmarking circuits."""
 
 import pytest
 
@@ -19,7 +13,7 @@ from mitiq.benchmarks.randomized_clifford_t_circuit import (
 )
 
 
-def test_generate_model_circuit_with_seed():
+def test_seed_circuit_equality():
     """Test that a model circuit is determined by its seed."""
     circuit_1 = generate_random_clifford_t_circuit(
         num_qubits=2,
@@ -55,6 +49,5 @@ def test_conversion(return_type):
         num_twoq_cliffords=2,
         num_t_gates=2,
         return_type=return_type,
-        seed=3,
     )
     assert return_type in circuit.__module__

--- a/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
@@ -29,7 +29,7 @@ def test_generate_model_circuit_no_seed():
                                                       num_twoq_cliffords=2, 
                                                       num_t_gates=2, 
                                                       seed=1)
-    assert len(circuit) == 3
+    assert len(circuit) == 2 #number of two qubit cliffords
 
 
 def test_generate_model_circuit_with_seed():
@@ -71,7 +71,7 @@ def test_compute_heavy_bitstrings():
     assert computed_heavy_set == true_heavy_set
 
 @pytest.mark.parametrize("return_type", SUPPORTED_PROGRAM_TYPES.keys())
-def test_volume_conversion(return_type):
+def test_conversion(return_type):
     circuit, _ = generate_random_clifford_t_circuit(num_qubits=2, 
                                                       num_oneq_cliffords=2,  
                                                       num_twoq_cliffords=2, 

--- a/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
@@ -24,21 +24,27 @@ from mitiq.benchmarks.randomized_clifford_t_circuit import (
 
 def test_generate_model_circuit_with_seed():
     """Test that a model circuit is determined by its seed."""
-    circuit_1, _ = generate_random_clifford_t_circuit(num_qubits=2, 
-                                                      num_oneq_cliffords=2,  
-                                                      num_twoq_cliffords=2, 
-                                                      num_t_gates=2, 
-                                                      seed=1)
-    circuit_2, _ = generate_random_clifford_t_circuit(num_qubits=2, 
-                                                      num_oneq_cliffords=2,  
-                                                      num_twoq_cliffords=2, 
-                                                      num_t_gates=2, 
-                                                      seed=1)
-    circuit_3, _ = generate_random_clifford_t_circuit(num_qubits=2, 
-                                                      num_oneq_cliffords=2,  
-                                                      num_twoq_cliffords=2, 
-                                                      num_t_gates=2, 
-                                                      seed=3)
+    circuit_1, _ = generate_random_clifford_t_circuit(
+        num_qubits=2,
+        num_oneq_cliffords=2,
+        num_twoq_cliffords=2,
+        num_t_gates=2,
+        seed=1,
+    )
+    circuit_2, _ = generate_random_clifford_t_circuit(
+        num_qubits=2,
+        num_oneq_cliffords=2,
+        num_twoq_cliffords=2,
+        num_t_gates=2,
+        seed=1,
+    )
+    circuit_3, _ = generate_random_clifford_t_circuit(
+        num_qubits=2,
+        num_oneq_cliffords=2,
+        num_twoq_cliffords=2,
+        num_t_gates=2,
+        seed=3,
+    )
 
     assert circuit_1 == circuit_2
     assert circuit_2 != circuit_3
@@ -60,12 +66,15 @@ def test_compute_heavy_bitstrings():
     computed_heavy_set = compute_heavy_bitstrings(model_circuit, 3)
     assert computed_heavy_set == true_heavy_set
 
+
 @pytest.mark.parametrize("return_type", SUPPORTED_PROGRAM_TYPES.keys())
 def test_conversion(return_type):
-    circuit, _ = generate_random_clifford_t_circuit(num_qubits=2, 
-                                                      num_oneq_cliffords=2,  
-                                                      num_twoq_cliffords=2, 
-                                                      num_t_gates=2, 
-                                                      return_type=return_type,
-                                                      seed=3)
+    circuit, _ = generate_random_clifford_t_circuit(
+        num_qubits=2,
+        num_oneq_cliffords=2,
+        num_twoq_cliffords=2,
+        num_t_gates=2,
+        return_type=return_type,
+        seed=3,
+    )
     assert return_type in circuit.__module__

--- a/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
@@ -16,28 +16,27 @@ import pytest
 
 from mitiq import SUPPORTED_PROGRAM_TYPES
 from mitiq.benchmarks.randomized_clifford_t_circuit import (
-    compute_heavy_bitstrings,
     generate_random_clifford_t_circuit,
 )
 
 
 def test_generate_model_circuit_with_seed():
     """Test that a model circuit is determined by its seed."""
-    circuit_1, _ = generate_random_clifford_t_circuit(
+    circuit_1 = generate_random_clifford_t_circuit(
         num_qubits=2,
         num_oneq_cliffords=2,
         num_twoq_cliffords=2,
         num_t_gates=2,
         seed=1,
     )
-    circuit_2, _ = generate_random_clifford_t_circuit(
+    circuit_2 = generate_random_clifford_t_circuit(
         num_qubits=2,
         num_oneq_cliffords=2,
         num_twoq_cliffords=2,
         num_t_gates=2,
         seed=1,
     )
-    circuit_3, _ = generate_random_clifford_t_circuit(
+    circuit_3 = generate_random_clifford_t_circuit(
         num_qubits=2,
         num_oneq_cliffords=2,
         num_twoq_cliffords=2,
@@ -48,27 +47,9 @@ def test_generate_model_circuit_with_seed():
     assert circuit_1 == circuit_2
     assert circuit_2 != circuit_3
 
-
-def test_compute_heavy_bitstrings():
-    """Test that the heavy bitstrings can be computed from a given circuit."""
-    a, b, c = cirq.LineQubit.range(3)
-    model_circuit = cirq.Circuit(
-        [
-            cirq.Moment([]),
-            cirq.Moment([cirq.X(a), cirq.Y(b)]),
-            cirq.Moment([]),
-            cirq.Moment([cirq.CNOT(a, c)]),
-            cirq.Moment([cirq.Z(a), cirq.H(b)]),
-        ]
-    )
-    true_heavy_set = [[1, 0, 1], [1, 1, 1]]
-    computed_heavy_set = compute_heavy_bitstrings(model_circuit, 3)
-    assert computed_heavy_set == true_heavy_set
-
-
 @pytest.mark.parametrize("return_type", SUPPORTED_PROGRAM_TYPES.keys())
 def test_conversion(return_type):
-    circuit, _ = generate_random_clifford_t_circuit(
+    circuit = generate_random_clifford_t_circuit(
         num_qubits=2,
         num_oneq_cliffords=2,
         num_twoq_cliffords=2,

--- a/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
@@ -21,6 +21,7 @@ from mitiq.benchmarks.randomized_clifford_t_circuit import (
     generate_random_clifford_t_circuit,
 )
 
+
 def test_generate_model_circuit_with_seed():
     """Test that a model circuit is determined by its seed."""
     circuit_1, _ = generate_random_clifford_t_circuit(num_qubits=2, 

--- a/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/tests/test_randomized_clifford_t_circuit.py
@@ -21,17 +21,6 @@ from mitiq.benchmarks.randomized_clifford_t_circuit import (
     generate_random_clifford_t_circuit,
 )
 
-
-def test_generate_model_circuit_no_seed():
-    """Test that random circuit of the right length is generated."""
-    circuit, _ = generate_random_clifford_t_circuit(num_qubits=2, 
-                                                      num_oneq_cliffords=2,  
-                                                      num_twoq_cliffords=2, 
-                                                      num_t_gates=2, 
-                                                      seed=1)
-    assert len(circuit) == 2 #number of two qubit cliffords
-
-
 def test_generate_model_circuit_with_seed():
     """Test that a model circuit is determined by its seed."""
     circuit_1, _ = generate_random_clifford_t_circuit(num_qubits=2, 


### PR DESCRIPTION
## Description

This PR adds the feature requested here https://github.com/unitaryfund/mitiq/issues/1230.

closes #1230 

---

### License

- [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file