### PR TITLE
Remove redundant word in release title

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -19,7 +19,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: ${{ github.ref }}
           body_path: ./CHANGELOG.md
           draft: true
           prerelease: false


### PR DESCRIPTION
## Description

One of the manual step in the release process I witnessed today was to remove the word 'Release' from the release title, which I agree with @natestemen it is redundant. We may as well remove it formally and save a manual step.
