### PR TITLE
Added warning filter to ignore warning

### DIFF
--- a/mitiq/rem/tests/test_inverse_confusion_matrix.py
+++ b/mitiq/rem/tests/test_inverse_confusion_matrix.py
@@ -183,6 +183,7 @@ def test_closest_positive_distribution():
             atol=1e-5,
         )
 
+
 @pytest.mark.filterwarnings("ignore:invalid value encountered in divide")
 def test_closest_positive_distribution_error():
     """Test unfeasible problem to trigger error."""

--- a/mitiq/rem/tests/test_inverse_confusion_matrix.py
+++ b/mitiq/rem/tests/test_inverse_confusion_matrix.py
@@ -183,7 +183,7 @@ def test_closest_positive_distribution():
             atol=1e-5,
         )
 
-
+@pytest.mark.filterwarnings("ignore:invalid value encountered in divide")
 def test_closest_positive_distribution_error():
     """Test unfeasible problem to trigger error."""
     with pytest.raises(ValueError, match="REM failed to determine"):


### PR DESCRIPTION
Fixes #2103 

## Description
When running test_closest_positive_distribution_error() from test_inverse_confusion_matrix.py the following warning is given:

```
mitiq/rem/tests/test_inverse_confusion_matrix.py::test_closest_positive_distribution_error
  /home/runner/work/mitiq/mitiq/mitiq/rem/inverse_confusion_matrix.py:145: RuntimeWarning: invalid value encountered in divide
    init_guess /= np.sum(init_guess)
```

Since this is expected to raise an error with an invalid input, the warning is not necessary and should be disabled.

## Steps to Duplicate
To duplicate this behavior locally, run `make test` then search the output for the warning. 

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

