### PR TITLE
Speed up tests using mocks

### DIFF
--- a/docs/source/guide/calibrators.md
+++ b/docs/source/guide/calibrators.md
@@ -43,7 +43,7 @@ from mitiq import Calibrator
 ```
 
 To instantiate a `Calibrator` we need to pass it an executor (as defined above), and a `Settings` object.
-You are free to define your own `Settings`, but as a simple starting point, we provide `ZNESettings` based on different zero-noise extrapolation strategies and `PECSettings` based on different quasiprobability representations of ideal gates.
+You are free to define your own `Settings`, but as a simple starting point, we provide `ZNE_SETTINGS` based on different zero-noise extrapolation strategies and `PEC_SETTINGS` based on different quasiprobability representations of ideal gates.
 Finally, the `execute_with_mitigation` function allows us to pass the calibration results directly to Mitiq and have it pick the strategy that performed best of those supplied in the `Settings` object.
 
 ## Calibration Experiments
@@ -91,6 +91,7 @@ cal.execute_with_mitigation(circuit, execute)
 ```
 
 ## Tutorial
+
 You can find an example on quantum error mitigation calibration in the **[Examples](../examples/calibration-tutorial.md)** section of the documentation.
 This example illustrates functionalities from the calibration module using ZNE
 on a simulated IBM Quantum backend using Qiskit, defining a new settings object.

--- a/mitiq/__init__.py
+++ b/mitiq/__init__.py
@@ -32,7 +32,7 @@ from mitiq import cdr, pec, rem, zne, ddd
 from mitiq.calibration import (
     Calibrator,
     execute_with_mitigation,
-    ZNESettings,
+    ZNE_SETTINGS,
     Settings,
 )
 

--- a/mitiq/calibration/__init__.py
+++ b/mitiq/calibration/__init__.py
@@ -4,4 +4,4 @@
 # LICENSE file in the root directory of this source tree.
 
 from mitiq.calibration.calibrator import Calibrator, execute_with_mitigation
-from mitiq.calibration.settings import Settings, ZNESettings, PECSettings
+from mitiq.calibration.settings import Settings, ZNE_SETTINGS, PEC_SETTINGS

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -285,7 +285,7 @@ class Calibrator:
             strategy.num_circuits_required() for strategy in self.strategies
         )
 
