### PR TITLE
Clarify CDR training docs regarding the use of a markov chain monte carlo

### DIFF
--- a/docs/source/guide/cdr-1-intro.md
+++ b/docs/source/guide/cdr-1-intro.md
@@ -16,10 +16,10 @@ kernelspec:
 Here we show how to use CDR by means of a simple example.
 
 ```{code-cell} ipython3
-import numpy as np
 import warnings
 warnings.simplefilter("ignore", np.ComplexWarning)
 
+import numpy as np
 import cirq
 from mitiq import cdr, Observable, PauliString
 ```
@@ -29,17 +29,15 @@ from mitiq import cdr, Observable, PauliString
 To use CDR, we call {func}`.cdr.execute_with_cdr` with four "ingredients":
 
 1. A quantum circuit to prepare a state $\rho$.
-1. A quantum computer or noisy simulator to return a {class}`.QuantumResult` from $\rho$.
-1. An observable $O$ which specifies what we wish to compute via $\text{Tr} [ \rho O ]$.
+1. A quantum computer or noisy simulator to return a {class}`mitiq.QuantumResult` from $\rho$.
+1. An observable $O$ which specifies what we wish to compute via $\mathrm{Tr} ( \rho O )$.
 1. A near-Clifford (classical) circuit simulator.
-
-+++
 
 ### 1. Define a quantum circuit
 
 The quantum circuit can be specified as any quantum circuit supported by Mitiq but
 **must be compiled into a gateset in which the only non-Clifford gates are
-single-qubit rotations around the $Z$ axis: $R_Z(\theta)$**.  For example:
+single-qubit rotations around the $Z$ axis: $R_Z(\theta)$**. For example:
 
 $$\{ \sqrt{X}, R_Z(\theta), \text{CNOT}\},$$
 $$\{{R_X(\pi/2)}, R_Z(\theta), \text{CZ}\},$$
@@ -52,8 +50,8 @@ Clifford gates and some non-Clifford $R_Z(\theta)$ rotations.
 ```{code-cell} ipython3
 a, b = cirq.LineQubit.range(2)
 circuit = cirq.Circuit(
-    cirq.H.on(a), # Clifford
-    cirq.H.on(b), # Clifford
+    cirq.H.on(a),  # Clifford
+    cirq.H.on(b),  # Clifford
     cirq.rz(1.75).on(a),
     cirq.rz(2.31).on(b),
     cirq.CNOT.on(a, b),  # Clifford
@@ -68,7 +66,9 @@ circuit = 5 * circuit
 ```
 
 ### 2. Define an executor
-We define an [executor](executors.md) function which inputs a circuit and returns a {class}`.QuantumResult`. Here for sake of example we use a simulator that adds single-qubit depolarizing noise after each moment and returns the final density matrix.
+
+We define an [executor](executors.md) function which inputs a circuit and returns a {class}`.QuantumResult`.
+Here for sake of example we use a simulator that adds single-qubit depolarizing noise after each layer and returns the final density matrix.
 
 ```{code-cell} ipython3
 from mitiq.interface.mitiq_cirq import compute_density_matrix
@@ -77,26 +77,28 @@ compute_density_matrix(circuit).round(3)
 ```
 
 ### 3. Observable
-As an example, assume that we wish to compute the expectation value $\text{Tr} [ \rho O ]$ of the following observable $O$:
+
+As an example, assume that we wish to compute the expectation value $\mathrm{Tr} [ \rho O ]$ of the following observable $O$:
 
 ```{code-cell} ipython3
-# Observable to measure.
 obs = Observable(PauliString("ZZ"), PauliString("X", coeff=-1.75))
 print(obs)
 ```
 
-**Note:** To apply CDR the {class}`Observable` should be Hermitian, i.e., it should always produce real expectation values.
+```{warning}
+To apply CDR the {class}`.Observable` must be Hermitian (i.e. it must always produce real expectation values).
+```
 
-+++
-
-You can read more about the {class}`Observable` class in the [documentation](observables.md).
-
-+++
+You can read more about the {class}`.Observable` class in the [documentation](observables.md).
 
 ### 4. (Near-Clifford) Simulator
-The CDR method creates a set of "training circuits" which are related to the input circuit and are efficiently simulable. These circuits are simulated on a classical (noiseless) simulator to collect data for regression. The simulator should also return a `QuantumResult`.
 
