### PR TITLE
Use Jupyter cache in gh workflow docs build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,13 @@ jobs:
           docker run --rm -idt -p 5000:5000 rigetti/qvm -S
           docker run --rm -idt -p 5555:5555 rigetti/quilc -R
 
+      - name: Fetch Jupyter cache
+        uses: actions/cache@v3
+        with:
+          path: ./docs/build/.jupyter_cache
+          key: jupyter-cache-${{ github.run_id }}
+          restore-keys: jupyter-cache
+
       - name: Build and test Sphinx docs
         run: |
           export BQSKIT_DOC_CHECK_OVERRIDE=1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,11 +55,10 @@ jobs:
           docker run --rm -idt -p 5555:5555 rigetti/quilc -R
 
       - name: Fetch Jupyter cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./docs/build/.jupyter_cache
           key: jupyter-cache-${{ github.run_id }}
-          restore-keys: jupyter-cache
 
       - name: Build and test Sphinx docs
         run: |


### PR DESCRIPTION
## Description

This is an attempt to use [Github Actions Cache](https://github.com/actions/cache) to restore jupyter_cache from one workflow run to the next one. That cache is created by Sphinx Myst-NB because we are setting [this](https://github.com/unitaryfund/mitiq/blob/ffa4b386fd77398e9135766d5eb2509480a72743/docs/source/conf.py#L128) in the configuration.

---

## Test
Unfortunately I can't test this with the awesome`act` tool, because this job starts docker in one of the steps (#dockerinception). So only a merge will tell if it works 😬
