### PR TITLE
remove redundant imports from top level `__init__.py`

### DIFF
--- a/mitiq/__init__.py
+++ b/mitiq/__init__.py
@@ -18,15 +18,9 @@ from mitiq.typing import (
 from mitiq.executor import Executor
 from mitiq.observable import PauliString, Observable
 
-# Interface between Cirq circuits and supported frontends.
-from mitiq import interface
-
 # About and version.
 from mitiq._about import about
 from mitiq._version import __version__
-
-# Error mitigation modules.
-from mitiq import cdr, pec, rem, zne, ddd
 
 # Calibration
 from mitiq.calibration import (
@@ -35,6 +29,3 @@ from mitiq.calibration import (
     ZNE_SETTINGS,
     Settings,
 )
-
-# Parallel interface for no error mitigation (for examples/benchmarking).
-from mitiq import raw


### PR DESCRIPTION
## Description

fixes https://github.com/unitaryfund/mitiq/issues/2202 by removing the lines all together as they are redundant to the `__init__.py` files that live in each of those respective directories.