### PR TITLE
Fix global tqdm module patch in test

### DIFF
--- a/mitiq/shadows/test/test_quantum_processing.py
+++ b/mitiq/shadows/test/test_quantum_processing.py
@@ -45,6 +45,10 @@ def test_tqdm_import_not_available():
         )  # Reload the module to trigger the import
         assert mitiq.shadows.quantum_processing.tqdm is None
 
+    # Reload the module again to restore the original tqdm import.
+    # Otherwise, the rest of the tests are affected by the patch (issue #2318)
+    importlib.reload(mitiq.shadows.quantum_processing)
+
 
 def test_generate_random_pauli_strings():
     """Tests that the function generates random Pauli strings."""


### PR DESCRIPTION
Despite the patch of tqdm happens in a context manager, the fact that the module is reloaded inside the context makes it so that the patch affects all other tests. No test wasn't failing, because there was no assert on tqdm being there, but codecov reports were affected by this, i.e., this PR fixes #2318.
