### PR TITLE
Exit early when circuit type is not supported

### DIFF
--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -15,7 +15,6 @@ from mitiq import QPROGRAM, Executor
 from mitiq.benchmarks import (
     generate_ghz_circuit,
     generate_mirror_circuit,
-    generate_quantum_volume_circuit,
     generate_rb_circuits,
     generate_w_circuit,
 )

--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -347,11 +347,9 @@ class Settings:
                 ideal_bitstring = "".join(map(str, bitstring_list))
                 ideal = {ideal_bitstring: 1.0}
             elif circuit_type == "qv":
-                circuit, _ = generate_quantum_volume_circuit(num_qubits, depth)
                 raise NotImplementedError(
                     "quantum volume circuits not yet supported in calibration"
                 )
-
             else:
                 raise ValueError(
                     "invalid value passed for `circuit_types`. Must be "


### PR DESCRIPTION
## Description

A small thing I noticed when reviewing #2248. Unless I am missing something, there is no point in generating the circuit for a circuit type we don't support.

`make test` passes successfully.

