### PR TITLE
Update to codecov-action v4 and use token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,7 @@ jobs:
       - name: Submit coverage report to Codecov
         # Only submit to Codecov once.
         if: ${{ matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'}}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
## Description

Upload to codecov fails in our pull requests builds, so we try to update to codecov-action v4. This version requires a token even for public repository. The secret token was taken from https://app.codecov.io/gh/unitaryfund/mitiq/settings and then set in https://github.com/unitaryfund/mitiq/settings/secrets/actions. 

