### PR TITLE
replace `black`, `flake8`, and `isort` with `ruff`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 79
-ignore = E203, W503
-exclude = __init__.py

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,11 +26,7 @@ updates:
       # Ignore minor and patch releases in other dev requirements.
       - dependency-name: "*pytest*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-      - dependency-name: "flake8"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-      - dependency-name: "black"
-        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
-      - dependency-name: "isort"
+      - dependency-name: "ruff"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "mypy"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,10 +6,8 @@
 <!--
 If the validation checks fail
   1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
-
-  2. Run `make check-style` and fix any flake8 (http://flake8.pycqa.org) errors.
-
-  3. Run `make format` to format your code with the black (https://black.readthedocs.io/en/stable/index.html) autoformatter.
+  2. Run `make check-format` and fix any ruff linting errors.
+  3. Run `make format` to format your code.
 
 For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
 -->
@@ -25,6 +23,7 @@ For more information, check the Mitiq style guidelines (https://mitiq.readthedoc
 - [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
 
 Before opening the PR, please ensure you have completed the following where appropriate.
+
 - [ ] I added unit tests for new code.
 - [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
 - [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,8 +6,7 @@
 <!--
 If the validation checks fail
   1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
-  2. Run `make check-format` and fix any ruff linting errors.
-  3. Run `make format` to format your code.
+  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.
 
 For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
 -->

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,7 @@ jobs:
       - name: Check types with mypy
         run: make check-types
 
-      - name: Lint with flake8
-        run: make check-style
-
-      - name: Check code style with Black
+      - name: Check code style/formatting
         run: make check-format
 
   docs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,21 +77,18 @@ Mitiq code is developed according the best practices of Python development.
 - Use annotations for type hints in the objects' signature.
 - Write [google-style docstrings](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods).
 
-We use [Black](https://black.readthedocs.io/en/stable/index.html) and `flake8` to automatically lint the code and enforce style requirements as part of the CI pipeline.
+We use [Ruff](https://docs.astral.sh/ruff/) to automatically lint the code and enforce style requirements as part of the CI pipeline.
 You can run these style tests yourself locally in the top-level directory of the repository.
 
-You can check for violations of the `flake8` rules with
-```bash
-make check-style
-```
-In order to check if `black` would reformat the code, use
+You can check for linting/formatting violations with
 ```bash
 make check-format
 ```
-If above format check fails then you will be presented with a [diff](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#diff) which can be resolved by running
+Many common issues can be fixed automatically using the following command, but some will require manual intervention to appease Ruff.
 ```bash
 make format
 ```
+
 We also use [Mypy](https://mypy.readthedocs.io/en/stable/) as a type checker to find incompatible types compared to the type
 hints in your code. To test this locally, run the type check test in the top-level directory of the repository.
 

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,17 @@ all: dist
 build: check-all docs test-all
 
 .PHONY: check-all
-check-all: check-format check-style check-types
+check-all: check-format check-types
 
 .PHONY: check-format
 check-format:
-	isort --check mitiq
-	black --check --diff mitiq
+	ruff check
+	ruff format --check
 
-.PHONY: check-style
-check-style:
-	flake8
+.PHONY: format
+format:
+	ruff check --fix
+	ruff format
 
 .PHONY: check-types
 check-types:
@@ -42,11 +43,6 @@ docs-clean:
 .PHONY: linkcheck
 linkcheck:
 	make -C docs linkcheck
-
-.PHONY: format
-format:
-	isort mitiq
-	black mitiq
 
 .PHONY: install
 install:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -12,10 +12,8 @@ qibo==0.2.4 # TODO: unpin this
 pytest==8.0.0
 pytest-xdist[psutil]==3.0.2
 pytest-cov==4.0.0
-flake8==7.0.0
-black==22.10
+ruff==0.3.1
 mypy==1.0.0
-isort==5.13.2
 types-tabulate
 
 # Documentation and examples.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,6 @@ import pybtex.style.formatting.unsrt
 import pybtex.style.template
 from pybtex.plugin import register_plugin as pybtex_register_plugin
 
-
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath(".."))
 sys.path.insert(0, os.path.abspath("../../"))

--- a/mitiq/_about.py
+++ b/mitiq/_about.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Information about Mitiq and dependencies."""
+
 import platform
 
 from cirq import __version__ as cirq_version

--- a/mitiq/_version.py
+++ b/mitiq/_version.py
@@ -5,6 +5,7 @@
 
 """Reads in version information.
 Note: This file will be overwritten by the packaging process."""
+
 import os
 
 directory_of_this_file = os.path.dirname(os.path.abspath(__file__))

--- a/mitiq/benchmarks/ghz_circuits.py
+++ b/mitiq/benchmarks/ghz_circuits.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Functions for creating GHZ circuits for benchmarking purposes."""
+
 from typing import Optional
 
 import cirq

--- a/mitiq/benchmarks/mirror_circuits.py
+++ b/mitiq/benchmarks/mirror_circuits.py
@@ -6,6 +6,7 @@
 """Functions for creating mirror circuits as defined in
 :cite:`Proctor_2021_NatPhys` for benchmarking quantum computers
 (with error mitigation)."""
+
 from typing import List, Optional, Tuple
 
 import cirq

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -10,6 +10,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Functions for generating randomized benchmarking circuits."""
+
 from typing import List, Optional
 
 import cirq

--- a/mitiq/benchmarks/rotated_randomized_benchmarking.py
+++ b/mitiq/benchmarks/rotated_randomized_benchmarking.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Functions for generating rotated randomized benchmarking circuits."""
+
 from typing import List, Optional, cast
 
 import cirq

--- a/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
+++ b/mitiq/benchmarks/tests/test_mirror_qv_circuits.py
@@ -5,7 +5,6 @@
 
 """Tests for mirror quantum volume circuits."""
 
-
 import cirq
 import pytest
 

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests for the Clifford data regression top-level API."""
+
 import re
 from functools import partial
 from unittest.mock import MagicMock, call

--- a/mitiq/cdr/cdr.py
+++ b/mitiq/cdr/cdr.py
@@ -328,7 +328,7 @@ def cdr_decorator(
     """
 
     def decorator(
-        executor: Callable[[QPROGRAM], QuantumResult]
+        executor: Callable[[QPROGRAM], QuantumResult],
     ) -> Callable[[QPROGRAM], float]:
         return mitigate_executor(
             executor,

--- a/mitiq/cdr/clifford_training_data.py
+++ b/mitiq/cdr/clifford_training_data.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Functions for mapping circuits to (near) Clifford circuits."""
+
 from typing import Any, List, Optional, Sequence, Union, cast
 
 import cirq

--- a/mitiq/cdr/clifford_utils.py
+++ b/mitiq/cdr/clifford_utils.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Functions for mapping circuits to (near) Clifford circuits."""
+
 from typing import List
 
 import cirq

--- a/mitiq/cdr/data_regression.py
+++ b/mitiq/cdr/data_regression.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """The data regression portion of Clifford data regression."""
+
 from typing import Sequence
 
 import numpy as np

--- a/mitiq/cdr/tests/test_cdr.py
+++ b/mitiq/cdr/tests/test_cdr.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests for the Clifford data regression top-level API."""
+
 from typing import List
 
 import cirq

--- a/mitiq/cdr/tests/test_clifford_training_data.py
+++ b/mitiq/cdr/tests/test_clifford_training_data.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests for generating (near) Clifford circuits."""
+
 import cirq
 import numpy as np
 import pytest

--- a/mitiq/cdr/tests/test_clifford_utils.py
+++ b/mitiq/cdr/tests/test_clifford_utils.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests for generating (near) Clifford circuits."""
+
 import cirq
 import numpy as np
 import pytest

--- a/mitiq/cdr/tests/test_data_regression.py
+++ b/mitiq/cdr/tests/test_data_regression.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests for the data regression portion of Clifford data regression."""
+
 import numpy as np
 import pytest
 

--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -197,7 +197,7 @@ def ddd_decorator(
     """
 
     def decorator(
-        executor: Callable[[QPROGRAM], QuantumResult]
+        executor: Callable[[QPROGRAM], QuantumResult],
     ) -> Callable[[QPROGRAM], Union[float, Tuple[float, Dict[str, Any]]]]:
         return mitigate_executor(
             executor,

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tools to determine slack windows in circuits and to insert DDD sequences."""
+
 from typing import Callable
 
 import numpy as np

--- a/mitiq/ddd/rules/rules.py
+++ b/mitiq/ddd/rules/rules.py
@@ -6,6 +6,7 @@
 """Built-in rules determining what DDD sequence should be applied in a given
 slack window.
 """
+
 from itertools import cycle
 from typing import List
 

--- a/mitiq/ddd/rules/tests/test_rules.py
+++ b/mitiq/ddd/rules/tests/test_rules.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for DDD rules."""
+
 import pytest
 from cirq import CNOT, Circuit, I, LineQubit, X, Y, Z, bit_flip
 

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -302,7 +302,7 @@ class Executor:
 
     @staticmethod
     def is_batched_executor(
-        executor: Callable[[Union[QPROGRAM, Sequence[QPROGRAM]]], Any]
+        executor: Callable[[Union[QPROGRAM, Sequence[QPROGRAM]]], Any],
     ) -> bool:
         """Returns True if the input function is recognized as a "batched
         executor", else False.

--- a/mitiq/executor/tests/test_executor.py
+++ b/mitiq/executor/tests/test_executor.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for Collector."""
+
 from random import choices
 from typing import List
 

--- a/mitiq/interface/conversions.py
+++ b/mitiq/interface/conversions.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Functions for converting to/from Mitiq's internal circuit representation."""
+
 from functools import wraps
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple, cast
 
@@ -199,7 +200,7 @@ def convert_from_mitiq(
 
 
 def accept_any_qprogram_as_input(
-    accept_cirq_circuit_function: Callable[[cirq.Circuit], Any]
+    accept_cirq_circuit_function: Callable[[cirq.Circuit], Any],
 ) -> Callable[[QPROGRAM], Any]:
     @wraps(accept_cirq_circuit_function)
     def accept_any_qprogram_function(
@@ -212,7 +213,7 @@ def accept_any_qprogram_as_input(
 
 
 def atomic_converter(
-    cirq_circuit_modifier: Callable[..., Any]
+    cirq_circuit_modifier: Callable[..., Any],
 ) -> Callable[..., Any]:
     """Decorator which allows for a function which inputs and returns a Cirq
     circuit to input and return any QPROGRAM.
@@ -244,7 +245,7 @@ def atomic_converter(
 
 
 def atomic_one_to_many_converter(
-    cirq_circuit_modifier: Callable[..., Iterable[cirq.Circuit]]
+    cirq_circuit_modifier: Callable[..., Iterable[cirq.Circuit]],
 ) -> Callable[..., Iterable[QPROGRAM]]:
     @wraps(cirq_circuit_modifier)
     def qprogram_modifier(

--- a/mitiq/interface/mitiq_braket/conversions.py
+++ b/mitiq/interface/mitiq_braket/conversions.py
@@ -11,9 +11,8 @@ import numpy.typing as npt
 from braket.circuits import Circuit as BKCircuit
 from braket.circuits import Instruction
 from braket.circuits import gates as braket_gates
-from cirq import Circuit, LineQubit
+from cirq import Circuit, LineQubit, protocols
 from cirq import ops as cirq_ops
-from cirq import protocols
 from cirq.linalg.decompositions import (
     deconstruct_single_qubit_matrix_into_angles,
     kak_decomposition,

--- a/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
+++ b/mitiq/interface/mitiq_cirq/tests/test_cirq_utils.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
-""" Tests for Cirq executors defined in cirq_utils.py"""
+"""Tests for Cirq executors defined in cirq_utils.py"""
 
 import cirq
 import numpy as np

--- a/mitiq/interface/mitiq_pyquil/conversions.py
+++ b/mitiq/interface/mitiq_pyquil/conversions.py
@@ -6,6 +6,7 @@
 """Functions to convert between Mitiq's internal circuit representation and
 pyQuil's circuit representation (Quil programs).
 """
+
 from cirq import Circuit, LineQubit
 from cirq_rigetti import circuit_from_quil
 from cirq_rigetti.quil_output import QuilOutput

--- a/mitiq/interface/mitiq_pyquil/tests/test_conversions_pyquil.py
+++ b/mitiq/interface/mitiq_pyquil/tests/test_conversions_pyquil.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests conversions to/from pyQuil circuits."""
+
 import numpy as np
 from pyquil import Program
 from pyquil.gates import CNOT, CZ, RZ, H, X, Y, Z

--- a/mitiq/interface/mitiq_pyquil/tests/test_zne_mitiq_pyquil.py
+++ b/mitiq/interface/mitiq_pyquil/tests/test_zne_mitiq_pyquil.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests for zne.py with PyQuil backend."""
+
 import numpy as np
 import pyquil
 

--- a/mitiq/interface/mitiq_qibo/conversions.py
+++ b/mitiq/interface/mitiq_qibo/conversions.py
@@ -6,6 +6,7 @@
 """Functions to convert between Mitiq's internal circuit representation and
 Qibo's circuit representation.
 """
+
 from typing import List
 
 from cirq import Circuit

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -6,6 +6,7 @@
 """Functions to convert between Mitiq's internal circuit representation and
 Qiskit's circuit representation.
 """
+
 import copy
 import re
 from typing import Any, List, Optional, Set, Tuple

--- a/mitiq/interface/mitiq_qiskit/qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/qiskit_utils.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Qiskit utility functions."""
+
 from functools import partial
 from typing import Optional, Tuple
 

--- a/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for conversions between Mitiq circuits and Qiskit circuits."""
+
 import copy
 
 import cirq

--- a/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_qiskit_utils.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for qiskit executors (qiskit_utils.py)."""
+
 import numpy as np
 import pytest
 from qiskit import QuantumCircuit

--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -5,9 +5,8 @@
 
 from collections import Counter
 from numbers import Number
-from typing import Any
+from typing import Any, Dict, List, Optional, Sequence, Set, Union, cast
 from typing import Counter as TCounter
-from typing import Dict, List, Optional, Sequence, Set, Union, cast
 
 import cirq
 import numpy as np

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -290,7 +290,7 @@ def pec_decorator(
     """
 
     def decorator(
-        executor: Callable[[QPROGRAM], QuantumResult]
+        executor: Callable[[QPROGRAM], QuantumResult],
     ) -> Callable[[QPROGRAM], Union[float, Tuple[float, Dict[str, Any]]]]:
         return mitigate_executor(
             executor,

--- a/mitiq/pec/representations/biased_noise.py
+++ b/mitiq/pec/representations/biased_noise.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 """Function to generate representations with biased noise."""
+
 import copy
 from typing import List
 
@@ -84,20 +85,10 @@ def represent_operation_with_local_biased_noise(
     b = epsilon * (3 * eta + 1) / (3 * (eta + 1))
     c = epsilon / (3 * (eta + 1))
     alpha = (a**2 + a * b - 2 * c**2) / (
-        a**3
-        + a**2 * b
-        - a * b**2
-        - 4 * a * c**2
-        - b**3
-        + 4 * b * c**2
+        a**3 + a**2 * b - a * b**2 - 4 * a * c**2 - b**3 + 4 * b * c**2
     )
     beta = (-a * b - b**2 + 2 * c**2) / (
-        a**3
-        + a**2 * b
-        - a * b**2
-        - 4 * a * c**2
-        - b**3
-        + 4 * b * c**2
+        a**3 + a**2 * b - a * b**2 - 4 * a * c**2 - b**3 + 4 * b * c**2
     )
     gamma = -c / (a**2 + 2 * a * b + b**2 - 4 * c**2)
     if len(qubits) == 1:

--- a/mitiq/pec/representations/learning.py
+++ b/mitiq/pec/representations/learning.py
@@ -348,7 +348,7 @@ def biased_noise_loss_function(
 
 
 def _parse_learning_kwargs(
-    learning_kwargs: Dict[str, Any]
+    learning_kwargs: Dict[str, Any],
 ) -> Tuple[npt.NDArray[np.float64], str, Dict[str, Any]]:
     r"""Function for handling additional options and data for the learning
     functions.

--- a/mitiq/pec/representations/tests/test_biased_noise.py
+++ b/mitiq/pec/representations/tests/test_biased_noise.py
@@ -38,21 +38,11 @@ def single_qubit_biased_noise_overhead(epsilon: float, eta: float) -> float:
     b = epsilon * (3 * eta + 1) / (3 * (eta + 1))
     c = epsilon / (3 * (eta + 1))
     eta1 = (a**2 + a * b - 2 * c**2) / (
-        a**3
-        + a**2 * b
-        - a * b**2
-        - 4 * a * c**2
-        - b**3
-        + 4 * b * c**2
+        a**3 + a**2 * b - a * b**2 - 4 * a * c**2 - b**3 + 4 * b * c**2
     )
     eta2 = -c / (a**2 + 2 * a * b + b**2 - 4 * c**2)
     eta3 = (-a * b - b**2 + 2 * c**2) / (
-        a**3
-        + a**2 * b
-        - a * b**2
-        - 4 * a * c**2
-        - b**3
-        + 4 * b * c**2
+        a**3 + a**2 * b - a * b**2 - 4 * a * c**2 - b**3 + 4 * b * c**2
     )
 
     return abs(eta1) + 2 * abs(eta2) + abs(eta3)
@@ -67,24 +57,12 @@ def two_qubit_biased_noise_overhead(epsilon: float, eta: float) -> float:
     b = epsilon * (3 * eta + 1) / (3 * (eta + 1))
     c = epsilon / (3 * (eta + 1))
     alpha_sq = (a**2 + a * b - 2 * c**2) ** 2 / (
-        a**3
-        + a**2 * b
-        - a * b**2
-        - 4 * a * c**2
-        - b**3
-        + 4 * b * c**2
+        a**3 + a**2 * b - a * b**2 - 4 * a * c**2 - b**3 + 4 * b * c**2
     ) ** 2
     alpha_beta = (
         (a**2 + a * b - 2 * c**2)
         * (-a * b - b**2 + 2 * c**2)
-        / (
-            a**3
-            + a**2 * b
-            - a * b**2
-            - 4 * a * c**2
-            - b**3
-            + 4 * b * c**2
-        )
+        / (a**3 + a**2 * b - a * b**2 - 4 * a * c**2 - b**3 + 4 * b * c**2)
         ** 2
     )
     alpha_gamma = (
@@ -92,37 +70,18 @@ def two_qubit_biased_noise_overhead(epsilon: float, eta: float) -> float:
         * (a**2 + a * b - 2 * c**2)
         / (
             (a**2 + 2 * a * b + b**2 - 4 * c**2)
-            * (
-                a**3
-                + a**2 * b
-                - a * b**2
-                - 4 * a * c**2
-                - b**3
-                + 4 * b * c**2
-            )
+            * (a**3 + a**2 * b - a * b**2 - 4 * a * c**2 - b**3 + 4 * b * c**2)
         )
     )
     beta_sq = (-a * b - b**2 + 2 * c**2) ** 2 / (
-        a**3
-        + a**2 * b
-        - a * b**2
-        - 4 * a * c**2
-        - b**3
-        + 4 * b * c**2
+        a**3 + a**2 * b - a * b**2 - 4 * a * c**2 - b**3 + 4 * b * c**2
     ) ** 2
     beta_gamma = (
         -c
         * (-a * b - b**2 + 2 * c**2)
         / (
             (a**2 + 2 * a * b + b**2 - 4 * c**2)
-            * (
-                a**3
-                + a**2 * b
-                - a * b**2
-                - 4 * a * c**2
-                - b**3
-                + 4 * b * c**2
-            )
+            * (a**3 + a**2 * b - a * b**2 - 4 * a * c**2 - b**3 + 4 * b * c**2)
         )
     )
     gamma_sq = c**2 / (a**2 + 2 * a * b + b**2 - 4 * c**2) ** 2

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for PEC."""
+
 import warnings
 from functools import partial
 from typing import List, Optional

--- a/mitiq/pec/types/types.py
+++ b/mitiq/pec/types/types.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Types used in probabilistic error cancellation."""
+
 import warnings
 from copy import deepcopy
 from typing import Any, List, Optional, Tuple, Union

--- a/mitiq/raw/raw.py
+++ b/mitiq/raw/raw.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Run experiments without error mitigation."""
+
 from typing import Callable, Optional, Union
 
 from mitiq import QPROGRAM, Executor, Observable, QuantumResult

--- a/mitiq/rem/rem.py
+++ b/mitiq/rem/rem.py
@@ -136,7 +136,7 @@ def rem_decorator(
     #   since arguments are required.
 
     def decorator(
-        executor: Callable[[QPROGRAM], MeasurementResult]
+        executor: Callable[[QPROGRAM], MeasurementResult],
     ) -> Callable[[QPROGRAM], MeasurementResult]:
         mitigated_executor = mitigate_executor(
             executor,

--- a/mitiq/rem/tests/test_post_select.py
+++ b/mitiq/rem/tests/test_post_select.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for postselection of measurement results."""
+
 import pytest
 
 from mitiq import MeasurementResult

--- a/mitiq/rem/tests/test_rem.py
+++ b/mitiq/rem/tests/test_rem.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for readout confusion inversion."""
+
 from functools import partial
 from typing import List
 

--- a/mitiq/shadows/quantum_processing.py
+++ b/mitiq/shadows/quantum_processing.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Quantum processing functions for classical shadows."""
+
 from typing import Callable, List, Optional, Sequence, Tuple
 
 import cirq

--- a/mitiq/shadows/shadows.py
+++ b/mitiq/shadows/shadows.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
-"""Classical shadow estimation for quantum circuits. """
+"""Classical shadow estimation for quantum circuits."""
 
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 

--- a/mitiq/shadows/shadows_utils.py
+++ b/mitiq/shadows/shadows_utils.py
@@ -177,9 +177,5 @@ def n_measurements_opts_expectation_bound(
     M = len(observables)
     K = 2 * np.log(2 * M / failure_rate)
 
-    N = (
-        34
-        * max(local_clifford_shadow_norm(o) for o in observables)
-        / error**2
-    )
+    N = 34 * max(local_clifford_shadow_norm(o) for o in observables) / error**2
     return int(np.ceil(N * K)), int(K)

--- a/mitiq/shadows/test/test_shadows.py
+++ b/mitiq/shadows/test/test_shadows.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Test classical shadow estimation process."""
+
 from numbers import Number
 
 import cirq

--- a/mitiq/tests/test_measurement_result.py
+++ b/mitiq/tests/test_measurement_result.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for measurement results."""
+
 import numpy as np
 import pytest
 

--- a/mitiq/tests/test_utils.py
+++ b/mitiq/tests/test_utils.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Tests for utility functions."""
+
 from copy import deepcopy
 
 import cirq

--- a/mitiq/tests/test_without_third_party_packages.py
+++ b/mitiq/tests/test_without_third_party_packages.py
@@ -10,6 +10,7 @@ Ideally these tests should touch all of Mitiq except for
 mitiq.interface.mitiq_[package], where [package] is any supported package that
 interfaces with Mitiq (see mitiq.SUPPORTED_PROGRAM_TYPES).
 """
+
 from abc import ABCMeta
 
 

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -5,14 +5,15 @@
 
 """Defines input / output types for a quantum computer (simulator):
 
-  * SUPPORTED_PROGRAM_TYPES: All supported packages / circuits which Mitiq can
-       interface with,
-  * QPROGRAM: All supported packages / circuits which are installed in the
-       environment Mitiq is run in, and
-  * QuantumResult: An object returned by a quantum computer (simulator) running
-       a quantum program from which expectation values to be mitigated can be
-       computed. Note this includes expectation values themselves.
+* SUPPORTED_PROGRAM_TYPES: All supported packages / circuits which Mitiq can
+     interface with,
+* QPROGRAM: All supported packages / circuits which are installed in the
+     environment Mitiq is run in, and
+* QuantumResult: An object returned by a quantum computer (simulator) running
+     a quantum program from which expectation values to be mitigated can be
+     computed. Note this includes expectation values themselves.
 """
+
 from collections import Counter
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union

--- a/mitiq/utils.py
+++ b/mitiq/utils.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Utility functions."""
+
 from copy import deepcopy
 from itertools import product
 from typing import Any, Dict, List, Tuple

--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Classes corresponding to different zero-noise extrapolation methods."""
+
 import warnings
 from abc import ABC, abstractmethod
 from copy import deepcopy

--- a/mitiq/zne/scaling/folding.py
+++ b/mitiq/zne/scaling/folding.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Functions for local and global unitary folding on supported circuits."""
+
 import warnings
 from copy import deepcopy
 from typing import Any, Dict, FrozenSet, List, Optional, cast

--- a/mitiq/zne/scaling/layer_scaling.py
+++ b/mitiq/zne/scaling/layer_scaling.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Functions for layer-wise unitary folding on supported circuits."""
+
 from copy import deepcopy
 from typing import Callable, List
 

--- a/mitiq/zne/scaling/tests/test_folding.py
+++ b/mitiq/zne/scaling/tests/test_folding.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for scaling noise by unitary folding."""
+
 import numpy as np
 import pytest
 from cirq import (
@@ -296,7 +297,7 @@ def test_fold_from_left_no_stretch():
     circuit = testing.random_circuit(qubits=2, n_moments=10, op_density=0.99)
     folded = fold_gates_from_left(circuit, scale_factor=1)
     assert _equal(folded, _squash_moments(circuit))
-    assert not (folded is circuit)
+    assert folded is not circuit
 
 
 def test_fold_from_left_scale_factor_larger_than_three():

--- a/mitiq/zne/scaling/tests/test_identity_insertion.py
+++ b/mitiq/zne/scaling/tests/test_identity_insertion.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for scaling noise by inserting identity layers."""
+
 import pytest
 from cirq import Circuit, LineQubit, ops
 

--- a/mitiq/zne/scaling/tests/test_layer_scaling.py
+++ b/mitiq/zne/scaling/tests/test_layer_scaling.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for scaling by layer."""
+
 from cirq import Circuit, LineQubit, ops
 
 from mitiq.zne.scaling import layer_folding

--- a/mitiq/zne/scaling/tests/test_parameter.py
+++ b/mitiq/zne/scaling/tests/test_parameter.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for parameter scaling."""
+
 from copy import deepcopy
 
 import numpy as np

--- a/mitiq/zne/tests/test_inference.py
+++ b/mitiq/zne/tests/test_inference.py
@@ -6,6 +6,7 @@
 """Tests for zero-noise inference and extrapolation methods (factories) with
 classically generated data.
 """
+
 from typing import Callable, List
 
 import cirq

--- a/mitiq/zne/tests/test_zne.py
+++ b/mitiq/zne/tests/test_zne.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Unit tests for zero-noise extrapolation."""
+
 import functools
 from typing import List
 

--- a/mitiq/zne/zne.py
+++ b/mitiq/zne/zne.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """High-level zero-noise extrapolation tools."""
+
 from functools import wraps
 from typing import Callable, List, Optional, Union
 
@@ -18,9 +19,7 @@ def execute_with_zne(
     observable: Optional[Observable] = None,
     *,
     factory: Optional[Factory] = None,
-    scale_noise: Callable[
-        [QPROGRAM, float], QPROGRAM
-    ] = fold_gates_at_random,  # type: ignore [has-type]
+    scale_noise: Callable[[QPROGRAM, float], QPROGRAM] = fold_gates_at_random,  # type: ignore [has-type]
     num_to_average: int = 1,
 ) -> float:
     """Estimates the error-mitigated expectation value associated to the
@@ -69,9 +68,7 @@ def mitigate_executor(
     observable: Optional[Observable] = None,
     *,
     factory: Optional[Factory] = None,
-    scale_noise: Callable[
-        [QPROGRAM, float], QPROGRAM
-    ] = fold_gates_at_random,  # type:ignore [has-type]
+    scale_noise: Callable[[QPROGRAM, float], QPROGRAM] = fold_gates_at_random,  # type:ignore [has-type]
     num_to_average: int = 1,
 ) -> Callable[[QPROGRAM], float]:
     """Returns a modified version of the input 'executor' which is
@@ -130,9 +127,7 @@ def zne_decorator(
     observable: Optional[Observable] = None,
     *,
     factory: Optional[Factory] = None,
-    scale_noise: Callable[
-        [QPROGRAM, float], QPROGRAM
-    ] = fold_gates_at_random,  # type: ignore [has-type]
+    scale_noise: Callable[[QPROGRAM, float], QPROGRAM] = fold_gates_at_random,  # type: ignore [has-type]
     num_to_average: int = 1,
 ) -> Callable[
     [Callable[[QPROGRAM], QuantumResult]], Callable[[QPROGRAM], float]
@@ -164,7 +159,7 @@ def zne_decorator(
         )
 
     def decorator(
-        executor: Callable[[QPROGRAM], QuantumResult]
+        executor: Callable[[QPROGRAM], QuantumResult],
     ) -> Callable[[QPROGRAM], float]:
         return mitigate_executor(
             executor,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,16 @@
-[tool.black]
+[tool.ruff]
+exclude = ["__init__.py"]
 line-length = 79
-target-version = ['py311']
 
-[tool.isort]
-profile = "black"
-skip_glob = ["**/__init__.py"]
-line_length = 79
-skip_gitignore = "True"
+[tool.ruff.lint]
+select = [
+    # pycodestyle
+    "E",
+    # pyflakes
+    "F",
+    # isort
+    "I",
+]
 
 [tool.pytest.ini_options]
 addopts = "--color=yes"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open("VERSION.txt", "r") as f:
     __version__ = f.read().strip()


### PR DESCRIPTION
## Description

Does what it says on the 🥫.

### Motivation

It's what the cool kids are using... jk

[Ruff](https://docs.astral.sh/ruff/) consolidates both linting (flake8) and formatting (black and isort) into a single tool which is configurable via the `pyproject.toml` file (flake8 refuses to support this feature, despite it becoming the defacto standard). This PR also consolidates the makefile so only one command is needed for linting/formatting checks and one command for fixing those problems (if possible).

### Request from reviewer

I want to make sure that the formatting that was done is required, given the ruff configuration. As part of the review, can you

1. Be on master
2. Install `ruff`
3. Copy the ruff config in [`pyproject.toml`](https://github.com/unitaryfund/mitiq/blob/3740c0a150b3fc57ca9c3b5a6055876d5b8dcd28/pyproject.toml) to your local machine
4. run `make format`
5. Ensure the changes are the same as what are in this PR