### PR TITLE
Used trusted publishers for testpypi publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -10,8 +10,7 @@ on:
     inputs: {}
 
 jobs:
-  build:
-    name: Build Mitiq distribution
+  deploy:
     if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
     steps:
@@ -23,32 +22,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Install dependencies for build
+      - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build
-      - name: Build mitiq
-        run: python -m build
-      - name: Store build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build
-          path: dist/*
-
-  publish:
-    name: Upload release to PyPi
-    runs-on: ubuntu-latest
-    needs: build
-    environment:
-      name: pypi
-      url: https://pypi.org/p/mitiq/
-    permissions:
-      id-token: write
-    steps:
-      - name: Fetch build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build
-          path: dist/
-      - name: Publish package distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+          make install requirements
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -10,7 +10,8 @@ on:
     inputs: {}
 
 jobs:
-  deploy:
+  build:
+    name: Build Mitiq distribution
     if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
     steps:
@@ -22,15 +23,32 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Install Python dependencies
+      - name: Install dependencies for build
         run: |
           python -m pip install --upgrade pip
-          make install requirements
-          pip install setuptools wheel twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python setup.py sdist bdist_wheel
-          twine upload dist/*
+          pip install build
+      - name: Build mitiq
+        run: python -m build
+      - name: Store build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: dist/*
+
+  publish:
+    name: Upload release to PyPi
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mitiq/
+    permissions:
+      id-token: write
+    steps:
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: dist/
+      - name: Publish package distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          make install requirements
+          make install
           pip install setuptools wheel twine
       - name: Build and publish
         env:

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    if: github.repository_owner == 'unitaryfund' && github.event_name == 'push'
+    if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
     steps:
       - name: Check out mitiq

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    name: Build Mitiq
     if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
     steps:
@@ -31,6 +32,7 @@ jobs:
           path: dist/*
 
   test-publish:
+    name: Upload release to test PyPi
     runs-on: ubuntu-latest
     needs: build
     environment:
@@ -57,7 +59,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: "3.11"
       - name: Install package from TestPyPI
         run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.python.org/simple/ mitiq
       - name: Set version variable

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -8,8 +8,8 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  deploy:
-    if: github.repository_owner == 'unitaryfund'
+  build:
+    if: github.repository_owner == 'unitaryfund' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Check out mitiq
@@ -23,27 +23,53 @@ jobs:
           python -m pip install --upgrade pip
           make install
           pip install setuptools wheel twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: ${{ secrets.TESTPYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TESTPYPI_PASSWORD }}
-        run: |
-          python setup.py sdist bdist_wheel
-          twine upload --repository testpypi dist/*
+      - name: Build mitiq
+        run: python setup.py sdist bdist_wheel
+      - name: Store build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: dist/*
 
-  # TODO: Need a way to get the version number from previous step
-  # download-test:
-  # runs-on: ubuntu-latest
-  # steps:
-  # - name: Check out mitiq
-  # uses: actions/checkout@v4
-  # - name: Set up Python
-  # uses: actions/setup-python@v5
-  # with:
-  # python-version: 3.8
-  # - name: Install Mitiq
-  # The ``--extra-index-url`` is necessary since otherwise ``TestPyPI``  would be
-  # looking for the required dependencies therein, but we want it to install them
-  # from the real PyPI channel.
-  #   run: |
-  #     pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.python.org/simple/ mitiq==x.y.z
+  test-publish:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/mitiq/
+    permissions:
+      id-token: write
+    steps:
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: dist/
+      - name: Publish package distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  verify-version:
+    needs: test-publish
+    runs-on: ubuntu-latest
+    environment: testpypi
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - name: Install package from TestPyPI
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.python.org/simple/ mitiq
+      - name: Set version variable
+        run: |
+          VER=$(cat VERSION.txt)
+          echo "VERSION=$VER" >> $GITHUB_ENV
+
+      - name: Verify the published version
+        run: |
+          TEST_IMPORT_VERSION=$(python -c "import mitiq; print(mitiq.__version__)")
+          if [ "$TEST_IMPORT_VERSION" != "$VERSION" ]; then
+            echo "Imported version $TEST_IMPORT_VERSION does not match tag $VERSION"
+            exit 1
+          fi

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -21,10 +21,9 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          make install
-          pip install setuptools wheel twine
+          pip install build
       - name: Build mitiq
-        run: python setup.py sdist bdist_wheel
+        run: python -m build
       - name: Store build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ check-types:
 clean:
 	rm -rf dist
 	rm -rf mitiq.egg-info
-	rm -rf .pytest_cache/
+	rm -rf .mypy_cache .pytest_cache .ruff_cache
+	rm -rf htmlcov coverage.xml .coverage
+	rm -rf .ipynb_checkpoints
 
 .PHONY: dist
 dist:

--- a/docs/source/release.md
+++ b/docs/source/release.md
@@ -99,9 +99,8 @@ release Mitiq are:
 
 ```bash
 python -m pip install --upgrade pip
-make install requirements
-pip install setuptools wheel twine
-python setup.py sdist bdist_wheel
+pip install build twine
+python -m build
 twine upload dist/*
 ```
 


### PR DESCRIPTION
## Description

This PR fixes the failing testpypi publishing action which runs nightly to ensure Mitiq can be uploaded to PyPI.

In addition it adds a check to ensure the version uploaded to testpypi is what is then later downloaded.

resolves https://github.com/unitaryfund/mitiq/issues/2150

### ⚠️ before merging ⚠️:

- [x] create an environment (through GitHub) called `testpypi` [[docs](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#creating-an-environment)]
- [ ] ~create an environment (through GitHub) called `pypi`~ (this will be done in a follow on PR when this change takes effect for the main release workflow)
- [x] ensure testpypi is set up properly to accept trusted publishing [[docs](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)]
