### PR TITLE
Fix typo 'ipynp' to 'ipynb' in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .idea/
 .coverage
 *.dat
-*.ipynp
+*.ipynb
 *.hdf5
 *.ipynb_checkpoints
 *.jupyter_cache


### PR DESCRIPTION
Fairly certain this is just a typo. I believe the intention is for git to ignore changes to jupyter notebooks (*.ipynb).

<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->

---

### License

- [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file
