### PR TITLE
Refactor classical postprocessing in shadows module

### DIFF
--- a/docs/source/examples/rshadows_tutorial.md
+++ b/docs/source/examples/rshadows_tutorial.md
@@ -249,7 +249,7 @@ plt.xticks(
 )
 
 plt.ylabel("Pauli fidelity")
-plt.legend()
+plt.legend();
 ```
 
 

--- a/docs/source/examples/rshadows_tutorial.md
+++ b/docs/source/examples/rshadows_tutorial.md
@@ -329,14 +329,12 @@ def compare_shadow_methods(
         
     output_shadow = classical_post_processing(
         shadow_outcomes=shadow_measurement_result,
-        use_calibration=False,
         observables=observables,
         k_shadows=k_shadows,
     )
 
     output_shadow_cal = classical_post_processing(
         shadow_outcomes=shadow_measurement_result,
-        use_calibration=True,
         calibration_results=f_est,
         observables=observables,
         k_shadows=k_shadows,

--- a/docs/source/examples/shadows_tutorial.md
+++ b/docs/source/examples/shadows_tutorial.md
@@ -179,7 +179,6 @@ shadow_outcomes = shadow_quantum_processing(
 # get shadow reconstruction of the density matrix
 output = classical_post_processing(
     shadow_outcomes,
-    use_calibration=False,
     state_reconstruction=True,
 )
 rho_shadow = output["reconstructed_state"]
@@ -286,7 +285,6 @@ for n_measurement in n_measurement_list:
         # perform shadow state reconstruction
         rho_shadow = classical_post_processing(
             shadow_outcomes=shadow_subset,
-            use_calibration=False,
             state_reconstruction=True,
         )["reconstructed_state"]
 
@@ -474,7 +472,6 @@ for error in epsilon_grid:
     shadow_outputs = shadow_quantum_processing(test_circuits, cirq_executor, r)
     output = classical_post_processing(
         shadow_outcomes=shadow_outputs,
-        use_calibration=False,
         observables=list_of_paulistrings,
         k_shadows=k,
     )

--- a/docs/source/guide/shadows-1-intro.md
+++ b/docs/source/guide/shadows-1-intro.md
@@ -10,43 +10,45 @@ kernelspec:
   language: python
   name: python3
 ---
+
 ```{admonition} Note:
-The documentation for Classical Shadows in Mitiq is still under construction. This users guide will change in the future. 
+The documentation for Classical Shadows in Mitiq is still under construction. This users guide will change in the future.
 ```
 
 # How Do I Use Classical Shadows Estimation?
-
 
 The `mitiq.shadows` module facilitates the application of the classical shadows protocol on quantum circuits, designed for tasks like quantum state tomography or expectation value estimation. In addition this module integrates a robust shadow estimation protocol that's tailored to counteract noise. The primary objective of the classical shadow protocol is to extract information from a quantum state using repeated measurements.
 
 The procedure can be broken down as follows:
 
-1. `shadow_quantum_processing`: 
+1. `shadow_quantum_processing`:
+
    - Purpose: Execute quantum processing on the provided quantum circuit.
    - Outcome: Measurement results from the processed circuit.
 
-2. `classical_post_processing`: 
+2. `classical_post_processing`:
    - Purpose: Handle classical processing of the measurement results.
    - Outcome: Estimation based on user-defined inputs.
 
 For users aiming to employ the robust shadow estimation protocol, an initial step is needed which entails characterizing the noisy quantum channel. This is done by:
 
 0. `pauli_twirling_calibration`
+
    - Purpose: Characterize the noisy quantum channel.
    - Outcome: A dictionary of `calibration_results`.
 
 1. `shadow_quantum_processing`: same as above.
 
 2. `classical_post_processing`
-   - Args: `use_calibration` = True, 
-           `calibration_results` = output of `pauli_twirling_calibration`
+   - Args: `calibration_results` = output of `pauli_twirling_calibration`
    - Outcome: Error mitigated estimation based on user-defined inputs.
 
 Notes:
-   - The calibration process is specifically designed to mitigate noise encountered during the classical shadow protocol, such as rotation and computational basis measurements. It does not address noise that occurs during state preparation.
-   - Do not need to redo the calibration stage (0. `pauli_twirling_calibration`) if:
-       1. The input circuit has a consistent number of qubits.
-       2. The estimated observables have the same or fewer qubit support.
+
+- The calibration process is specifically designed to mitigate noise encountered during the classical shadow protocol, such as rotation and computational basis measurements. It does not address noise that occurs during state preparation.
+- Do not need to redo the calibration stage (0. `pauli_twirling_calibration`) if:
+  1.  The input circuit has a consistent number of qubits.
+  2.  The estimated observables have the same or fewer qubit support.
 
 ## Protocol Overview
 
@@ -54,8 +56,9 @@ The classical shadow protocol aims to create an approximate classical representa
 
 One can use the `mitiq.shadows' module as follows.
 
-### User-defined inputs 
-Define a quantum circuit, e.g., a circuit which prepares a GHZ state with $n$ = `3` qubits, 
+### User-defined inputs
+
+Define a quantum circuit, e.g., a circuit which prepares a GHZ state with $n$ = `3` qubits,
 
 ```{code-cell} ipython3
 import numpy as np
@@ -76,12 +79,11 @@ circuit = cirq.Circuit(
 print(circuit)
 ```
 
-Define an executor to run the circuit on a quantum computer or a noisy simulator. Note that the *robust shadow estimation* technique can only calibrate and mitigate the noise acting on the operations associated to the classical shadow protocol. So, in order to test the technique, we assume that the state preparation part of the circuit is noiseless. In particular, we define an executor in which:
+Define an executor to run the circuit on a quantum computer or a noisy simulator. Note that the _robust shadow estimation_ technique can only calibrate and mitigate the noise acting on the operations associated to the classical shadow protocol. So, in order to test the technique, we assume that the state preparation part of the circuit is noiseless. In particular, we define an executor in which:
 
 1. A noise channel is added to circuit right before the measurements. I.e. $U_{\Lambda_U}(M_z)_{\Lambda_{\mathcal{M}_Z}}\equiv U\Lambda\mathcal{M}_Z$.
 
 2. A single measurement shot is taken for each circuit, as required by classical shadow protocol.
-
 
 ```{code-cell} ipython3
 from mitiq import MeasurementResult
@@ -125,8 +127,7 @@ def cirq_executor(
     return executor
 ```
 
