### PR TITLE
Revert recent commits on classical shadows to fix tutorials in documentation

### DIFF
--- a/mitiq/shadows/classical_postprocessing.py
+++ b/mitiq/shadows/classical_postprocessing.py
@@ -361,7 +361,7 @@ def expectation_estimation_shadow(
                 b = create_string(num_qubits, target_locs)
                 f_val = f_est.get(b, None)
                 if f_val is None:
-                    product = 0.0
+                    means.append(0.0)
                 else:
                     # product becomes an array of snapshots expectation values
                     # witch satisfy condition (1) and (2)
@@ -369,11 +369,10 @@ def expectation_estimation_shadow(
             else:
                 product = 3 ** (len(target_locs)) * product
 
+            # append the mean of the product in each split
+            means.append(np.sum(product) / len(idxes))
         else:
-            product = 0.0
-
-        # append the mean of the product in each split
-        means.append(np.sum(product) / len(idxes))
+            means.append(0.0)
 
     # return the median of means
     return float(np.real(np.median(means) * coeff))

--- a/mitiq/shadows/classical_postprocessing.py
+++ b/mitiq/shadows/classical_postprocessing.py
@@ -347,7 +347,7 @@ def expectation_estimation_shadow(
             u_lists_shadow_k[:, target_locs] == target_obs, axis=1
         )
         if sum(indices) == 0:
-            means.append(0.0)
+            product = 0.0
         else:
             eigenvalues = np.array(
                 [
@@ -367,7 +367,7 @@ def expectation_estimation_shadow(
                 b = create_string(num_qubits, target_locs)
                 f_val = f_est.get(b, None)
                 if f_val is None:
-                    means.append(0.0)
+                    product = 0.0
                 else:
                     # product becomes an array of snapshots expectation values
                     # witch satisfy condition (1) and (2)
@@ -375,8 +375,8 @@ def expectation_estimation_shadow(
             else:
                 product = 3 ** (target_support.count("1")) * product
 
-            # append the mean of the product in each split
-            means.append(np.sum(product) / n_group_measurements)
+        # append the mean of the product in each split
+        means.append(np.sum(product) / n_group_measurements)
 
     # return the median of means
     return float(np.real(np.median(means) * coeff))


### PR DESCRIPTION
This PR, reverts #2115 and #2113, to recover the original code that used to generate good results in the docs examples.

It also manually re-apply the small changes of #2115, since to me they seem are correct.
So, overall, this PR corresponds to an effective revert of just #2113 .

We can always re-implement something similar to #2113, after we figure out the hidden problem with that.

Meanwhile, reverting to the original code looks like a pragmatic solution.

