### PR TITLE
Fix examples link in README.md

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Nathaniel T. Stemen
 Nathan Shammah
 Will J. Zeng
 Min Li
+Jordan Sullivan
 
 L-P-B
 Paul Chung

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1301,7 +1301,7 @@ Another important change is the integration with Amazon Braket, such that Mitiq 
 
 In the context of probabilistic error cancellation, the sub-module `mitiq.pec.representations` has been significantly improved. Now one can easily compute the optimal quasi-probabiliy representation of an ideal gate as a linear combination of `NoisyOperation` objects.
 
-Thanks to all contributors (@L-P-B, @Aaron-Robertson, @francespoblete, @LaurentAjdnik, @maxtremblay, @andre-a-alves, @paniash, @purva-thakre) and in particular to the participants of [unitaryHACK](https://unitaryhack.dev/)!
+Thanks to all contributors (@L-P-B, @Aaron-Robertson, @francespoblete, @LaurentAjdnik, @maxtremblay, @andre-a-alves, @paniash, @purva-thakre) and in particular to the participants of [unitaryHACK](https://2021.unitaryhack.dev/)!
 
 ### All Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1301,7 +1301,7 @@ Another important change is the integration with Amazon Braket, such that Mitiq 
 
 In the context of probabilistic error cancellation, the sub-module `mitiq.pec.representations` has been significantly improved. Now one can easily compute the optimal quasi-probabiliy representation of an ideal gate as a linear combination of `NoisyOperation` objects.
 
-Thanks to all contributors (@L-P-B, @Aaron-Robertson, @francespoblete, @LaurentAjdnik, @maxtremblay, @andre-a-alves, @paniash, @purva-thakre) and in particular to the participants of [unitaryHACK](https://unitaryfund.github.io/unitaryhack/)!
+Thanks to all contributors (@L-P-B, @Aaron-Robertson, @francespoblete, @LaurentAjdnik, @maxtremblay, @andre-a-alves, @paniash, @purva-thakre) and in particular to the participants of [unitaryHACK](https://unitaryhack.dev/)!
 
 ### All Changes
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Try out the calibration module demonstrated below to help find the best paramete
 
 ![](docs/source/img/calibration.gif)
 
-See our [guides](https://mitiq.readthedocs.io/en/stable/guide/guide.html) and [examples](https://mitiq.readthedocs.io) for more explanation, techniques, and benchmarks.
+See our [guides](https://mitiq.readthedocs.io/en/stable/guide/guide.html) and [examples](https://mitiq.readthedocs.io/en/stable/examples/examples.html) for more explanation, techniques, and benchmarks.
 
 ## Quick Tour
 


### PR DESCRIPTION
Under the Calibration section, it says "See our [guides](https://mitiq.readthedocs.io/en/stable/guide/guide.html) and [examples](https://mitiq.readthedocs.io/) for more explanation, techniques, and benchmarks." but the link to examples is currently pointing to our docs homepage (https://mitiq.readthedocs.io/) rather than the examples section (https://mitiq.readthedocs.io/en/stable/examples/examples.html). Simple update.

Second update was to the unitaryHack link, pointing it to the updated 2021 link in the changelog. 
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file
