### PR TITLE
Retry linkcheck when building docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -166,6 +166,8 @@ linkcheck_ignore = [
     r"https://arxiv.org/abs/1807.05572",
 ]
 
+linkcheck_retries = 3
+
 
 class ApsStyle(pybtex.style.formatting.unsrt.Style):
     """Style that mimicks APS journals."""


### PR DESCRIPTION
## Description

Linkcheck when building docs fails too often on PR build, e.g. [this run](https://github.com/unitaryfund/mitiq/actions/runs/8629414504/job/23653574928?pr=2276).

Let's try retries!
