### PR TITLE
adding rotated randomized benchmarking circuits to calibrator

### DIFF
--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -350,7 +350,8 @@ class Settings:
                     }
                 else:
                     raise NotImplementedError(
-                        "rotated rb with >1 qubits not supported in calibration"
+                        """rotated rb circuits with >1 qubits
+                        not yet supported in calibration"""
                     )
 
             elif circuit_type == "mirror":

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -18,8 +18,8 @@ from mitiq.benchmarks import (
     generate_mirror_circuit,
     generate_quantum_volume_circuit,
     generate_rb_circuits,
+    generate_rotated_rb_circuits,
     generate_w_circuit,
-    generate_rotated_rb_circuits
 )
 from mitiq.interface import convert_from_mitiq
 from mitiq.pec import execute_with_pec
@@ -341,12 +341,17 @@ class Settings:
             elif circuit_type == "rotated_rb":
                 theta = benchmark["theta"]
                 if num_qubits == 1:
-                    circuit = generate_rotated_rb_circuits(num_qubits, depth)[0]
-                    ideal = {"0": (2/3) * np.sin(theta/2)**2, "1": 1 - (2/3) * np.sin(theta/2)**2}
+                    circuit = generate_rotated_rb_circuits(num_qubits, depth)[
+                        0
+                    ]
+                    ideal = {
+                        "0": (2 / 3) * np.sin(theta / 2) ** 2,
+                        "1": 1 - (2 / 3) * np.sin(theta / 2) ** 2,
+                    }
                 else:
                     raise NotImplementedError(
-                    "rotated rb circuits with > 1 qubits not yet supported in calibration"
-                )
+                        "rotated rb with >1 qubits not supported in calibration"
+                    )
 
             elif circuit_type == "mirror":
                 seed = benchmark.get("circuit_seed", None)

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -344,10 +344,8 @@ class Settings:
                     circuit = generate_rotated_rb_circuits(num_qubits, depth)[
                         0
                     ]
-                    ideal = {
-                        "0": (2 / 3) * np.sin(theta / 2) ** 2,
-                        "1": 1 - (2 / 3) * np.sin(theta / 2) ** 2,
-                    }
+                    p = (2 / 3) * np.sin(theta / 2) ** 2
+                    ideal = {"0": p, "1": 1 - p}
                 else:
                     raise NotImplementedError(
                         """rotated rb circuits with >1 qubits

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, List, cast
 
 import cirq
 import networkx as nx
+import numpy as np
 
 from mitiq import QPROGRAM, Executor
 from mitiq.benchmarks import (
@@ -18,6 +19,7 @@ from mitiq.benchmarks import (
     generate_quantum_volume_circuit,
     generate_rb_circuits,
     generate_w_circuit,
+    generate_rotated_rb_circuits
 )
 from mitiq.interface import convert_from_mitiq
 from mitiq.pec import execute_with_pec
@@ -336,6 +338,16 @@ class Settings:
             elif circuit_type == "rb":
                 circuit = generate_rb_circuits(num_qubits, depth)[0]
                 ideal = {"0" * num_qubits: 1.0}
+            elif circuit_type == "rotated_rb":
+                theta = benchmark["theta"]
+                if num_qubits == 1:
+                    circuit = generate_rotated_rb_circuits(num_qubits, depth)[0]
+                    ideal = {"0": (2/3) * np.sin(theta/2)**2, "1": 1 - (2/3) * np.sin(theta/2)**2}
+                else:
+                    raise NotImplementedError(
+                    "rotated rb circuits with > 1 qubits not yet supported in calibration"
+                )
+
             elif circuit_type == "mirror":
                 seed = benchmark.get("circuit_seed", None)
                 circuit, bitstring_list = generate_mirror_circuit(

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -41,7 +41,7 @@ light_zne_settings = Settings(
             "circuit_type": "rotated_rb",
             "num_qubits": 1,
             "circuit_depth": 10,
-            "theta": np.pi/3
+            "theta": np.pi / 3,
         },
     ],
     strategies=[

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -38,9 +38,10 @@ light_zne_settings = Settings(
             "circuit_depth": 1,
         },
         {
-            "circuit_type": "mirror",
-            "num_qubits": 2,
-            "circuit_depth": 1,
+            "circuit_type": "rotated_rb",
+            "num_qubits": 1,
+            "circuit_depth": 10,
+            "theta": np.pi/3
         },
     ],
     strategies=[

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -209,6 +209,28 @@ def test_make_circuits_rotated_rb_circuits():
     assert problems[0].type == "rotated_rb"
 
 
+def test_make_circuits_rotated_rb_circuits_invalid_qubits():
+    settings = Settings(
+        benchmarks=[
+            {
+                "circuit_type": "rotated_rb",
+                "num_qubits": 2,
+                "circuit_depth": 10,
+                "theta": np.pi / 3,
+            }
+        ],
+        strategies=[
+            {
+                "technique": "zne",
+                "scale_noise": fold_global,
+                "factory": RichardsonFactory([1.0, 2.0, 3.0]),
+            },
+        ],
+    )
+    with pytest.raises(NotImplementedError, match="rotated rb circuits"):
+        settings.make_problems()
+
+
 def test_make_circuits_qv_circuits():
     settings = Settings(
         [

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -185,6 +185,29 @@ def test_Strategy_pretty_dict():
         )
 
 
+def test_make_circuits_rotated_rb_circuits():
+    settings = Settings(
+    benchmarks=[
+        {
+            "circuit_type": "rotated_rb",
+            "num_qubits": 1,
+            "circuit_depth": 10,
+            "theta": np.pi/3
+        }
+    ],
+    strategies=[
+        {
+            "technique": "zne",
+            "scale_noise": fold_global,
+            "factory": RichardsonFactory([1.0, 2.0, 3.0]),
+        },
+    ],
+)
+    problems = settings.make_problems()
+    assert len(problems) == 1
+    assert problems[0].type == "rotated_rb"
+
+
 def test_make_circuits_qv_circuits():
     settings = Settings(
         [

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -6,6 +6,7 @@ import json
 
 import cirq
 import pytest
+import numpy as np
 import qiskit
 
 from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -5,8 +5,8 @@
 import json
 
 import cirq
-import pytest
 import numpy as np
+import pytest
 import qiskit
 
 from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES
@@ -188,22 +188,22 @@ def test_Strategy_pretty_dict():
 
 def test_make_circuits_rotated_rb_circuits():
     settings = Settings(
-    benchmarks=[
-        {
-            "circuit_type": "rotated_rb",
-            "num_qubits": 1,
-            "circuit_depth": 10,
-            "theta": np.pi/3
-        }
-    ],
-    strategies=[
-        {
-            "technique": "zne",
-            "scale_noise": fold_global,
-            "factory": RichardsonFactory([1.0, 2.0, 3.0]),
-        },
-    ],
-)
+        benchmarks=[
+            {
+                "circuit_type": "rotated_rb",
+                "num_qubits": 1,
+                "circuit_depth": 10,
+                "theta": np.pi / 3,
+            }
+        ],
+        strategies=[
+            {
+                "technique": "zne",
+                "scale_noise": fold_global,
+                "factory": RichardsonFactory([1.0, 2.0, 3.0]),
+            },
+        ],
+    )
     problems = settings.make_problems()
     assert len(problems) == 1
     assert problems[0].type == "rotated_rb"


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->

---

### License

- [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file
