### PR TITLE
Remove qibo snippet from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,23 +47,6 @@ Well done making your first contribution so quickly 🏎️💨!
 Announcing support for [Qibo](https://qibo.science/), a newly integrated frontend in Mitiq! 📣
 Qibo is an "end-to-end open source platform for quantum simulation, self-hosted quantum hardware control, calibration and characterization".
 
-```py
-from qibo import Circuit
-from mitiq.conversions import convert_to_mitiq
-
-circuit = Circuit(2)
-circuit.add(gates.H(0))
-circuit.add(gates.H(1))
-
-print(circuit)
-
-def executor(circuit):
-    return circuit.execute()
-
-
-mitigated = mitiq.zne.execute_with_zne(convert_to_mitiq(circuit), executor)
-```
-
 Thank you to new contributor Francesc Sabater for excellent work integrating Qibo and Mitiq!
 Thanks also to new contibutor Sam Burdick for fixing our readme.
 


### PR DESCRIPTION
## Description

Remove qibo snippet from v34.0 section of the changelog.
---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file
