### PR TITLE
Fix cache key in gh workflow docs job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,16 @@ jobs:
           docker run --rm -idt -p 5000:5000 rigetti/qvm -S
           docker run --rm -idt -p 5555:5555 rigetti/quilc -R
 
+      - name: Generate hash from all files excluding example notebooks
+        run: |
+          HASH=$(find . -type f -not -path './docs/source/examples/*' | sort | xargs cat | sha256sum | awk '{print $1}')
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+
       - name: Fetch Jupyter cache
         uses: actions/cache@v4
         with:
           path: ./docs/build/.jupyter_cache
-          key: jupyter-cache-${{ github.run_id }}
+          key: jupyter-cache-${{ env.hash }}
 
       - name: Build and test Sphinx docs
         run: |


### PR DESCRIPTION
## Description

In #2279 I introduced an extra step in the workflow job that build docs for caching Jupyter notebook execution. As it was written, the step was not of much use.

Summary of a brainstorming session I had with @natestemen:

1. A new `run_id` was generated for each commit that is pushed, see list of cache generated in https://github.com/unitaryfund/mitiq/actions/caches. This means the cache was only restored when one would manually re-run the workflow.

2. Even with a different key, there are problems with having this cache in the workflow step. Jupyter cache doesn't execute a notebook cell whenever that cell is not modified, that is, for any commit that changes code or docs in Mitiq, none of the notebooks would run. This is not what we want, since we use those notebooks as a sort of E2E test for code and docs. 

3. The only valid use case would be using the cache for those commits when a notebook is modified (*and nothing else*). Since the example notebooks are independent from each other, and there is no code or doc links to be test, this is a rare, but valid use case.

This PR implements the cache in scenario 3. 