### PR TITLE
Distribute docs build over number of CPUs.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,3 +57,4 @@ Yash Prabhat
 Vladimir Kozhukalov
 Francesc Sabater
 Emiliano Godinez
+Alessandro Cosentino

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -j auto
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build


### PR DESCRIPTION
## Description

An attempt to speed up docs build (see https://github.com/unitaryfund/mitiq/issues/2083).
It looks like the bottleneck is the notebook execution. [MyST-NB is parallel-friendly](https://myst-nb.readthedocs.io/en/latest/quickstart.html), hence this attempt.

Some data points from testing this on my local machine (Apple M2 Pro):
  
| Build | `time make docs-clean`  |
|--------|--------|
| Serial | 962.92s user 424.57s system 193% cpu 11:57.48 total |
| Parallel | 1052.97s user 250.09s system 443% cpu 4:53.88 total |

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

N/A - [ ] I added unit tests for new code.
N/A - [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
N/A - [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
N/A - [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file
