### PR TITLE
Pin myst-parser

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -24,7 +24,7 @@ sphinxcontrib-bibtex==2.6.2
 sphinx-copybutton==0.5.2
 sphinx-autodoc-typehints==2.0.0
 myst-nb==1.0.0
-myst-parser>=2.0.0
+myst-parser==2.0.0
 pydata-sphinx-theme==0.15.2
 jupytext==1.16.1
 sphinx-gallery==0.15.0


### PR DESCRIPTION
Myst-parser 3.0.0 was released today and that was breaking our builds.

My bad, I left this dependency too loose in #2269, and it's causing builds to fail, e.g. https://github.com/unitaryfund/mitiq/actions/runs/8807617694
