### PR TITLE
Add `Qibo` to `Frontend` section of docs

### DIFF
--- a/docs/source/guide/frontends-backends.md
+++ b/docs/source/guide/frontends-backends.md
@@ -52,10 +52,11 @@ For example, you can use {func}`mitiq.interface.mitiq_braket.conversions.from_br
 Examples for using each of the frameworks to represent the input to a mitigation method are linked below.
 
 - {doc}`Cirq <../examples/cirq-ibmq-backends>`
-- {doc}`Qiskit <../examples/ibmq-backends>`
 - {doc}`PyQuil <../examples/pyquil_demo>`
-- {doc}`PennyLane <../examples/pennylane-ibmq-backends>`
+- {doc}`Qiskit <../examples/ibmq-backends>`
 - {doc}`Braket <../examples/braket_mirror_circuit>`
+- {doc}`PennyLane <../examples/pennylane-ibmq-backends>`
+- {doc}`Qibo <../examples/qibo-noisy-simulation>`
 
 ## Backends
 


### PR DESCRIPTION
[This section](https://mitiq.readthedocs.io/en/latest/guide/frontends-backends.html#frontends) in the docs links a bunch of examples specific to the available frontends. `Qibo` example was missing from this list. 

In addition, the order of the listed example was changed to be consistent with the output of the following code block:
```python
import mitiq

mitiq.SUPPORTED_PROGRAM_TYPES.keys()
```