-Given the above general executor, we define a specific example of a noisy executor, assuming a bit flip channel with a  probability of `0.1'
-
+Given the above general executor, we define a specific example of a noisy executor, assuming a bit flip channel with a probability of `0.1'
 
 ```{code-cell} ipython3
 from functools import partial
@@ -164,24 +165,28 @@ f_est
 
 the varible `locality` is the maximum number of qubits on which our operators of interest are acting on. E.g. if our operator is a sequence of two point correlation terms $\{\langle Z_iZ_{i+1}\rangle\}_{0\leq i\leq n-1}$, then `locality` = 2. We note that one could also split the calibration process into two stages:
 
-01. `shadow_quantum_processing`
-   - Outcome: Get quantum measurement result of the calibration circuit $|0\rangle^{\otimes n}$ `zero_state_shadow_outcomes`.
+1.  `shadow_quantum_processing`
 
-02. `pauli_twirling_calibration`
-   - Outcome: A dictionary of `calibration_results`.
-For more details, please refer to  [this tutorial](../examples/rshadows_tutorial.md)
+- Outcome: Get quantum measurement result of the calibration circuit $|0\rangle^{\otimes n}$ `zero_state_shadow_outcomes`.
+
+2.  `pauli_twirling_calibration`
+
+- Outcome: A dictionary of `calibration_results`.
+  For more details, please refer to [this tutorial](../examples/rshadows_tutorial.md)
 
 ### 1. Quantum Processing
+
 In this step, we obtain classical shadow snapshots from the input state (before applying the invert channel).
 
 #### 1.1 Add Rotation Gate and Meausure the Rotated State in Computational Basis
+
 At present, the implementation supports random Pauli measurement. This is equivalent to randomly sampling $U$ from the local Clifford group $Cl_2^n$, followed by a $Z$-basis measurement (see [this tutorial](../examples/shadows_tutorial.md) for a clear explanation).
 
 #### 1.2 Get the Classical Shadows
+
 One can obtain the list of measurement results of local Pauli measurements in terms of bitstrings, and the related Pauli-basis measured in terms of strings as follows.
 
-
-You have two choices: run the quantum measurement or directly use the results from the previous run. 
+You have two choices: run the quantum measurement or directly use the results from the previous run.
 
 - If **True**, the measurement will be run again.
 - If **False**, the results from the previous run will be used.
@@ -206,10 +211,8 @@ else:
         num_total_measurements_shadow=5000,
     )
 ```
-                                                                     
 
 As an example, we print out one of those measurement outcomes and the associated measured operator:
-
 
 ```{code-cell} ipython3
 print("one snapshot measurement result = ", shadow_measurement_output[0][0])
@@ -217,9 +220,11 @@ print("one snapshot measurement basis = ", shadow_measurement_output[1][0])
 ```
 
 ### 2. Classical Post-Processing
-In this step, we estimate our object of interest (expectation value or density matrix) by post-processing the (previously obtained) measurement outcomes. 
+
+In this step, we estimate our object of interest (expectation value or density matrix) by post-processing the (previously obtained) measurement outcomes.
 
 #### 2.1 Example: Operator Expectation Value Esitimation
