### PR TITLE
Make test for 3rd party imports meaningful again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Submit coverage report to Codecov
         # Only submit to Codecov once.
         if: ${{ matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'}}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,9 +73,12 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Mitiq
+        # Since requirements.txt includes cirq, which in turn has pyquil as dependency,
+        # we explicitly remove pyquil from the installed packages after installing mitiq
         run: |
           python -m pip install --upgrade pip
           pip install .
+          pip uninstall -y pyquil
 
       - name: Test without 3rd party packages
         run: |

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -3,8 +3,7 @@
 # module.
 # Original authors: Cirq developers: Xiao Mi, Dave Bacon, Craig Gidney,
 # Ping Yeh, Matthew Neely.
-# Code URL = ('https://github.com/quantumlib/Cirq/blob/main/cirq-core/cirq/
-# experiments/qubit_characterizations.py').
+# Code URL = ('https://github.com/quantumlib/Cirq/blob/main/cirq-core/cirq/experiments/qubit_characterizations.py').
 #
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.

--- a/mitiq/tests/test_without_third_party_packages.py
+++ b/mitiq/tests/test_without_third_party_packages.py
@@ -11,7 +11,9 @@ mitiq.interface.mitiq_[package], where [package] is any supported package that
 interfaces with Mitiq (see mitiq.SUPPORTED_PROGRAM_TYPES).
 """
 
-from abc import ABCMeta
+from typing import Union, get_origin
+
+from cirq import Circuit
 
 
 def test_import():
@@ -20,14 +22,14 @@ def test_import():
     """
     import mitiq
 
-    if isinstance(mitiq.QPROGRAM, ABCMeta):
-        pass  # If only Cirq is installed, QPROGRAM is not a typing.Union.
-    else:
+    if get_origin(mitiq.QPROGRAM) is Union:
         assert (
             1  # cirq.Circuit is always supported.
             <= len(mitiq.QPROGRAM.__args__)  # All installed types.
             <= len(mitiq.SUPPORTED_PROGRAM_TYPES.keys())  # All types.
         )
+    else:
+        assert mitiq.QPROGRAM is Circuit
 
 
 # TODO: More tests wanted!


### PR DESCRIPTION
## Description

(This fix is a prerequisite for working on https://github.com/unitaryfund/mitiq/issues/746.)

A test was created in https://github.com/unitaryfund/mitiq/pull/745 to double check that one can import mitiq without _any_ 3rd party integration package installed. However, this was relying on `pip install .` not installing any integration packages, which is no longer the case, since `cirq` is in the main `requirements.txt` and in turn installs `pyquil`.

In other words, the scenario in which QPROGRAM collapses to the single Circuit type (and not an Union) was never hit. This PR addresses this.

A more elegant fix would imply to only have `cirq-core` in the main requirements, but that requires some deeper redesign of how we integrate 3rd parties packages. 

## Test

I tested this with the awesome [act](https://github.com/nektos/act/) tool (note: it requires Docker) by running

```sh
act push --container-architecture linux/amd64 -j core
```
From the output (in the screenshot), one can see that pyquil is found and uninstalled.

<img width="773" alt="Screenshot 2024-04-07 at 20 48 45" src="https://github.com/unitaryfund/mitiq/assets/1048336/f49e8a4d-cbf0-4183-82ef-c3e3fe734120">

