### PR TITLE
Add clarification for virtualenv files vs mitiq directory

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,3 +57,4 @@ Yash Prabhat
 Vladimir Kozhukalov
 Francesc Sabater
 Emiliano Godinez
+Sam Burdick

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ The rest of this document describes the technical details of getting set up to d
 
 1. Ensure you have python 3.9 or greater installed. If not, you can find the downloads [here](https://www.python.org/downloads/).
 2. Set up a virtual environment to isolate dependencies. This can be done with many different tools including [Virtualenv](https://virtualenv.pypa.io/en/latest/), [Pipenv](https://pypi.org/project/pipenv/), [Poetry](https://python-poetry.org/), and [Anaconda](https://www.anaconda.com/products/distribution). In what follows we will use Anaconda, but if you're familiar with other tools feel free to use those.
-3. Set up a local version of the [Mitiq repository](https://github.com/unitaryfund/mitiq). To do this you will need to use `git` which is a version control system. If you're unfamiliar, check out the [docs](https://git-scm.com/), and learn about what the typical [`git` workflow](https://www.asmeurer.com/git-workflow/) looks like.
+3. Set up a local version of the [Mitiq repository](https://github.com/unitaryfund/mitiq). To do this you will need to use `git` which is a version control system. If you're unfamiliar, check out the [docs](https://git-scm.com/), and learn about what the typical [`git` workflow](https://www.asmeurer.com/git-workflow/) looks like. **Make sure your local directory of mitiq is located in a different directory containing the files that make up your virtual environment.**
 4. Inside the Mitiq repository (`cd mitiq`), activate a virtual environment. With conda this is done using the following command.
 ```
 conda create --name myenv python=3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ The rest of this document describes the technical details of getting set up to d
 
 1. Ensure you have python 3.9 or greater installed. If not, you can find the downloads [here](https://www.python.org/downloads/).
 2. Set up a virtual environment to isolate dependencies. This can be done with many different tools including [Virtualenv](https://virtualenv.pypa.io/en/latest/), [Pipenv](https://pypi.org/project/pipenv/), [Poetry](https://python-poetry.org/), and [Anaconda](https://www.anaconda.com/products/distribution). In what follows we will use Anaconda, but if you're familiar with other tools feel free to use those.
-3. Set up a local version of the [Mitiq repository](https://github.com/unitaryfund/mitiq). To do this you will need to use `git` which is a version control system. If you're unfamiliar, check out the [docs](https://git-scm.com/), and learn about what the typical [`git` workflow](https://www.asmeurer.com/git-workflow/) looks like. **Make sure your local directory of mitiq is located in a different directory containing the files that make up your virtual environment.**
+3. Set up a local version of the [Mitiq repository](https://github.com/unitaryfund/mitiq). To do this you will need to use `git` which is a version control system. If you're unfamiliar, check out the [docs](https://git-scm.com/), and learn about what the typical [`git` workflow](https://www.asmeurer.com/git-workflow/) looks like. Make sure your local directory of mitiq is located in a different directory containing the files that make up your virtual environment.
 4. Inside the Mitiq repository (`cd mitiq`), activate a virtual environment. With conda this is done using the following command.
 ```
 conda create --name myenv python=3


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.

  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.

  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->

Adding a line of clarification to allow make checks to perform inside a virtual environment, specifically that virtualenv files and mitiq must be in different directories. Since the documentation should be beginner friendly, this change is warranted.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file