+
 For example, if we want to estimate the two point correlation function $\{\langle Z_iZ_{i+1}\rangle\}_{0\leq i\leq n-1}$, we will define the corresponding Puali strings:
 
 ```{code-cell} ipython3
@@ -238,13 +243,11 @@ The corresponding expectation values can be estimated (with and without calibrat
 ```{code-cell} ipython3
 est_corrs = classical_post_processing(
     shadow_outcomes=shadow_measurement_output,
-    use_calibration=False,
     observables=two_pt_correlations,
     k_shadows=1,
 )
 cal_est_corrs = classical_post_processing(
     shadow_outcomes=shadow_measurement_output,
-    use_calibration=True,
     calibration_results=f_est,
     observables=two_pt_correlations,
     k_shadows=1,
@@ -252,7 +255,6 @@ cal_est_corrs = classical_post_processing(
 ```
 
 Let's compare the results with the exact theoretical values:
-
 
 ```{code-cell} ipython3
 expval_exact = []
@@ -263,7 +265,6 @@ for i, pauli_string in enumerate(two_pt_correlations):
     )
     expval_exact.append(exp.real)
 ```
-
 
 ```{code-cell} ipython3
 print("Classical shadow estimation:", est_corrs)
@@ -277,12 +278,10 @@ print(
 )
 ```
 
-
 #### 2.2 Example: GHZ State Reconstruction
-In addition to the estimation of expectation values, the `mitiq.shadow` module can also be used to reconstruct an approximated version of the density matrix. 
+
+In addition to the estimation of expectation values, the `mitiq.shadow` module can also be used to reconstruct an approximated version of the density matrix.
 As an example, we use the 3-qubit GHZ circuit, previously defined. As a first step, we calculate the Pauli fidelities $f_b$ characterizing the noisy quantum channel $\mathcal{M}=\sum_{b\in\{0,1\}^n}f_b\Pi_b$:
-
-
 
 ```{code-cell} ipython3
 noisy_executor = partial(
@@ -307,9 +306,7 @@ else:
 f_est
 ```
 
-
-Similar to the previous case (estimation of expectation values), the quantum processing for estimating the density matrix  is done as follows.
-
+Similar to the previous case (estimation of expectation values), the quantum processing for estimating the density matrix is done as follows.
 
 ```{code-cell} ipython3
 if not run_quantum_processing:
@@ -328,12 +325,10 @@ else:
 ```{code-cell} ipython3
 est_corrs = classical_post_processing(
     shadow_outcomes=shadow_measurement_output,
-    use_calibration=False,
     state_reconstruction=True,
 )
 cal_est_corrs = classical_post_processing(
     shadow_outcomes=shadow_measurement_output,
-    use_calibration=True,
     calibration_results=f_est,
     state_reconstruction=True,
 )
@@ -348,7 +343,6 @@ ghz_state = circuit.final_state_vector().reshape(-1, 1)
 ghz_true = ghz_state @ ghz_state.conj().T
 ptm_ghz_state = operator_ptm_vector_rep(ghz_true)
 ```
-
 
 ```{code-cell} ipython3
 from mitiq.shadows.shadows_utils import fidelity

--- a/mitiq/shadows/classical_postprocessing.py
+++ b/mitiq/shadows/classical_postprocessing.py
@@ -21,9 +21,9 @@ from mitiq.utils import matrix_kronecker_product, operator_ptm_vector_rep
 
 # Local unitaries to measure Pauli operators in the Z basis
 PAULI_MAP = {
-    "X": cirq.H._unitary_(),
-    "Y": cirq.H._unitary_() @ cirq.S._unitary_().conj(),
-    "Z": cirq.I._unitary_(),
+    "X": cirq.unitary(cirq.H),
+    "Y": cirq.unitary(cirq.H) @ cirq.unitary(cirq.S).conj(),
+    "Z": cirq.unitary(cirq.I),
 }
 
 # Density matrices of single-qubit basis states
@@ -247,7 +247,7 @@ def classical_snapshot(
             state = ZERO_STATE if b == "0" else ONE_STATE
             U = PAULI_MAP[u]
             # apply inverse of the quantum channel,get PTM vector rep
-            local_rho = 3.0 * (U.conj().T @ state @ U) - cirq.I._unitary_()
+            local_rho = 3.0 * (U.conj().T @ state @ U) - cirq.unitary(cirq.I)
             local_rhos.append(local_rho)
 
         rho_snapshot = matrix_kronecker_product(local_rhos)

--- a/mitiq/shadows/classical_postprocessing.py
+++ b/mitiq/shadows/classical_postprocessing.py
@@ -357,15 +357,12 @@ def expectation_estimation_shadow(
                     )
 
                 b = create_string(num_qubits, target_locs)
-                f_val = f_est.get(b, None)
-                if f_val is None:
-                    product = 0.0
-                else:
-                    # product becomes an array of snapshots expectation values
-                    # witch satisfy condition (1) and (2)
-                    product = (1.0 / f_val) * product
+                f_val = f_est.get(b, np.inf)
+                # product becomes an array of snapshot expectation values
+                # witch satisfy condition (1) and (2)
+                product = (1 / f_val) * product
             else:
-                product = 3 ** (len(target_locs)) * product
+                product = 3 ** len(target_locs) * product
 
         else:
             product = 0.0

--- a/mitiq/shadows/classical_postprocessing.py
+++ b/mitiq/shadows/classical_postprocessing.py
@@ -293,7 +293,7 @@ def shadow_state_reconstruction(
 
 def expectation_estimation_shadow(
     measurement_outcomes: Tuple[List[str], List[str]],
-    pauli_str: mitiq.PauliString,  # type: ignore
+    pauli_str: mitiq.PauliString,
     k_shadows: int,
     pauli_twirling_calibration: bool,
     f_est: Optional[Dict[str, float]] = None,

--- a/mitiq/shadows/classical_postprocessing.py
+++ b/mitiq/shadows/classical_postprocessing.py
@@ -208,8 +208,8 @@ def classical_snapshot(
 
 def shadow_state_reconstruction(
     shadow_measurement_outcomes: Tuple[List[str], List[str]],
-    pauli_twirling_calibration: bool,
-    f_est: Optional[Dict[str, float]] = None,
+    calibrate: bool,
+    fidelities: Optional[Dict[str, float]] = None,
 ) -> npt.NDArray[Any]:
     """Reconstruct a state approximation as an average over all snapshots.
 
@@ -225,19 +225,12 @@ def shadow_state_reconstruction(
     Returns:
         The state reconstructed from classical shadow protocol
     """
+    bitstrings, paulistrings = shadow_measurement_outcomes
 
-    # classical values of random Pauli measurement stored in classical computer
-    b_lists_shadow, u_lists_shadow = shadow_measurement_outcomes
-
-    # Averaging over snapshot states.
     return np.mean(
         [
-            classical_snapshot(
-                b_list_shadow, u_list_shadow, pauli_twirling_calibration, f_est
-            )
-            for b_list_shadow, u_list_shadow in zip(
-                b_lists_shadow, u_lists_shadow
-            )
+            classical_snapshot(bitstring, paulistring, calibrate, fidelities)
+            for bitstring, paulistring in zip(bitstrings, paulistrings)
         ],
         axis=0,
     )

--- a/mitiq/shadows/classical_postprocessing.py
+++ b/mitiq/shadows/classical_postprocessing.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import cirq
 import numpy as np
-from numpy.typing import NDArray
+import numpy.typing as npt
 
 import mitiq
 from mitiq.shadows.shadows_utils import create_string
@@ -184,7 +184,7 @@ def classical_snapshot(
     u_list_shadow: str,
     pauli_twirling_calibration: bool,
     f_est: Optional[Dict[str, float]] = None,
-) -> NDArray[Any]:
+) -> npt.NDArray[Any]:
     r"""
     Implement a single snapshot state reconstruction
     with calibration of the noisy quantum channel.
@@ -258,7 +258,7 @@ def shadow_state_reconstruction(
     shadow_measurement_outcomes: Tuple[List[str], List[str]],
     pauli_twirling_calibration: bool,
     f_est: Optional[Dict[str, float]] = None,
-) -> NDArray[Any]:
+) -> npt.NDArray[Any]:
     """Reconstruct a state approximation as an average over all snapshots.
 
     Args:

--- a/mitiq/shadows/classical_postprocessing.py
+++ b/mitiq/shadows/classical_postprocessing.py
@@ -123,8 +123,8 @@ def get_pauli_fidelities(
             for b, f in fidelities.items():
                 all_fidelities[b].append(f)
 
-        for bitstring, fidelities in all_fidelities.items():
-            means[bitstring].append(sum(fidelities) / batch_size)
+        for bitstring, fids in all_fidelities.items():
+            means[bitstring].append(sum(fids) / batch_size)
 
     return {
         bitstring: median(averages) for bitstring, averages in means.items()

--- a/mitiq/shadows/shadows.py
+++ b/mitiq/shadows/shadows.py
@@ -154,7 +154,6 @@ def shadow_quantum_processing(
 
 def classical_post_processing(
     shadow_outcomes: Tuple[List[str], List[str]],
-    use_calibration: bool = False,
     calibration_results: Optional[Dict[str, float]] = None,
     observables: Optional[List[mitiq.PauliString]] = None,
     k_shadows: Optional[int] = None,
@@ -166,7 +165,6 @@ def classical_post_processing(
 
     Args:
         shadow_outcomes: The output of function `shadow_quantum_processing`.
-        use_calibration: Whether to use the robust shadow estimation.
         calibration_results: The output of function `pauli_twirling_calibrate`.
         observables: The set of observables to measure.
         k_shadows: Number of groups of "median of means" used for shadow
@@ -175,18 +173,13 @@ def classical_post_processing(
             the expectation value of the observables.
 
     Returns:
+        TODO: rewrite this.
         If `state_reconstruction` is True: state tomography matrix in
         :math:`\mathbb{M}_{2^n}(\mathbb{C})` if use_calibration is False,
         otherwise state tomography vector in :math:`\mathbb{C}^{4^d}`.
         If observables is given: estimated expectation values of
         observables.
     """
-
-    if use_calibration:
-        if calibration_results is None:
-            raise ValueError(
-                "Calibration results cannot be None when use_calibration"
-            )
 
     """
     Additional information:
@@ -196,7 +189,7 @@ def classical_post_processing(
     output: Dict[str, Union[float, NDArray[Any]]] = {}
     if state_reconstruction:
         reconstructed_state = shadow_state_reconstruction(
-            shadow_outcomes, use_calibration, fidelities=calibration_results
+            shadow_outcomes, fidelities=calibration_results
         )
         output["reconstructed_state"] = reconstructed_state  # type: ignore
     elif observables is not None:
@@ -208,7 +201,6 @@ def classical_post_processing(
                 shadow_outcomes,
                 obs,
                 k_shadows=k_shadows,
-                pauli_twirling_calibration=use_calibration,
                 f_est=calibration_results,
             )
             output[str(obs)] = expectation_values

--- a/mitiq/shadows/shadows.py
+++ b/mitiq/shadows/shadows.py
@@ -196,7 +196,7 @@ def classical_post_processing(
     output: Dict[str, Union[float, NDArray[Any]]] = {}
     if state_reconstruction:
         reconstructed_state = shadow_state_reconstruction(
-            shadow_outcomes, use_calibration, f_est=calibration_results
+            shadow_outcomes, use_calibration, fidelities=calibration_results
         )
         output["reconstructed_state"] = reconstructed_state  # type: ignore
     elif observables is not None:

--- a/mitiq/shadows/shadows.py
+++ b/mitiq/shadows/shadows.py
@@ -200,7 +200,7 @@ def classical_post_processing(
             expectation_values = expectation_estimation_shadow(
                 shadow_outcomes,
                 obs,
-                batch_size=k_shadows,
+                num_batches=k_shadows,
                 fidelities=calibration_results,
             )
             output[str(obs)] = expectation_values

--- a/mitiq/shadows/shadows.py
+++ b/mitiq/shadows/shadows.py
@@ -200,8 +200,8 @@ def classical_post_processing(
             expectation_values = expectation_estimation_shadow(
                 shadow_outcomes,
                 obs,
-                k_shadows=k_shadows,
-                f_est=calibration_results,
+                batch_size=k_shadows,
+                fidelities=calibration_results,
             )
             output[str(obs)] = expectation_values
     return output

--- a/mitiq/shadows/shadows_utils.py
+++ b/mitiq/shadows/shadows_utils.py
@@ -98,7 +98,7 @@ def fidelity(
 
 
 def batch_calibration_data(
-    data: Tuple[List[str], List[str]], batch_size: int
+    data: Tuple[List[str], List[str]], num_batches: int
 ) -> Generator[Tuple[List[str], List[str]], None, None]:
     """Batch calibration into chunks of size batch_size.
 
@@ -110,6 +110,7 @@ def batch_calibration_data(
         Tuples of bit strings and pauli strings.
     """
     bits, paulis = data
+    batch_size = len(bits) // num_batches
     for i in range(0, len(bits), batch_size):
         yield bits[i : i + batch_size], paulis[i : i + batch_size]
 

--- a/mitiq/shadows/shadows_utils.py
+++ b/mitiq/shadows/shadows_utils.py
@@ -9,39 +9,13 @@
 
 """Defines utility functions for classical shadows protocol."""
 
-from typing import Iterable, List, Tuple
+from typing import List, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
 from scipy.linalg import sqrtm
 
 import mitiq
-
-
-def eigenvalues_to_bitstring(values: Iterable[int]) -> str:
-    """Converts eigenvalues to bitstring. e.g., ``[-1,1,1] -> "100"``
-
-    Args:
-        values: A list of eigenvalues (must be $-1$ and $1$).
-
-    Returns:
-        A string of 1s and 0s corresponding to the states associated to
-        eigenvalues.
-    """
-    return "".join(["1" if v == -1 else "0" for v in values])
-
-
-def bitstring_to_eigenvalues(bitstring: str) -> List[int]:
-    """Converts bitstring to eigenvalues. e.g., ``"100" -> [-1,1,1]``
-
-    Args:
-        bitstring: A string of 1s and 0s.
-
-    Returns:
-        A list of eigenvalues (either $-1$ or $1$) corresponding to the
-        bitstring.
-    """
-    return [1 if b == "0" else -1 for b in bitstring]
 
 
 def create_string(str_len: int, loc_list: List[int]) -> str:

--- a/mitiq/shadows/shadows_utils.py
+++ b/mitiq/shadows/shadows_utils.py
@@ -9,7 +9,7 @@
 
 """Defines utility functions for classical shadows protocol."""
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -37,6 +37,36 @@ def create_string(str_len: int, loc_list: List[int]) -> str:
     return "".join(
         map(lambda i: "1" if i in set(loc_list) else "0", range(str_len))
     )
+
+
+def valid_bitstrings(
+    num_qubits: int, max_hamming_weight: Optional[int] = None
+) -> set[str]:
+    """
+    Description.
+
+    Args:
+        num_qubits:
+        max_hamming_weight:
+
+    Returns:
+        The set of all valid bitstrings on ``num_qubits`` bits, with a maximum
+        hamming weight.
+    Raises:
+        Value error when ``max_hamming_weight`` is not greater than 0.
+    """
+    if max_hamming_weight and max_hamming_weight < 1:
+        raise ValueError(
+            "max_hamming_weight must be greater than 0. "
+            f"Got {max_hamming_weight}."
+        )
+
+    bitstrings = {
+        bin(i)[2:].zfill(num_qubits)
+        for i in range(2**num_qubits)
+        if bin(i).count("1") <= max_hamming_weight or num_qubits
+    }
+    return bitstrings
 
 
 def n_measurements_tomography_bound(epsilon: float, num_qubits: int) -> int:

--- a/mitiq/shadows/shadows_utils.py
+++ b/mitiq/shadows/shadows_utils.py
@@ -12,6 +12,8 @@
 from typing import Generator, List, Optional, Tuple
 
 import numpy as np
+import numpy.typing as npt
+from scipy.linalg import sqrtm
 
 import mitiq
 
@@ -67,6 +69,32 @@ def valid_bitstrings(
         if bin(i).count("1") <= max_hamming_weight or num_qubits
     }
     return bitstrings
+
+
+def fidelity(
+    sigma: npt.NDArray[np.complex64], rho: npt.NDArray[np.complex64]
+) -> float:
+    """
+    Calculate the fidelity between two states.
+
+    Args:
+        sigma: A state in terms of square matrix or vector.
+        rho: A state in terms square matrix or vector.
+
+    Returns:
+        Scalar corresponding to the fidelity.
+    """
+    if sigma.ndim == 1 and rho.ndim == 1:
+        val = np.abs(np.dot(sigma.conj(), rho)) ** 2.0
+    elif sigma.ndim == 1 and rho.ndim == 2:
+        val = np.abs(sigma.conj().T @ rho @ sigma)
+    elif sigma.ndim == 2 and rho.ndim == 1:
+        val = np.abs(rho.conj().T @ sigma @ rho)
+    elif sigma.ndim == 2 and rho.ndim == 2:
+        val = np.abs(np.trace(sqrtm(sigma) @ rho @ sqrtm(sigma)))
+    else:
+        raise ValueError("Invalid input dimensions")
+    return float(val)
 
 
 def batch_calibration_data(

--- a/mitiq/shadows/shadows_utils.py
+++ b/mitiq/shadows/shadows_utils.py
@@ -9,7 +9,7 @@
 
 """Defines utility functions for classical shadows protocol."""
 
-from typing import List, Optional, Tuple
+from typing import Generator, List, Optional, Tuple
 
 import numpy as np
 
@@ -67,6 +67,23 @@ def valid_bitstrings(
         if bin(i).count("1") <= max_hamming_weight or num_qubits
     }
     return bitstrings
+
+
+def batch_calibration_data(
+    data: Tuple[List[str], List[str]], batch_size: int
+) -> Generator[Tuple[List[str], List[str]], None, None]:
+    """Batch calibration into chunks of size batch_size.
+
+    Args:
+        data: The random Pauli measurement outcomes.
+        batch_size: Size of each batch that will be processed.
+
+    Yields:
+        Tuples of bit strings and pauli strings.
+    """
+    bits, paulis = data
+    for i in range(0, len(bits), batch_size):
+        yield bits[i : i + batch_size], paulis[i : i + batch_size]
 
 
 def n_measurements_tomography_bound(epsilon: float, num_qubits: int) -> int:

--- a/mitiq/shadows/shadows_utils.py
+++ b/mitiq/shadows/shadows_utils.py
@@ -66,7 +66,7 @@ def valid_bitstrings(
     bitstrings = {
         bin(i)[2:].zfill(num_qubits)
         for i in range(2**num_qubits)
-        if bin(i).count("1") <= max_hamming_weight or num_qubits
+        if bin(i).count("1") <= (max_hamming_weight or num_qubits)
     }
     return bitstrings
 

--- a/mitiq/shadows/shadows_utils.py
+++ b/mitiq/shadows/shadows_utils.py
@@ -12,8 +12,6 @@
 from typing import List, Tuple
 
 import numpy as np
-from numpy.typing import NDArray
-from scipy.linalg import sqrtm
 
 import mitiq
 
@@ -109,29 +107,3 @@ def n_measurements_opts_expectation_bound(
         / error**2
     )
     return int(np.ceil(N * K)), int(K)
-
-
-def fidelity(
-    sigma: NDArray[np.complex64], rho: NDArray[np.complex64]
-) -> float:
-    """
-    Calculate the fidelity between two states.
-
-    Args:
-        sigma: A state in terms of square matrix or vector.
-        rho: A state in terms square matrix or vector.
-
-    Returns:
-        Scalar corresponding to the fidelity.
-    """
-    if sigma.ndim == 1 and rho.ndim == 1:
-        val = np.abs(np.dot(sigma.conj(), rho)) ** 2.0
-    elif sigma.ndim == 1 and rho.ndim == 2:
-        val = np.abs(sigma.conj().T @ rho @ sigma)
-    elif sigma.ndim == 2 and rho.ndim == 1:
-        val = np.abs(rho.conj().T @ sigma @ rho)
-    elif sigma.ndim == 2 and rho.ndim == 2:
-        val = np.abs(np.trace(sqrtm(sigma) @ rho @ sqrtm(sigma)))
-    else:
-        raise ValueError("Invalid input dimensions")
-    return float(val)

--- a/mitiq/shadows/test/test_classical_postprocessing.py
+++ b/mitiq/shadows/test/test_classical_postprocessing.py
@@ -5,7 +5,6 @@
 
 """Tests for classical post-processing functions for classical shadows."""
 
-import cirq
 import numpy as np
 
 import mitiq
@@ -177,25 +176,21 @@ def test_shadow_state_reconstruction_cal():
 
 
 def test_expectation_estimation_shadow():
-    b_lists = ["0101", "0110"]
-    u_lists = ["ZZXX", "ZZXX"]
-
-    measurement_outcomes = (b_lists, u_lists)
-    observable = mitiq.PauliString("ZZ", support=(0, 1))
-    k = 1
+    measurement_outcomes = ["0101", "0110"], ["ZZXX", "ZZXX"]
+    pauli = mitiq.PauliString("ZZ")
+    batch_size = 1
     expected_result = -9
 
     result = expectation_estimation_shadow(
-        measurement_outcomes, observable, k, False
+        measurement_outcomes, pauli, batch_size
     )
-    assert isinstance(result, float), f"Expected a float, got {type(result)}"
     assert np.isclose(result, expected_result)
 
 
 def test_expectation_estimation_shadow_cal():
-    b_lists = ["0101", "0110"]
-    u_lists = ["YXZZ", "XXXX"]
-    f_est = {
+    bitstrings = ["0101", "0110"]
+    paulistrings = ["YXZZ", "XXXX"]
+    fidelities = {
         "0000": 1,
         "0001": 1 / 3,
         "0010": 1 / 3,
@@ -214,16 +209,14 @@ def test_expectation_estimation_shadow_cal():
         "1111": 1 / 81,
     }
 
-    measurement_outcomes = b_lists, u_lists
-    observable = mitiq.PauliString("YXZZ", support=(0, 1, 2, 3))
-    k = 1
+    measurement_outcomes = bitstrings, paulistrings
+    pauli = mitiq.PauliString("YXZZ")
+    batch_size = 1
     expected_result = 81 / 2
-    print("expected_result", expected_result)
 
     result = expectation_estimation_shadow(
-        measurement_outcomes, observable, k, f_est
+        measurement_outcomes, pauli, batch_size, fidelities
     )
-    assert isinstance(result, float), f"Expected a float, got {type(result)}"
     assert np.isclose(result, expected_result)
 
 
@@ -232,13 +225,12 @@ def test_expectation_estimation_shadow_no_indices():
     Test expectation estimation for a shadow with no matching indices.
     The result should be 0 as there are no matching
     """
-    q0, q1, q2 = cirq.LineQubit.range(3)
-    observable = mitiq.PauliString("XYZ", support=(0, 1, 2))
+    pauli = mitiq.PauliString("XYZ")
     measurement_outcomes = ["101", "010", "101"], ["ZXY", "YZX", "ZZY"]
-    k_shadows = 1
+    batch_size = 1
 
     result = expectation_estimation_shadow(
-        measurement_outcomes, observable, k_shadows, False
+        measurement_outcomes, pauli, batch_size
     )
 
-    assert result == 0.0
+    assert result == 0

--- a/mitiq/shadows/test/test_classical_postprocessing.py
+++ b/mitiq/shadows/test/test_classical_postprocessing.py
@@ -24,6 +24,67 @@ def test_get_single_shot_pauli_fidelity():
     u_list = "XY"
     expected_result = {"00": 1.0, "01": 0.0, "10": 0.0, "11": 0.0}
     assert get_single_shot_pauli_fidelity(b_list, u_list) == expected_result
+    b_list = "01101"
+    u_list = "XYZYZ"
+    print(get_single_shot_pauli_fidelity(b_list, u_list))
+    assert get_single_shot_pauli_fidelity(b_list, u_list) == {
+        "00000": 1.0,
+        "10000": 0.0,
+        "01000": 0.0,
+        "00100": -1.0,
+        "00010": 0.0,
+        "00001": -1.0,
+        "11000": 0.0,
+        "10100": 0.0,
+        "10010": 0.0,
+        "10001": 0.0,
+        "01100": 0.0,
+        "01010": 0.0,
+        "01001": 0.0,
+        "00110": 0.0,
+        "00101": 1.0,
+        "00011": 0.0,
+        "11100": 0.0,
+        "11010": 0.0,
+        "11001": 0.0,
+        "10110": 0.0,
+        "10101": 0.0,
+        "10011": 0.0,
+        "01110": 0.0,
+        "01101": 0.0,
+        "01011": 0.0,
+        "00111": 0.0,
+        "11110": 0.0,
+        "11101": 0.0,
+        "11011": 0.0,
+        "10111": 0.0,
+        "01111": 0.0,
+        "11111": 0.0,
+    }
+
+
+def test_get_single_shot_pauli_fidelity_with_locality():
+    b_list = "11101"
+    u_list = "XYZYZ"
+    print(get_single_shot_pauli_fidelity(b_list, u_list, locality=2))
+    assert get_single_shot_pauli_fidelity(b_list, u_list, locality=2) == {
+        "00000": 1.0,
+        "10000": 0.0,
+        "01000": 0.0,
+        "00100": -1.0,
+        "00010": 0.0,
+        "00001": -1.0,
+        "11000": 0.0,
+        "10100": 0.0,
+        "10010": 0.0,
+        "10001": 0.0,
+        "01100": 0.0,
+        "01010": 0.0,
+        "01001": 0.0,
+        "00110": 0.0,
+        "00101": 1.0,
+        "00011": 0.0,
+    }
 
 
 def test_get_pauli_fidelity():

--- a/mitiq/shadows/test/test_classical_postprocessing.py
+++ b/mitiq/shadows/test/test_classical_postprocessing.py
@@ -103,7 +103,6 @@ def test_get_pauli_fidelity():
 def test_classical_snapshot_cal():
     b_list_shadow = "01"
     u_list_shadow = "XY"
-    pauli_twirling_calibration = True
     f_est = {"00": 1, "01": 1 / 3, "10": 1 / 3, "11": 1 / 9}
     expected_result = operator_ptm_vector_rep(
         np.array(
@@ -116,9 +115,7 @@ def test_classical_snapshot_cal():
         )
     )
     np.testing.assert_array_almost_equal(
-        classical_snapshot(
-            b_list_shadow, u_list_shadow, pauli_twirling_calibration, f_est
-        ),
+        classical_snapshot(b_list_shadow, u_list_shadow, f_est),
         expected_result,
     )
 
@@ -261,7 +258,7 @@ def test_shadow_state_reconstruction_cal():
             ]
         )
     )
-    result = shadow_state_reconstruction(measurement_outcomes, True, f_est)
+    result = shadow_state_reconstruction(measurement_outcomes, f_est)
     num_qubits = len(measurement_outcomes[0])
     assert isinstance(result, np.ndarray)
     assert result.shape == (4**num_qubits,)
@@ -313,7 +310,7 @@ def test_expectation_estimation_shadow_cal():
     print("expected_result", expected_result)
 
     result = expectation_estimation_shadow(
-        measurement_outcomes, observable, k, True, f_est
+        measurement_outcomes, observable, k, f_est
     )
     assert isinstance(result, float), f"Expected a float, got {type(result)}"
     assert np.isclose(result, expected_result)

--- a/mitiq/shadows/test/test_classical_postprocessing.py
+++ b/mitiq/shadows/test/test_classical_postprocessing.py
@@ -93,18 +93,11 @@ def test_get_pauli_fidelity():
         ["XX", "YY", "ZZ", "XY"],
     )
     k_calibration = 2
-    expected_result = {
-        "00": (1 + 0j),
-        "10": (-0.25 + 0j),
-        "01": (0.25 + 0j),
-        "11": (-0.25 + 0j),
-    }
+    expected_result = {"00": 1, "10": -0.25, "01": 0.25, "11": -0.25}
     result = get_pauli_fidelities(
         calibration_measurement_outcomes, k_calibration
     )
-
-    for key in expected_result.keys():
-        assert np.isclose(result[key], expected_result[key])
+    assert result == expected_result
 
 
 def test_classical_snapshot_cal():

--- a/mitiq/shadows/test/test_classical_postprocessing.py
+++ b/mitiq/shadows/test/test_classical_postprocessing.py
@@ -125,144 +125,55 @@ def test_classical_snapshot():
     u_list = "XY"
     expected_result = np.array(
         [
-            [0.25 + 0.0j, 0.0 + 0.75j, 0.75 + 0.0j, 0.0 + 2.25j],
-            [0.0 - 0.75j, 0.25 + 0.0j, 0.0 - 2.25j, 0.75 + 0.0j],
-            [0.75 + 0.0j, 0.0 + 2.25j, 0.25 + 0.0j, 0.0 + 0.75j],
-            [0.0 - 2.25j, 0.75 + 0.0j, 0.0 - 0.75j, 0.25 + 0.0j],
+            [0.25, 0.75j, 0.75, 2.25j],
+            [-0.75j, 0.25, -2.25j, 0.75],
+            [0.75, 2.25j, 0.25, 0.75j],
+            [-2.25j, 0.75, -0.75j, 0.25],
         ]
     )
     result = classical_snapshot(b_list, u_list, False)
-    assert isinstance(result, np.ndarray)
-    assert result.shape == (
-        2 ** len(b_list),
-        2 ** len(b_list),
-    )
-    assert np.allclose(result, expected_result)
+    np.testing.assert_allclose(result, expected_result)
 
 
 def test_shadow_state_reconstruction():
-    b_lists = ["010", "001", "000"]
-    u_lists = ["XYZ", "ZYX", "YXZ"]
+    bitstrings = ["010", "001", "000"]
+    paulistrings = ["XYZ", "ZYX", "YXZ"]
+    measurement_outcomes = (bitstrings, paulistrings)
 
-    measurement_outcomes = (b_lists, u_lists)
-
-    expected_result = np.array(
+    expected_state = np.array(
         [
-            [
-                [
-                    0.5 + 0.0j,
-                    -0.5 + 0.0j,
-                    0.5 + 0.0j,
-                    0.0 + 1.5j,
-                    0.5 - 0.5j,
-                    0.0 + 0.0j,
-                    0.0 + 0.0j,
-                    0.0 + 0.0j,
-                ],
-                [
-                    -0.5 + 0.0j,
-                    0.0 + 0.0j,
-                    0.0 + 1.5j,
-                    -0.25 - 0.75j,
-                    0.0 + 0.0j,
-                    -0.25 + 0.25j,
-                    0.0 + 0.0j,
-                    0.0 + 0.0j,
-                ],
-                [
-                    0.5 + 0.0j,
-                    0.0 - 1.5j,
-                    0.5 + 0.0j,
-                    -0.5 + 0.0j,
-                    0.0 - 3.0j,
-                    0.0 + 0.0j,
-                    0.5 - 0.5j,
-                    0.0 + 0.0j,
-                ],
-                [
-                    0.0 - 1.5j,
-                    -0.25 + 0.75j,
-                    -0.5 + 0.0j,
-                    0.0 + 0.0j,
-                    0.0 + 0.0j,
-                    0.0 + 1.5j,
-                    0.0 + 0.0j,
-                    -0.25 + 0.25j,
-                ],
-                [
-                    0.5 + 0.5j,
-                    0.0 + 0.0j,
-                    0.0 + 3.0j,
-                    0.0 + 0.0j,
-                    0.25 + 0.0j,
-                    0.25 + 0.0j,
-                    0.5 + 0.75j,
-                    0.0 - 0.75j,
-                ],
-                [
-                    0.0 + 0.0j,
-                    -0.25 - 0.25j,
-                    0.0 + 0.0j,
-                    0.0 - 1.5j,
-                    0.25 + 0.0j,
-                    -0.25 + 0.0j,
-                    0.0 - 0.75j,
-                    -0.25 + 0.0j,
-                ],
-                [
-                    0.0 + 0.0j,
-                    0.0 + 0.0j,
-                    0.5 + 0.5j,
-                    0.0 + 0.0j,
-                    0.5 - 0.75j,
-                    0.0 + 0.75j,
-                    0.25 + 0.0j,
-                    0.25 + 0.0j,
-                ],
-                [
-                    0.0 + 0.0j,
-                    0.0 + 0.0j,
-                    0.0 + 0.0j,
-                    -0.25 - 0.25j,
-                    0.0 + 0.75j,
-                    -0.25 + 0.0j,
-                    0.25 + 0.0j,
-                    -0.25 + 0.0j,
-                ],
-            ]
+            [0.5, -0.5, 0.5, 1.5j, 0.5 - 0.5j, 0, 0, 0],
+            [-0.5, 0, 1.5j, -0.25 - 0.75j, 0, -0.25 + 0.25j, 0, 0],
+            [0.5, -1.5j, 0.5, -0.5, -3.0j, 0, 0.5 - 0.5j, 0],
+            [-1.5j, -0.25 + 0.75j, -0.5, 0, 0, 1.5j, 0, -0.25 + 0.25j],
+            [0.5 + 0.5j, 0, 3.0j, 0, 0.25, 0.25, 0.5 + 0.75j, -0.75j],
+            [0, -0.25 - 0.25j, 0, -1.5j, 0.25, -0.25, -0.75j, -0.25],
+            [0, 0, 0.5 + 0.5j, 0, 0.5 - 0.75j, 0.75j, 0.25, 0.25],
+            [0, 0, 0, -0.25 - 0.25j, 0.75j, -0.25, 0.25, -0.25],
         ]
     )
 
-    result = shadow_state_reconstruction(measurement_outcomes, False)
-    num_qubits = len(measurement_outcomes[0])
-    assert isinstance(result, np.ndarray)
-    assert result.shape == (
-        2**num_qubits,
-        2**num_qubits,
-    )
-    assert np.allclose(result, expected_result)
+    state = shadow_state_reconstruction(measurement_outcomes)
+    np.testing.assert_almost_equal(state, expected_state)
 
 
 def test_shadow_state_reconstruction_cal():
-    b_lists = ["01", "01"]
-    u_lists = ["XY", "XY"]
-    measurement_outcomes = (b_lists, u_lists)
-    f_est = {"00": 1, "01": 1 / 3, "10": 1 / 3, "11": 1 / 9}
-    expected_result_vec = operator_ptm_vector_rep(
+    bitstrings, paulistrings = ["01", "01"], ["XY", "XY"]
+    measurement_outcomes = (bitstrings, paulistrings)
+    fidelities = {"00": 1, "01": 1 / 3, "10": 1 / 3, "11": 1 / 9}
+
+    expected_state_vec = operator_ptm_vector_rep(
         np.array(
             [
-                [0.25 + 0.0j, 0.0 + 0.75j, 0.75 + 0.0j, 0.0 + 2.25j],
-                [0.0 - 0.75j, 0.25 + 0.0j, 0.0 - 2.25j, 0.75 + 0.0j],
-                [0.75 + 0.0j, 0.0 + 2.25j, 0.25 + 0.0j, 0.0 + 0.75j],
-                [0.0 - 2.25j, 0.75 + 0.0j, 0.0 - 0.75j, 0.25 + 0.0j],
+                [0.25, 0.75j, 0.75, 2.25j],
+                [-0.75j, 0.25, -2.25j, 0.75],
+                [0.75, 2.25j, 0.25, 0.75j],
+                [-2.25j, 0.75, -0.75j, 0.25],
             ]
         )
     )
-    result = shadow_state_reconstruction(measurement_outcomes, f_est)
-    num_qubits = len(measurement_outcomes[0])
-    assert isinstance(result, np.ndarray)
-    assert result.shape == (4**num_qubits,)
-    assert np.allclose(result, expected_result_vec)
+    state = shadow_state_reconstruction(measurement_outcomes, fidelities)
+    np.testing.assert_almost_equal(state, expected_state_vec)
 
 
 def test_expectation_estimation_shadow():

--- a/mitiq/shadows/test/test_classical_postprocessing.py
+++ b/mitiq/shadows/test/test_classical_postprocessing.py
@@ -25,7 +25,6 @@ def test_get_single_shot_pauli_fidelity():
     assert get_single_shot_pauli_fidelity(b_list, u_list) == expected_result
     b_list = "01101"
     u_list = "XYZYZ"
-    print(get_single_shot_pauli_fidelity(b_list, u_list))
     assert get_single_shot_pauli_fidelity(b_list, u_list) == {
         "00000": 1.0,
         "10000": 0.0,
@@ -65,7 +64,6 @@ def test_get_single_shot_pauli_fidelity():
 def test_get_single_shot_pauli_fidelity_with_locality():
     b_list = "11101"
     u_list = "XYZYZ"
-    print(get_single_shot_pauli_fidelity(b_list, u_list, locality=2))
     assert get_single_shot_pauli_fidelity(b_list, u_list, locality=2) == {
         "00000": 1.0,
         "10000": 0.0,

--- a/mitiq/shadows/test/test_shadows.py
+++ b/mitiq/shadows/test/test_shadows.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Test classical shadow estimation process."""
+from numbers import Number
 
 import cirq
 
@@ -38,7 +39,6 @@ def executor(
 
 
 def test_pauli_twirling_calibrate():
-
     # Call the function with valid inputs
     result = pauli_twirling_calibrate(
         qubits=qubits, executor=executor, num_total_measurements_calibration=2
@@ -47,9 +47,8 @@ def test_pauli_twirling_calibrate():
     # Check that the dictionary contains the correct number of entries
     assert len(result) <= 2**num_qubits
 
-    # Check that all values in the dictionary are floats
     for value in result.values():
-        assert isinstance(value, complex)
+        assert isinstance(value, Number)
 
     # Call shadow_quantum_processing to get shadow_outcomes
     shadow_outcomes = (["11", "00"], ["ZZ", "XX"])
@@ -63,13 +62,11 @@ def test_pauli_twirling_calibrate():
     # Check that the dictionary contains the correct number of entries
     assert len(result) <= 2**num_qubits
 
-    # Check that all values in the dictionary are floats
     for value in result.values():
-        assert isinstance(value, complex)
+        assert isinstance(value, Number)
 
 
 def test_shadow_quantum_processing():
-
     # Call the function with valid inputs
     result = shadow_quantum_processing(
         circuit, executor, num_total_measurements_shadow=10
@@ -112,7 +109,6 @@ def test_classical_post_processing():
     )
     result_cal = classical_post_processing(
         shadow_outcomes,
-        use_calibration=True,
         calibration_results=calibration_results,
         observables=observables,
         k_shadows=1,

--- a/mitiq/shadows/test/test_shadows_utils.py
+++ b/mitiq/shadows/test/test_shadows_utils.py
@@ -5,12 +5,9 @@
 
 """Defines utility functions for classical shadows protocol."""
 
-import numpy as np
-
 import mitiq
 from mitiq.shadows.shadows_utils import (
     create_string,
-    fidelity,
     n_measurements_opts_expectation_bound,
     n_measurements_tomography_bound,
 )
@@ -43,11 +40,3 @@ def test_n_measurements_opts_expectation_bound():
     N, K = n_measurements_opts_expectation_bound(0.5, observables, 0.1)
     assert isinstance(N, int), f"Expected int, got {type(N)}"
     assert isinstance(K, int), f"Expected int, got {type(K)}"
-
-
-def test_fidelity():
-    state_vector = np.array([0.5, 0.5, 0.5, 0.5])
-    rho = np.eye(4) / 4
-    assert np.isclose(
-        fidelity(state_vector, rho), 0.25
-    ), f"Expected 0.25, got {fidelity(state_vector, rho)}"

--- a/mitiq/shadows/test/test_shadows_utils.py
+++ b/mitiq/shadows/test/test_shadows_utils.py
@@ -9,32 +9,11 @@ import numpy as np
 
 import mitiq
 from mitiq.shadows.shadows_utils import (
-    bitstring_to_eigenvalues,
     create_string,
-    eigenvalues_to_bitstring,
     fidelity,
     n_measurements_opts_expectation_bound,
     n_measurements_tomography_bound,
 )
-
-# Tests start here
-
-
-def test_eigenvalues_to_bitstring():
-    values = [-1, 1, 1]
-    assert eigenvalues_to_bitstring(values) == "100"
-    assert bitstring_to_eigenvalues(eigenvalues_to_bitstring(values)) == values
-
-
-def test_bitstring_to_eigenvalues():
-    bitstring = "100"
-    np.testing.assert_array_equal(
-        bitstring_to_eigenvalues(bitstring), np.array([-1, 1, 1])
-    )
-    assert (
-        eigenvalues_to_bitstring(bitstring_to_eigenvalues(bitstring))
-        == bitstring
-    )
 
 
 def test_create_string():

--- a/mitiq/shadows/test/test_shadows_utils.py
+++ b/mitiq/shadows/test/test_shadows_utils.py
@@ -3,13 +3,18 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Defines utility functions for classical shadows protocol."""
+import math
+
+import numpy as np
 
 import mitiq
 from mitiq.shadows.shadows_utils import (
+    batch_calibration_data,
     create_string,
+    fidelity,
     n_measurements_opts_expectation_bound,
     n_measurements_tomography_bound,
+    valid_bitstrings,
 )
 
 
@@ -19,16 +24,33 @@ def test_create_string():
     assert create_string(str_len, loc_list) == "01010"
 
 
+def test_valid_bitstrings():
+    num_qubits = 5
+    bitstrings_on_5_qubits = valid_bitstrings(num_qubits)
+    assert len(bitstrings_on_5_qubits) == 2**num_qubits
+    assert all(b == "0" or b == "1" for b in bitstrings_on_5_qubits.pop())
+
+    num_qubits = 4
+    max_hamming_weight = 2
+    bitstrings_on_3_qubits_hamming_2 = valid_bitstrings(
+        num_qubits, max_hamming_weight
+    )
+    assert len(bitstrings_on_3_qubits_hamming_2) == sum(
+        math.comb(num_qubits, i) for i in range(max_hamming_weight + 1)
+    )  # sum_{i == 0}^{max_hamming_weight} (num_qubits choose i)
+
+
+def test_batch_calibration_data():
+    data = (["010", "110", "000", "001"], ["XXY", "ZYY", "ZZZ", "XYZ"])
+    num_batches = 2
+    for bits, paulis in batch_calibration_data(data, num_batches):
+        assert len(bits) == len(paulis) == num_batches
+
+
 def test_n_measurements_tomography_bound():
-    assert (
-        n_measurements_tomography_bound(0.5, 2) == 2176
-    ), f"Expected 2176, got {n_measurements_tomography_bound(0.5, 2)}"
-    assert (
-        n_measurements_tomography_bound(1.0, 1) == 136
-    ), f"Expected 136, got {n_measurements_tomography_bound(1.0, 1)}"
-    assert (
-        n_measurements_tomography_bound(0.1, 3) == 217599
-    ), f"Expected 217599, got {n_measurements_tomography_bound(0.1, 3)}"
+    assert n_measurements_tomography_bound(0.5, 2) == 2176
+    assert n_measurements_tomography_bound(1.0, 1) == 136
+    assert n_measurements_tomography_bound(0.1, 3) == 217599
 
 
 def test_n_measurements_opts_expectation_bound():
@@ -38,5 +60,13 @@ def test_n_measurements_opts_expectation_bound():
         mitiq.PauliString("Z"),
     ]
     N, K = n_measurements_opts_expectation_bound(0.5, observables, 0.1)
-    assert isinstance(N, int), f"Expected int, got {type(N)}"
-    assert isinstance(K, int), f"Expected int, got {type(K)}"
+    assert isinstance(N, int)
+    assert isinstance(K, int)
+
+
+def test_fidelity():
+    state_vector = np.array([0.5, 0.5, 0.5, 0.5])
+    rho = np.eye(4) / 4
+    assert np.isclose(
+        fidelity(state_vector, rho), 0.25
+    ), f"Expected 0.25, got {fidelity(state_vector, rho)}"


### PR DESCRIPTION
## Description

PR to refactor [`mitiq/shadows/classical_postprocessing.py`](https://github.com/unitaryfund/mitiq/blob/e14a799a90665d12ea004e6342de0c39961a35dc/mitiq/shadows/classical_postprocessing.py).

Addresses some issues raised in #2129 

### Docs

Despite there being tests for the shadows module, as we saw in https://github.com/unitaryfund/mitiq/pull/2113/ the tests do not cover everything and a change can pass tests despite making drastic changes to the results in a tutorial.


| shadow tutorial before | after |
| ---------------------- | ----- |
| ![Screenshot 2024-01-10 at 4 21 03 PM](https://github.com/unitaryfund/mitiq/assets/12703123/9498ec14-3a38-4f6b-8486-b84bfeef809a) | ![Screenshot 2024-01-10 at 4 19 44 PM](https://github.com/unitaryfund/mitiq/assets/12703123/481e15b4-cb0c-49ee-83db-5655255e61bd) | 

Note there is a _slight_ difference in the above plot. I'm not totally sure why.

| rshadow tutorial before | after |
| ----------------------- | ----- |
| ![Screenshot 2024-01-10 at 5 42 45 PM](https://github.com/unitaryfund/mitiq/assets/12703123/260e7a00-80a3-41e3-adb4-40954ad049b5) | ![Screenshot 2024-01-10 at 4 31 58 PM](https://github.com/unitaryfund/mitiq/assets/12703123/555c34f6-df0b-46ae-91e7-36c58e67b20c) |

All the other plots that I checked look either identical, or very close.