-To use CDR at scale, an efficient near-Clifford circuit simulator must be specified. In this example, the circuit is small enough to use any classical simulator, and we use the same density matrix simulator as above but without noise.
+The CDR method creates a set of "training circuits" which are related to the input circuit and are efficiently simulable.
+These circuits are simulated on a classical (noiseless) simulator to collect data for regression.
+The simulator should also return a `QuantumResult`.
+
+To use CDR at scale, an efficient near-Clifford circuit simulator must be specified.
+In this example, the circuit is small enough to use any classical simulator, and we use the same density matrix simulator as above but without noise.
 
 ```{code-cell} ipython3
 def simulate(circuit: cirq.Circuit) -> np.ndarray:
@@ -107,47 +109,46 @@ simulate(circuit).round(3)
 
 ## Run CDR
 
-Now we can run CDR. We first compute the noiseless result then the noisy result to compare to the mitigated result from CDR.
+Now we can run CDR.
+We first compute the noiseless result then the noisy result to compare to the mitigated result from CDR.
 
-+++
-
-### The noiseless result
+### The ideal result
 
 ```{code-cell} ipython3
-ideal_measurement = obs.expectation(circuit, simulate).real
-print("ideal_measurement = ",ideal_measurement)
+ideal_expval = obs.expectation(circuit, simulate).real
+print(f"ideal expectation value: {ideal_expval:.2f}")
 ```
 
 ### The noisy result
-We now generate the noisy result. Note that {func}`.compute_density_matrix` function by default runs a simulation with noise.
+
+We now generate the noisy result.
+Note that {func}`.compute_density_matrix` function by default runs a simulation with noise.
 
 ```{code-cell} ipython3
-unmitigated_measurement = obs.expectation(circuit, compute_density_matrix).real
-print("unmitigated_measurement = ", unmitigated_measurement)
+unmitigated_expval = obs.expectation(circuit, compute_density_matrix).real
+print(f"unmitigated expectation value: {unmitigated_expval:.2f}")
 ```
 
 ### The mitigated result
 
 ```{code-cell} ipython3
