### PR TITLE
Pin Qibo version

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,7 +6,7 @@ pyquil~=3.5.4
 pennylane-qiskit~=0.34.1
 pennylane~=0.34.0
 amazon-braket-sdk~=1.69.0
-qibo~=0.2.4
+qibo==0.2.4 # TODO: unpin this
 
 # Unit tests, coverage, and formatting/style.
 pytest==8.0.0


### PR DESCRIPTION
## Description

Pin the version of Qibo to 0.2.4. Currently, [master](https://github.com/unitaryfund/mitiq/commit/6a30f16edd18d768ac5cbd2ba571ef3e3284f58c) is failing all of CI due to a conversion issue. This is the failing test (specifically, it is failing on Qibo):
https://github.com/unitaryfund/mitiq/blob/6a30f16edd18d768ac5cbd2ba571ef3e3284f58c/mitiq/calibration/tests/test_calibration.py#L177-L193

and the error is
```
FAILED mitiq/calibration/tests/test_calibration.py::test_ZNE_workflow_multi_platform[qibo] - mitiq.interface.conversions.CircuitConversionError: Circuit could not be converted to an internal Mitiq circuit. This may be because the circuit contains custom gates or Pragmas (pyQuil). If you think this is a bug or that this circuit should be supported, you can open an issue at https://github.com/unitaryfund/mitiq. 
```

The only circuits it is running at mirror circuits on 1 and 2 qubits [[source](https://github.com/unitaryfund/mitiq/blob/6a30f16edd18d768ac5cbd2ba571ef3e3284f58c/mitiq/calibration/tests/test_calibration.py#L32-L52)], which I thought would mean that there is a bug converting those circuits, but `mitiq/calibration/tests/test_calibration.py::test_PEC_workflow_multi_platform[qibo]` is running just fine and it tests on mirror circuits as well.

Further investigation will be needed to unpin this Qibo version, but as a temporary measure I suggest we pin it to get CI passing.