### PR TITLE
Changed to use the split for b_list_shadow

### DIFF
--- a/mitiq/shadows/classical_postprocessing.py
+++ b/mitiq/shadows/classical_postprocessing.py
@@ -343,7 +343,7 @@ def expectation_estimation_shadow(
             np.all(u_lists_shadow[idxes] == target_obs, axis=1)
         )
 
-        if len(matchingIndexes[0]):
+        if len(matching_indexes[0]):
             product = (-1) ** np.sum(
                 b_lists_shadow[idxes][matching_indexes].astype(int),
                 axis=1,

--- a/mitiq/shadows/classical_postprocessing.py
+++ b/mitiq/shadows/classical_postprocessing.py
@@ -343,7 +343,7 @@ def expectation_estimation_shadow(
             np.nonzero(np.all(u_lists_shadow[idxes] == target_obs, axis=1))[0]
         ):
             product = (-1) ** np.sum(
-                b_lists_shadow[
+                b_lists_shadow[idxes][
                     np.nonzero(
                         np.all(u_lists_shadow[idxes] == target_obs, axis=1)
                     )

--- a/mitiq/shadows/classical_postprocessing.py
+++ b/mitiq/shadows/classical_postprocessing.py
@@ -339,13 +339,13 @@ def expectation_estimation_shadow(
 
     # loop over the splits of the shadow:
     for idxes in group_idxes:
-        matchingIndexes = np.nonzero(
+        matching_indexes = np.nonzero(
             np.all(u_lists_shadow[idxes] == target_obs, axis=1)
         )
 
         if len(matchingIndexes[0]):
             product = (-1) ** np.sum(
-                b_lists_shadow[idxes][matchingIndexes].astype(int),
+                b_lists_shadow[idxes][matching_indexes].astype(int),
                 axis=1,
             )
 

--- a/mitiq/shadows/classical_postprocessing.py
+++ b/mitiq/shadows/classical_postprocessing.py
@@ -339,15 +339,13 @@ def expectation_estimation_shadow(
 
     # loop over the splits of the shadow:
     for idxes in group_idxes:
-        if len(
-            np.nonzero(np.all(u_lists_shadow[idxes] == target_obs, axis=1))[0]
-        ):
+        matchingIndexes = np.nonzero(
+            np.all(u_lists_shadow[idxes] == target_obs, axis=1)
+        )
+
+        if len(matchingIndexes[0]):
             product = (-1) ** np.sum(
-                b_lists_shadow[idxes][
-                    np.nonzero(
-                        np.all(u_lists_shadow[idxes] == target_obs, axis=1)
-                    )
-                ].astype(int),
+                b_lists_shadow[idxes][matchingIndexes].astype(int),
                 axis=1,
             )
 


### PR DESCRIPTION
This corrects an issue from PR #2113.

In particular, the issue was that indexes that are relative to a split were used against the full b_lists_shadow object. 

The correction changes it so that the indexes that are relative to a split are used against that split.

After making changes, values through the `expectation_estimation_shadow` function were compared between the previous code and the new code.
![image](https://github.com/unitaryfund/mitiq/assets/62308289/f4677388-d810-4ea5-8d6e-3b2971237b2c)


Also, the results in the final plot are now matching the previous results:
new code:
![image](https://github.com/unitaryfund/mitiq/assets/62308289/c5f4e13d-9b08-42d3-abcf-d51a853c049d)

v0.31.0 code:
![image](https://github.com/unitaryfund/mitiq/assets/62308289/85d55ea5-db05-4cc2-baf0-defd414669d4)


### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [X] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [X] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [X] Added myself / the copyright holder to the AUTHORS file