-mitigated_measurement = cdr.execute_with_cdr(
+mitigated_expval = cdr.execute_with_cdr(
     circuit,
     compute_density_matrix,
     observable=obs,
     simulator=simulate,
     seed=0,
 ).real
-print("mitigated_measurement = ", mitigated_measurement)
+print(f"mitigated expectation value: {mitigated_expval:.2f}")
 ```
 
 ```{code-cell} ipython3
-error_unmitigated = abs(unmitigated_measurement-ideal_measurement)
-error_mitigated = abs(mitigated_measurement-ideal_measurement)
+unmitigated_error = abs(unmitigated_expval - ideal_expval)
+mitigated_error = abs(mitigated_expval - ideal_expval)
 
-print("Error (unmitigated):", error_unmitigated)
-print("Error (mitigated with CDR):", error_mitigated)
+print(f"Unmitigated Error:           {unmitigated_error:.2f}")
+print(f"Mitigated Error:             {mitigated_error:.2f}")
 
-print("Relative error (unmitigated):", (error_unmitigated/ideal_measurement))
-print("Relative error (mitigated with CDR):", error_mitigated/ideal_measurement)
-
-print(f"Error reduction with CDR: {(error_unmitigated-error_mitigated)/error_unmitigated :.1%}.")
+improvement_factor = unmitigated_error / mitigated_error
+print(f"Improvement factor with CDR: {improvement_factor:.2f}")
 ```

--- a/docs/source/guide/cdr-1-intro.md
+++ b/docs/source/guide/cdr-1-intro.md
@@ -16,10 +16,10 @@ kernelspec:
 Here we show how to use CDR by means of a simple example.
 
 ```{code-cell} ipython3
+import numpy as np
 import warnings
 warnings.simplefilter("ignore", np.ComplexWarning)
 
-import numpy as np
 import cirq
 from mitiq import cdr, Observable, PauliString
 ```

--- a/docs/source/guide/cdr-2-use-case.md
+++ b/docs/source/guide/cdr-2-use-case.md
@@ -15,26 +15,22 @@ kernelspec:
 
 ## Advantages
 
-The main advantage of CDR is that it can be applied without knowing the specific details of the noise
-model. Indeed, in CDR, the effects of noise are indirectly _learned_ through the execution of an appropriate
-set of test circuits. In this way, the final error mitigation inference tends to self-tune with respect
-to the used backend.
+The main advantage of CDR is that it can be applied without knowing the specific details of the noise model.
+Indeed, in CDR, the effects of noise are indirectly _learned_ through the execution of an appropriate set of test circuits.
+In this way, the final error mitigation inference tends to be tuned to the used backend.
 
-This self-tuning property is even stronger in the case of _variable-noise-CDR_, i.e., when using the _scale_factors_ option
-in {func}`.execute_with_cdr`. In this case, the final error mitigated expectation value is obtained
-as a linear combination of noise-scaled expectation values. This is similar to the [ZNE approach](zne-5-theory.md) but, in CDR, 
-the coefficients of the linear combination are learned instead of being fixed by the extrapolation model.
-
+This self-tuning property is even stronger in the case of _variable-noise-CDR_, i.e., when using the `scale_factors` option in {func}`.execute_with_cdr`.
+In this case, the final error mitigated expectation value is obtained as a linear combination of noise-scaled expectation values.
+This is similar to [Zero-Noise Extrapolation](zne-5-theory.md) but, in CDR, the coefficients of the linear combination are learned instead of being fixed by the extrapolation model.
 
 ## Disadvantages
 
-The main disadvantage of CDR is that the learning process is performed on a suite of test circuits which
-only _resemble_ the original circuit of interest. Indeed, test circuits are _near-Clifford approximations_
-of the original one. Only when the approximation is justified, the application of CDR can produce meaningful
-results.
-Increasing the `fraction_non_clifford` option in {func}`.execute_with_cdr` can alleviate this problem
-to some extent. Note that, the larger `fraction_non_clifford` is, the larger the classical computation overhead is.
+The main disadvantage of CDR is that the learning process is performed on a suite of test circuits which only _resemble_ the original circuit of interest.
+Indeed, test circuits are _near-Clifford approximations_ of the original one.
+Only when the approximation is justified, the application of CDR can produce meaningful results.
+Increasing the `fraction_non_clifford` option in {func}`.execute_with_cdr` can alleviate this problem to some extent.
+Note that, the larger `fraction_non_clifford` is, the larger the classical computation overhead is.
 
-Another relevant aspect to consider is that, to apply CDR in a scalable way, a valid near-Clifford simulator
-is necessary. Note that the computation cost of a valid near-Clifford simulator should scale with the number of non-Clifford
-gates, independently from the circuit depth. Only in this case, the learning phase of CDR can be applied efficiently.
+Another relevant aspect to consider is that, to apply CDR in a scalable way, a valid near-Clifford simulator is necessary.
+Note that the computation cost of a valid near-Clifford simulator should scale with the number of non-Clifford gates, independently from the circuit depth.
+Only in this case, the learning phase of CDR can be applied efficiently.

--- a/docs/source/guide/cdr-3-options.md
+++ b/docs/source/guide/cdr-3-options.md
@@ -13,9 +13,10 @@ kernelspec:
 
 # What additional options are available in CDR?
 
-In addition to the four necessary ingredients shown in [How do I use CDR?](cdr-1-intro.md), there are additional parameters in CDR.
+In addition to the four necessary ingredients shown in {doc}`cdr-1-intro`, there are additional parameters in CDR.
 
-One option is how many circuits are in the training set (default is 10). This can be changed as follows.
+One option is how many circuits are in the training set (default is 10).
+This can be changed as follows.
 
 ```{code-cell} ipython3
 import warnings
@@ -29,8 +30,8 @@ from mitiq.interface.mitiq_cirq import compute_density_matrix
 
 a, b = cirq.LineQubit.range(2)
 circuit = cirq.Circuit(
-    cirq.H.on(a), # Clifford
-    cirq.H.on(b), # Clifford
+    cirq.H.on(a),  # Clifford
+    cirq.H.on(b),  # Clifford
     cirq.rz(1.75).on(a),
     cirq.rz(2.31).on(b),
     cirq.CNOT.on(a, b),  # Clifford
@@ -56,11 +57,10 @@ cdr.execute_with_cdr(
 ).real
 ```
 
-+++
-
 ## Fit function
 
-Another option is which fit function to use for regression (default is {func}`cdr.linear_fit_function`).
+Another option is which fit function to use for regression (default is {func}`.linear_fit_function`).
+
 ```{code-cell} ipython3
 cdr.execute_with_cdr(
     circuit,
@@ -72,18 +72,13 @@ cdr.execute_with_cdr(
 ).real
 ```
 
-Beyond the built-in {func}`cdr.linear_fit_function` and {func}`cdr.linear_fit_function_no_intercept`,
-the user could also define other custom functions.
+Beyond the built-in {func}`.linear_fit_function` and {func}`.linear_fit_function_no_intercept`, the user can define other custom functions.
 
 ## Variable noise CDR
-
-+++
 
 The `circuit` and the associated training circuits can also be run at different noise scale factors to implement [variable noise Clifford data regression](https://arxiv.org/abs/2011.01157) {cite}`Lowe_2021_PRR`.
 
 ```{code-cell} ipython3
-from mitiq.zne import scaling
-
 cdr.execute_with_cdr(
     circuit,
     compute_density_matrix,

--- a/docs/source/guide/cdr-4-low-level.md
+++ b/docs/source/guide/cdr-4-low-level.md
@@ -26,7 +26,7 @@ The CDR workflow in Mitiq is divided in two steps: Generating circuits, both for
 Similarly to ZNE and PEC, CDR is divided in two main stages: first, one of circuit generation and a second for inference of the mitigated value.
 In CDR, the generation of quantum circuits is different, as it involves the generation of training circuits.
 
-```{warning}
+```{note}
 In {cite}`Czarnik_2021_Quantum`, the authors lay out two different methods for generating the training circuits.
 
 1. Randomly replacing gates in the target circuit with nearby Clifford gates.

--- a/docs/source/guide/cdr-4-low-level.md
+++ b/docs/source/guide/cdr-4-low-level.md
@@ -25,6 +25,16 @@ The CDR workflow in Mitiq is divided in two steps: Generating circuits, both for
 
 Similarly to ZNE and PEC, CDR is divided in two main stages: first, one of circuit generation and a second for inference of the mitigated value.
 In CDR, the generation of quantum circuits is different, as it involves the generation of training circuits.
+
+```{warning}
+In {cite}`Czarnik_2021_Quantum`, the authors lay out two different methods for generating the training circuits.
+
+1. Randomly replacing gates in the target circuit with nearby Clifford gates.
+2. Construct new circuits with the use of a Markov Chain Monte Carlo (MCMC) which produce classicaly simulable states.
+
+The authors of {cite}`Czarnik_2021_Quantum` derive results with the use of the MCMC method, whereas Mitiq uses simpler approach presented in point 1.
+```
+
 The division of CDR into training, learning and prediction stages is shown more generally in the figure below.
 
 ```{figure} ../img/cdr_diagram2.png

--- a/docs/source/guide/cdr-4-low-level.md
+++ b/docs/source/guide/cdr-4-low-level.md
@@ -13,9 +13,7 @@ kernelspec:
 
 # What happens when I use CDR?
 
-Clifford Data Regression (CDR) is a learning-based quantum error mitigation technique {cite}`Czarnik_2021_Quantum`.
-
-A figure of the typical workflow for CDR in Mitiq is shown in the figure below.
+A figure of the typical workflow of CDR as implemented in Mitiq is shown in the figure below.
 
 ```{figure} ../img/cdr_workflow2_steps.png
 ---
@@ -25,9 +23,9 @@ name: cdr-workflow
 The CDR workflow in Mitiq is divided in two steps: Generating circuits, both for a classical simulator and on the intended backend, and then performing the inference from measurements to obtain a noise mitigated expectation value.
 ```
 
-The figure illustrates the Clifford data regression (CDR) workflow in Mitiq.
-
-The CDR workflow Figure above shows a schema of the implementation of CDR in Mitiq. Similarly to ZNE and PEC, also CDR in Mitiq is divided in two main stages: The first one of circuit generation and the second for inference of the mitigated value. However, in CDR, the generation of quantum circuits is different, as it involves the generation of training circuits. The division of CDR into training, learning and prediction stages is shown in the figure below.
+Similarly to ZNE and PEC, CDR is divided in two main stages: first, one of circuit generation and a second for inference of the mitigated value.
+In CDR, the generation of quantum circuits is different, as it involves the generation of training circuits.
+The division of CDR into training, learning and prediction stages is shown more generally in the figure below.
 
 ```{figure} ../img/cdr_diagram2.png
 ---
@@ -36,4 +34,3 @@ name: cdr-process
 ---
 Near-Clifford approximations of the actual circuit are simulated, without noise, on a classical simulator (circuits can be efficiently simulated classically) and executed on the noisy quantum computer (or a noisy simulator). These results are used as training data to infer the zero-noise expectation value of the error miitigated original circuit, that is finally run on the quantum computer (or noisy simulator).
 ```
-

--- a/docs/source/guide/cdr-5-theory.md
+++ b/docs/source/guide/cdr-5-theory.md
@@ -13,30 +13,16 @@ kernelspec:
 
 # What is the theory behind CDR?
 
-Clifford data regression (CDR) is a quantum error mitigation technique that has been introduced in Ref. {cite}`Czarnik_2021_Quantum` and extended to variable-noise CDR in Ref. {cite}`Lowe_2021_PRR`.
-. The presented error mitigation (EM) strategy is designed for gate-based quantum computers. This method primarily consists of creating a training data set $\{(X_{\phi_i}^{\text{error}}, X_{\phi_i}^{\text{exact}})\}$, where $X_{\phi_i}^{\text{error}}$ and $X_{\phi_i}^{\text{exact}}$ are the expectation values of an observable $X$ for a state $|\phi_i\rangle$ under error and error-free conditions, respectively. 
+Clifford Data Regression is a quantum error mitigation technique introduced in {cite}`Czarnik_2021_Quantum` and extended to variable-noise CDR in {cite}`Lowe_2021_PRR`.
+The error mitigation strategy is designed for gate-based quantum computers.
+This method primarily consists of creating a training data set $\{(X_{\phi_i}^{\text{error}}, X_{\phi_i}^{\text{exact}})\}$, where $X_{\phi_i}^{\text{error}}$ and $X_{\phi_i}^{\text{exact}}$ are the expectation values of an observable $X$ for a state $|\phi_i\rangle$ under error and error-free conditions, respectively.
 
 This method includes the following steps:
 
-## Step 1: Choose Near-Clifford Circuits for Training
+1. **Choose Near-Clifford Circuits for Training.** Near-Clifford circuits are selected due to their capability to be efficiently simulated classically, and are denoted by $S_\psi=\{|\phi_i\rangle\}_i$.
+2. **Construct the Training Set.** The training set $\{(X_{\phi_i}^{\text{error}}, X_{\phi_i}^{\text{exact}})\}_i$ is constructed by calculating the expectation values of $X$ for each state $|\phi_i\rangle$ in $S_\psi$, on both a quantum computer (to obtain $X_{\phi_i}^{\text{error}}$) and a classical computer (to obtain $X_{\phi_i}^{\text{exact}}$).
+3. **Learn the Error Mitigation Model.** A model $f(X^{\text{error}}, a)$ for $X^{exact}$ is defined and learned. Here, $a$ is the set of parameters to be determined. This is achieved by minimizing the distance between the training set, as expressed by the following optimization problem: $a_{opt} = \underset{a}{\text{argmin}} \sum_i \left| X_{\phi_i}^{\text{exact}} - f(X_{\phi_i}^{\text{error}},a) \right|^2.$ In this expression, $a_{opt}$ are the parameters that minimize the cost function.
+4. **Apply the Error Mitigation Model.** Finally, the learned model $f(X^{\text{error}}, a_{opt})$ is used to correct the expectation values of $X$ for new quantum states, expressed as $X_\psi^{\text{exact}} = f(X_\psi^{\text{error}}, a_{opt})$.
 
-Near-Clifford circuits are selected due to their capability to be efficiently simulated classically, and are denoted by $S_\psi=\{|\phi_i\rangle\}_i$.
-
-## Step 2: Construct the Training Set 
-
-The training set $\{(X_{\phi_i}^{\text{error}}, X_{\phi_i}^{\text{exact}})\}_i$ is constructed by calculating the expectation values of $X$ for each state $|\phi_i\rangle$ in $S_\psi$, on both a quantum computer (to obtain $X_{\phi_i}^{\text{error}}$) and a classical computer (to obtain $X_{\phi_i}^{\text{exact}}$).
-
-## Step 3: Learn the Error Mitigation Model
-
-A model $f(X^{\text{error}}, a)$ for $X^{exact}$ is defined and learned. Here, $a$ is the set of parameters to be determined. This is achieved by minimizing the distance between the training set, as expressed by the following optimization problem:
-
-$$a_{opt} = \underset{a}{\text{argmin}} \sum_i \left| X_{\phi_i}^{\text{exact}} - f(X_{\phi_i}^{\text{error}},a) \right|^2.$$
-
-In this expression, $a_{opt}$ are the parameters that minimize the cost function.
-
-## Step 4: Apply the Error Mitigation Model
-
-Finally, the learned model $f(X^{\text{error}}, a_{opt})$ is used to correct the expectation values of $X$ for new quantum states, expressed as $X_\psi^{\text{exact}} = f(X_\psi^{\text{error}}, a_{opt})$.
-
-The effectiveness of this method has been proven on circuits with up to 64 qubits and for tasks such as estimating ground-state energies. However, its performance is dependent on the task, the system, the quality of the training data, and the choice of model.
-
+The effectiveness of this method has been proven on circuits with up to 64 qubits and for tasks such as estimating ground-state energies.
+However, its performance is dependent on the task, the system, the quality of the training data, and the choice of model.

--- a/docs/source/guide/cdr-5-theory.md
+++ b/docs/source/guide/cdr-5-theory.md
@@ -14,8 +14,8 @@ kernelspec:
 # What is the theory behind CDR?
 
 Clifford Data Regression is a quantum error mitigation technique introduced in {cite}`Czarnik_2021_Quantum` and extended to variable-noise CDR in {cite}`Lowe_2021_PRR`.
-The error mitigation strategy is designed for gate-based quantum computers.
-This method primarily consists of creating a training data set $\{(X_{\phi_i}^{\text{error}}, X_{\phi_i}^{\text{exact}})\}$, where $X_{\phi_i}^{\text{error}}$ and $X_{\phi_i}^{\text{exact}}$ are the expectation values of an observable $X$ for a state $|\phi_i\rangle$ under error and error-free conditions, respectively.
+This error mitigation strategy is designed for application at the gate level and is relatively straightforward to apply on gate-based quantum computers.
+CDR primarily consists of creating a training data set $\{(X_{\phi_i}^{\text{error}}, X_{\phi_i}^{\text{exact}})\}$, where $X_{\phi_i}^{\text{error}}$ and $X_{\phi_i}^{\text{exact}}$ are the expectation values of an observable $X$ for a state $|\phi_i\rangle$ under error and error-free conditions, respectively.
 
 This method includes the following steps:
 
@@ -24,5 +24,5 @@ This method includes the following steps:
 3. **Learn the Error Mitigation Model.** A model $f(X^{\text{error}}, a)$ for $X^{exact}$ is defined and learned. Here, $a$ is the set of parameters to be determined. This is achieved by minimizing the distance between the training set, as expressed by the following optimization problem: $a_{opt} = \underset{a}{\text{argmin}} \sum_i \left| X_{\phi_i}^{\text{exact}} - f(X_{\phi_i}^{\text{error}},a) \right|^2.$ In this expression, $a_{opt}$ are the parameters that minimize the cost function.
 4. **Apply the Error Mitigation Model.** Finally, the learned model $f(X^{\text{error}}, a_{opt})$ is used to correct the expectation values of $X$ for new quantum states, expressed as $X_\psi^{\text{exact}} = f(X_\psi^{\text{error}}, a_{opt})$.
 
-The effectiveness of this method has been proven on circuits with up to 64 qubits and for tasks such as estimating ground-state energies.
+The effectiveness of this method has been demonstrated on circuits with up to 64 qubits and for tasks such as estimating ground-state energies.
 However, its performance is dependent on the task, the system, the quality of the training data, and the choice of model.

--- a/docs/source/guide/cdr.md
+++ b/docs/source/guide/cdr.md
@@ -7,7 +7,7 @@ Clifford data regression (CDR) is a learning-based quantum error mitigation tech
 width: 700px
 name: cdr-workflow-overview
 ---
-The CDR workflow in Mitiq is fully explained in the [What happens when I use CDR?](cdr-4-low-level.md) section.
+The CDR workflow in Mitiq is fully explained in the {doc}`cdr-4-low-level` section.
 ```
 
 Below you can find sections of the documentation that address the following questions:
@@ -23,4 +23,4 @@ cdr-4-low-level.md
 cdr-5-theory.md
 ```
 
-A simple tutorial on CDR can be found in the code blocks in the [Problem setup](cdr-1-intro.md) section of the first section of the user guide.
+A simple tutorial using CDR can be found on the {doc}`cdr-1-intro` page.


### PR DESCRIPTION
## Description

There is an important omission from our documentation regarding how Mitiq creates training circuits for Clifford Data Regression. There are two methods put forth in the [original paper](https://arxiv.org/abs/2005.10189), yet the authors choice is different from the one in Mitiq. This PR adds clarification for that detail.

- bddae0b0a0fdab8df2483a17b3544d90831668ec contains general cleanup of the CDR pages
- 5abe596a4cacafbf4b0d8e17d45995c6a889f8f9 is the issue that "resolves" this issue.

fixes https://github.com/unitaryfund/mitiq/issues/1393