-        noisy = num_circuits * num_options
+        noisy = num_circuits * (num_options + 1)
         ideal = 0  # TODO: ideal executor is currently unused
         return {
             "noisy_executions": noisy,

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -21,10 +21,10 @@ from mitiq import (
     QuantumResult,
 )
 from mitiq.calibration.settings import (
+    ZNE_SETTINGS,
     BenchmarkProblem,
     Settings,
     Strategy,
-    ZNE_SETTINGS,
 )
 from mitiq.interface import convert_from_mitiq
 

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -24,7 +24,7 @@ from mitiq.calibration.settings import (
     BenchmarkProblem,
     Settings,
     Strategy,
-    ZNESettings,
+    ZNE_SETTINGS,
 )
 from mitiq.interface import convert_from_mitiq
 
@@ -228,7 +228,7 @@ class Calibrator:
         executor: Union[Executor, Callable[[QPROGRAM], QuantumResult]],
         *,
         frontend: str,
-        settings: Settings = ZNESettings,
+        settings: Settings = ZNE_SETTINGS,
         ideal_executor: Union[
             Executor, Callable[[QPROGRAM], QuantumResult], None
         ] = None,

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -392,7 +392,7 @@ class Settings:
         return funcs
 
 
-ZNESettings = Settings(
+ZNE_SETTINGS = Settings(
     benchmarks=[
         {
             "circuit_type": "ghz",
@@ -458,7 +458,7 @@ ZNESettings = Settings(
     ],
 )
 
-PECSettings = Settings(
+PEC_SETTINGS = Settings(
     benchmarks=[
         {
             "circuit_type": "ghz",

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -9,7 +9,7 @@ import pytest
 import qiskit
 
 from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES
-from mitiq.calibration import PECSettings, Settings, ZNESettings
+from mitiq.calibration import PEC_SETTINGS, Settings, ZNE_SETTINGS
 from mitiq.calibration.settings import (
     BenchmarkProblem,
     MitigationTechnique,
@@ -246,9 +246,9 @@ def test_unsupported_technique_error():
         strategy.mitigation_function()
 
 
-def test_ZNESettings():
-    circuits = ZNESettings.make_problems()
-    strategies = ZNESettings.make_strategies()
+def test_ZNE_SETTINGS():
+    circuits = ZNE_SETTINGS.make_problems()
+    strategies = ZNE_SETTINGS.make_strategies()
     repr_string = repr(circuits[0])
     assert all(
         s in repr_string
@@ -258,9 +258,9 @@ def test_ZNESettings():
     assert len(strategies) == 2 * 2 * 2
 
 
-def test_PECSettings():
-    circuits = PECSettings.make_problems()
-    strategies = PECSettings.make_strategies()
+def test_PEC_SETTINGS():
+    circuits = PEC_SETTINGS.make_problems()
+    strategies = PEC_SETTINGS.make_strategies()
     repr_string = repr(circuits[0])
     assert all(
         s in repr_string

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -9,7 +9,7 @@ import pytest
 import qiskit
 
 from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES
-from mitiq.calibration import PEC_SETTINGS, Settings, ZNE_SETTINGS
+from mitiq.calibration import PEC_SETTINGS, ZNE_SETTINGS, Settings
 from mitiq.calibration.settings import (
     BenchmarkProblem,
     MitigationTechnique,

--- a/mitiq/qse/qse_utils.py
+++ b/mitiq/qse/qse_utils.py
@@ -74,15 +74,14 @@ def get_expectation_value_for_observable(
         )[0]
         return (pauli_expectation_cache[cache_key] * pauli_string.coeff).real
 
-    expectation_value = 0.0
-    if isinstance(observable, PauliString):
-        pauli_string = observable
-        expectation_value += get_expectation_value_for_one_pauli(pauli_string)
-    elif isinstance(observable, Observable):
-        for pauli_string in observable.paulis:
-            expectation_value += get_expectation_value_for_one_pauli(
-                pauli_string
-            )
+    paulis = (
+        [observable]
+        if isinstance(observable, PauliString)
+        else observable.paulis
+    )
+    expectation_value = sum(
+        get_expectation_value_for_one_pauli(pauli) for pauli in paulis
+    )
     return expectation_value
 
 

--- a/mitiq/qse/qse_utils.py
+++ b/mitiq/qse/qse_utils.py
@@ -5,8 +5,8 @@
 
 """Functions for computing the projector for subspace expansion."""
 
-from typing import Callable, Dict, Sequence, Union, Optional
 from itertools import product
+from typing import Callable, Dict, Optional, Sequence, Union
 
 import numpy as np
 import numpy.typing as npt

--- a/mitiq/qse/qse_utils.py
+++ b/mitiq/qse/qse_utils.py
@@ -73,7 +73,7 @@ def get_expectation_value_for_observable(
         ).real
 
     total_expectation_value_for_observable = 0.0
-    final_executor: Executor = (
+    final_executor = (
         executor if isinstance(executor, Executor) else Executor(executor)
     )
 

--- a/mitiq/qse/qse_utils.py
+++ b/mitiq/qse/qse_utils.py
@@ -113,17 +113,16 @@ def _compute_hamiltonian_overlap_matrix(
     code_hamiltonian: Observable,
     pauli_string_to_expectation_cache: Dict[PauliString, complex] = {},
 ) -> npt.NDArray[np.float64]:
-    H: List[List[float]] = []
-    # H_ij = <Ψ|Mi† H Mj|Ψ>
-    for i in range(len(check_operators)):
-        H.append([])
-        for j in range(len(check_operators)):
-            H[-1].append(
-                get_expectation_value_for_observable(
-                    circuit,
-                    executor,
-                    check_operators[i] * code_hamiltonian * check_operators[j],
-                    pauli_string_to_expectation_cache,
-                )
+    num_ops = len(check_operators)
+
+    H = np.zeros((num_ops, num_ops))
+    # Hij = ⟨Ψ|Mi† H Mj|Ψ⟩
+    for i in range(num_ops):
+        for j in range(num_ops):
+            H[i, j] = get_expectation_value_for_observable(
+                circuit,
+                executor,
+                check_operators[i] * code_hamiltonian * check_operators[j],
+                pauli_string_to_expectation_cache,
             )
-    return np.array(H)
+    return H

--- a/mitiq/qse/qse_utils.py
+++ b/mitiq/qse/qse_utils.py
@@ -61,6 +61,10 @@ def get_expectation_value_for_observable(
     This function modifies pauli_string_to_expectation_cache in place.
     """
 
+    final_executor = (
+        executor if isinstance(executor, Executor) else Executor(executor)
+    )
+
     def get_expectation_value_for_one_pauli(
         pauli_string: PauliString,
     ) -> float:
@@ -73,10 +77,6 @@ def get_expectation_value_for_observable(
         ).real
 
     total_expectation_value_for_observable = 0.0
-    final_executor = (
-        executor if isinstance(executor, Executor) else Executor(executor)
-    )
-
     if isinstance(observable, PauliString):
         pauli_string = observable
         total_expectation_value_for_observable += (

--- a/mitiq/qse/qse_utils.py
+++ b/mitiq/qse/qse_utils.py
@@ -53,7 +53,7 @@ def get_expectation_value_for_observable(
     circuit: QPROGRAM,
     executor: Union[Executor, Callable[[QPROGRAM], QuantumResult]],
     observable: Union[PauliString, Observable],
-    pauli_string_to_expectation_cache: Dict[PauliString, complex] = {},
+    pauli_expectation_cache: Dict[PauliString, complex] = {},
 ) -> float:
     """Provide pauli_string_to_expectation_cache if you want to take advantage
     of caching.
@@ -69,25 +69,21 @@ def get_expectation_value_for_observable(
         pauli_string: PauliString,
     ) -> float:
         cache_key = pauli_string.with_coeff(1)
-        pauli_string_to_expectation_cache[cache_key] = final_executor.evaluate(
+        pauli_expectation_cache[cache_key] = final_executor.evaluate(
             circuit, Observable(cache_key)
         )[0]
-        return (
-            pauli_string_to_expectation_cache[cache_key] * pauli_string.coeff
-        ).real
+        return (pauli_expectation_cache[cache_key] * pauli_string.coeff).real
 
-    total_expectation_value_for_observable = 0.0
+    expectation_value = 0.0
     if isinstance(observable, PauliString):
         pauli_string = observable
-        total_expectation_value_for_observable += (
-            get_expectation_value_for_one_pauli(pauli_string)
-        )
+        expectation_value += get_expectation_value_for_one_pauli(pauli_string)
     elif isinstance(observable, Observable):
         for pauli_string in observable.paulis:
-            total_expectation_value_for_observable += (
-                get_expectation_value_for_one_pauli(pauli_string)
+            expectation_value += get_expectation_value_for_one_pauli(
+                pauli_string
             )
-    return total_expectation_value_for_observable
+    return expectation_value
 
 
 def _compute_overlap_matrix(

--- a/mitiq/qse/qse_utils.py
+++ b/mitiq/qse/qse_utils.py
@@ -90,7 +90,7 @@ def _compute_overlap_matrix(
     circuit: QPROGRAM,
     executor: Union[Executor, Callable[[QPROGRAM], QuantumResult]],
     check_operators: Sequence[PauliString],
-    pauli_string_to_expectation_cache: Dict[PauliString, complex] = {},
+    pauli_expectation_cache: Dict[PauliString, complex] = {},
     code_hamiltonian: Optional[Observable] = None,
 ) -> npt.NDArray[np.float64]:
     num_ops = len(check_operators)
@@ -106,9 +106,6 @@ def _compute_overlap_matrix(
         else:
             observable = check_operators[i] * check_operators[j]
         H[i, j] = get_expectation_value_for_observable(
-            circuit,
-            executor,
-            observable,
-            pauli_string_to_expectation_cache,
+            circuit, executor, observable, pauli_expectation_cache
         )
     return H

--- a/mitiq/qse/tests/test_qse.py
+++ b/mitiq/qse/tests/test_qse.py
@@ -192,7 +192,7 @@ def test_compute_hamiltonian_overlap_matrix(prepare_setup):
     H = _compute_hamiltonian_overlap_matrix(
         qc, execute_no_noise, check_operators, code_hamiltonian, {}
     )
-    assert np.allclose(H, -16 * np.ones(16))
+    assert np.allclose(H, np.full(16, -16))
 
     H = _compute_hamiltonian_overlap_matrix(
         qc,

--- a/mitiq/qse/tests/test_qse.py
+++ b/mitiq/qse/tests/test_qse.py
@@ -164,14 +164,13 @@ def test_compute_overlap_matrix(prepare_setup):
     S = _compute_overlap_matrix(
         qc, execute_with_depolarized_noise, check_operators, {}
     )
-    # assert that S's diagonal is all ones but the off-diagonal elements
-    #  are less than 1.
-    # Diagonal terms are all 1's because we are computing
-    # <Ψ|C_i C_i|Ψ> = <Ψ|Ψ> = 1
+    # Diagonal terms are all 1 because
+    # ⟨Ψ|C_i C_i|Ψ⟩ = ⟨Ψ|Ψ⟩ = 1
     assert np.allclose(np.diag(np.diag(S)), np.eye(16))
-    # Check that all off diagonal entries of S are the same and less than 1
-    # Off diagonal terms are less than 1 because we are computing <Ψ|C_i C_j|Ψ>
-    # = <Ψ|C_k|Ψ> < 1 (since |Ψ> was rotated a bit from the logical subspace)
+
+    # Off diagonal terms are less than 1 because
+    # ⟨Ψ|C_i C_j|Ψ⟩  = ⟨Ψ|C_k|Ψ⟩ < 1
+    # (since |Ψ⟩ was rotated a bit from the logical subspace)
     # All off diagonal terms are the same because of the symmetry of the
     # total depolarizing noise.
     off_diag_elements = S[np.where(~np.eye(16, dtype=bool))]
@@ -184,7 +183,7 @@ def test_compute_overlap_matrix_with_hamiltonian(prepare_setup):
 
     # If we have a full set of check operators that form a group then all
     # entries of the H matrix should be the same.
-    # H_jk = sum over all i's <Ψ|C_i|Ψ>
+    # H_jk = sum over all i's ⟨Ψ|C_i|Ψ⟩
 
     H = _compute_overlap_matrix(
         qc, execute_no_noise, check_operators, {}, code_hamiltonian
@@ -266,20 +265,19 @@ def prepare_logical_0_state_for_5_1_3_code():
     def gram_schmidt(
         orthogonal_vecs: List[np.ndarray],
     ) -> np.ndarray:
-        # normalize input
         orthonormalVecs = [
             vec / np.sqrt(np.vdot(vec, vec)) for vec in orthogonal_vecs
         ]
-        dim = np.shape(orthogonal_vecs[0])[0]  # get dim of vector space
+        dim = np.shape(orthogonal_vecs[0])[0]
         for i in range(dim - len(orthogonal_vecs)):
             new_vec = np.zeros(dim)
-            new_vec[i] = 1  # construct ith basis vector
+            new_vec[i] = 1
             projs = sum(
                 [
                     np.vdot(new_vec, cached_vec) * cached_vec
                     for cached_vec in orthonormalVecs
                 ]
-            )  # sum of projections of new vec with all existing vecs
+            )
             new_vec -= projs
             orthonormalVecs.append(
                 new_vec / np.sqrt(np.vdot(new_vec, new_vec))

--- a/mitiq/qse/tests/test_qse.py
+++ b/mitiq/qse/tests/test_qse.py
@@ -175,7 +175,7 @@ def test_compute_overlap_matrix(prepare_setup):
     # All off diagonal terms are the same because of the symmetry of the
     # total depolarizing noise.
     off_diag_elements = S[np.where(~np.eye(16, dtype=bool))]
-    np.allclose(off_diag_elements, off_diag_elements[0])
+    assert np.allclose(off_diag_elements, off_diag_elements[0])
     assert off_diag_elements[0] < 1
 
 

--- a/mitiq/qse/tests/test_qse.py
+++ b/mitiq/qse/tests/test_qse.py
@@ -232,7 +232,7 @@ def test_compute_hamiltonian_overlap_matrix():
     assert H[0][0].real > -16
 
 
-def get_observable_in_code_space(observable: List[cirq.PauliString]):
+def get_observable_in_code_space(observable: cirq.PauliString):
     FIVE_I = PauliString("IIIII")
     projector_onto_code_space = [
         PauliString("XZZXI"),

--- a/mitiq/qse/tests/test_qse.py
+++ b/mitiq/qse/tests/test_qse.py
@@ -21,10 +21,7 @@ from mitiq.qse import (
     mitigate_executor,
     qse_decorator,
 )
-from mitiq.qse.qse_utils import (
-    _compute_hamiltonian_overlap_matrix,
-    _compute_overlap_matrix,
-)
+from mitiq.qse.qse_utils import _compute_overlap_matrix
 
 
 def execute_with_depolarized_noise(circuit: QPROGRAM) -> np.ndarray:
@@ -182,24 +179,24 @@ def test_compute_overlap_matrix(prepare_setup):
     assert off_diag_elements[0] < 1
 
 
-def test_compute_hamiltonian_overlap_matrix(prepare_setup):
+def test_compute_overlap_matrix_with_hamiltonian(prepare_setup):
     qc, check_operators, code_hamiltonian = prepare_setup
 
     # If we have a full set of check operators that form a group then all
     # entries of the H matrix should be the same.
     # H_jk = sum over all i's <Ψ|C_i|Ψ>
 
-    H = _compute_hamiltonian_overlap_matrix(
-        qc, execute_no_noise, check_operators, code_hamiltonian, {}
+    H = _compute_overlap_matrix(
+        qc, execute_no_noise, check_operators, {}, code_hamiltonian
     )
     assert np.allclose(H, np.full(16, -16))
 
-    H = _compute_hamiltonian_overlap_matrix(
+    H = _compute_overlap_matrix(
         qc,
         execute_with_depolarized_noise,
         check_operators,
-        code_hamiltonian,
         {},
+        code_hamiltonian,
     )
     assert np.allclose(H, H[0][0])
     assert H[0][0].real > -16


### PR DESCRIPTION
## Description

Speed up the tests round three. This time mostly using the mocking approach in order to cut down on the expensive computations that are performed. I also cleaned up some of the adjacent code while trying to understand the QSE tests.

The following table is the runtime of `make test` before and after the changes included in this PR.

| before | after |
| ------ | ----- |
| 5:31   | 3:39  |

fixes https://github.com/unitaryfund/mitiq/issues/2080