### PR TITLE
resolve flaky mirror QV circuit test

### DIFF
--- a/mitiq/benchmarks/mirror_qv_circuits.py
+++ b/mitiq/benchmarks/mirror_qv_circuits.py
@@ -6,7 +6,7 @@
 """Functions to create a Mirror Quantum Volume Benchmarking circuit
 as defined in https://arxiv.org/abs/2303.02108."""
 
-from typing import Optional
+from typing import Optional, cast
 
 import cirq
 
@@ -63,6 +63,8 @@ def generate_mirror_qv_circuit(
     qv_circuit, _ = generate_quantum_volume_circuit(
         num_qubits, first_half_depth, seed=seed, decompose=decompose
     )
+    qv_circuit = cast(cirq.Circuit, qv_circuit)
+
     mirror_qv_circuit = qv_circuit + cirq.inverse(qv_circuit)
 
     if decompose:

--- a/mitiq/benchmarks/mirror_qv_circuits.py
+++ b/mitiq/benchmarks/mirror_qv_circuits.py
@@ -14,7 +14,7 @@ from mitiq import QPROGRAM
 from mitiq.benchmarks.quantum_volume_circuits import (
     generate_quantum_volume_circuit,
 )
-from mitiq.interface.conversions import convert_from_mitiq, convert_to_mitiq
+from mitiq.interface.conversions import convert_from_mitiq
 
 
 def generate_mirror_qv_circuit(
@@ -60,22 +60,14 @@ def generate_mirror_qv_circuit(
     else:
         first_half_depth = int((depth + 1) / 2)
 
-    qv_generated, _ = generate_quantum_volume_circuit(
+    qv_circuit, _ = generate_quantum_volume_circuit(
         num_qubits, first_half_depth, seed=seed, decompose=decompose
     )
-    qv_half_circ, _ = convert_to_mitiq(qv_generated)
-
-    mirror_half_circ = cirq.Circuit()
-    qv_half_ops = list(qv_half_circ.all_operations())
-    for i in range(len(qv_half_ops))[::-1]:
-        op_inverse = cirq.inverse(qv_half_ops[i])
-        mirror_half_circ.append(op_inverse, strategy=cirq.InsertStrategy.NEW)
-
-    circ = qv_half_circ + mirror_half_circ
+    mirror_qv_circuit = qv_circuit + cirq.inverse(qv_circuit)
 
     if decompose:
         # Decompose random unitary gates into simpler gates.
-        circ = cirq.Circuit(cirq.decompose(circ))
+        mirror_qv_circuit = cirq.Circuit(cirq.decompose(mirror_qv_circuit))
 
     return_type = "cirq" if not return_type else return_type
-    return convert_from_mitiq(circ, return_type)
+    return convert_from_mitiq(mirror_qv_circuit, return_type)

--- a/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
@@ -52,7 +52,7 @@ def test_generate_model_circuit_with_seed():
     circuit_2 = generate_mirror_qv_circuit(4, 3, seed=1)
     circuit_3 = generate_mirror_qv_circuit(4, 3, seed=2)
 
-    assert circuit_1 == circuit_2
+    assert cirq.approx_eq(circuit_1, circuit_2, atol=1e-12)
     assert circuit_2 != circuit_3
 
 


### PR DESCRIPTION
## Description

Misty and I took a look at the recent failures we've been seeing with the `test_generate_model_circuit_with_seed` test which was originally raised in #2121. We weren't able to reproduce the failure locally, but we did find that the failure is due to tiny numerical differences in matrix gates coming from the **inverse** part of the mirror circuit. E.g.

```py
(-0.41154946430369077+0.009252886470149477j),
                                        ^^^^^
(-0.41154946430369077+0.00925288647014949j), 
                                        ^^^^ 
```

While trying to fix this, we simplified some of the code to make it more readable (and probably a tiny bit faster). To fix the flaky test itself we use approximate equality instead of exact with an extremely small absolute tolerance to ensure the only differences are from numerics.

fixes https://github.com/unitaryfund/mitiq/issues/2121

### Why can't we reproduce this locally?

The only ideas I have is that the chip running the computations to compute inverses of matrix gates is given more resources on my machine than the GitHub runner. If others have ideas, please say so!

### History

Mirror Quantum Volume circuits were introduced in https://github.com/unitaryfund/mitiq/pull/1838, and indeed the first commit https://github.com/unitaryfund/mitiq/pull/1838/commits/b9777e362c2262727c800cf4c737cd2e5e0fa9ff on the branch uses the simplest way to construct a mirror quantum volume circuit using something like the following.
```py
qv_half = generate_quantum_volume_circuit(...)
mirror_qv = qv_half + cirq.inverse(qv_half)
```

A few commits later https://github.com/unitaryfund/mitiq/pull/1838/commits/2bf73b49a1a1ef00c3fda10a844b6b5d2ffec615, this code was substantially modified with commit message "mypy". Presumably this change was made to make mypy happy, but in doing so added a lot of complexity to the code. Even though this code works, it made debugging the code a bit harder than it would have otherwise. For that reason, and the general principle that readable code is (almost) always better, we've reverted to a simpler approach. With this approach we do have to use a `typing.cast` call to ensure mypy knows the correct type of the circuit returned from [`generate_quantum_volume_circuit`](https://github.com/unitaryfund/mitiq/blob/0a9c20285f4c2b20dfd93c5eaf982f9abfbb9611/mitiq/benchmarks/quantum_volume_circuits.py#L31).[^1]

### Post-Mortem

This issue was made more difficult to debug due to the fact that code was rewritten to appease `mypy`[^2]. This, however, should not be the purpose of using mypy. We should do our best to help mypy understand the code we want to write, not **re**write code because mypy is complaining. At its best, mypy is a tool to help make our code better and more readable and at its worst, it can nudge us to rewrite clear code into something that is less readable despite passing mypy.

My recommendation here is to follow something like the following practice.

1. Write code as you wish!
2. Check types with mypy
3. If needed, help mypy understand by supplying more accurately typing. Try to avoid `typing.cast` and `#  type:ignore` comments, but sometimes they are needed. 

In particular, though, do not add code that will run (at runtime) **only** to appease mypy.

---

cc @purva-thakre since you wrote the original implementation, and @Misty-W since we paired on this together.

[^1]: Which, BTW, is not known by mypy because the return type is a general `QPROGRAM`.
[^2]: My working theory from looking through the commit history.
