### PR TITLE
Update Qibo demo snippet on v0.34 changelog 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ Qibo is an "end-to-end open source platform for quantum simulation, self-hosted 
 
 ```py
 from qibo import Circuit
-from mitiq.conversions import convert_to_mitiq
 
 circuit = Circuit(2)
 circuit.add(gates.H(0))
@@ -20,7 +19,7 @@ def executor(circuit):
     return circuit.execute()
 
 
-mitigated = mitiq.zne.execute_with_zne(convert_to_mitiq(circuit), executor)
+mitigated = mitiq.zne.execute_with_zne(circuit, executor)
 ```
 
 Thank you to new contributor Francesc Sabater for excellent work integrating Qibo and Mitiq!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Announcing support for [Qibo](https://qibo.science/), a newly integrated fronten
 Qibo is an "end-to-end open source platform for quantum simulation, self-hosted quantum hardware control, calibration and characterization".
 
 ```py
-from qibo import Circuit
+from qibo import Circuit, gates
+import mitiq
 
 circuit = Circuit(2)
 circuit.add(gates.H(0))


### PR DESCRIPTION


## Description

Now that Qibo is integrated with Mitiq, we don't need to use `convert_to_mitiq` for Qibo circuits.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file