### PR TITLE
Remove qiskit-ibm-provider

### DIFF
--- a/docs/source/examples/cirq-ibmq-backends.md
+++ b/docs/source/examples/cirq-ibmq-backends.md
@@ -71,12 +71,13 @@ for instructions to create an account, save credentials, and see online quantum 
 ```{code-cell} ipython3
 import qiskit
 from qiskit_aer import QasmSimulator
-from qiskit_ibm_provider import IBMProvider
+from qiskit_ibm_runtime import QiskitRuntimeService
 from mitiq.interface.mitiq_qiskit.conversions import to_qiskit
 
-if IBMProvider.saved_accounts() and USE_REAL_HARDWARE:
-    provider = IBMProvider()
-    backend = provider.get_backend("ibm_brisbane")  # Set quantum computer here!
+if QiskitRuntimeService.saved_accounts() and USE_REAL_HARDWARE:
+    service = QiskitRuntimeService()
+    backend = service.least_busy(operational=True, simulator=False)
+    noise_model = False
 else:
     # Simulate the circuit with noise
     noise_model = initialized_depolarizing_noise(noise_level=0.02)

--- a/docs/source/examples/ddd_on_ibmq_ghz.md
+++ b/docs/source/examples/ddd_on_ibmq_ghz.md
@@ -38,7 +38,7 @@ from matplotlib import pyplot as plt
 
 import qiskit
 from qiskit_aer import AerSimulator
-from qiskit_ibm_provider import IBMProvider
+from qiskit_ibm_runtime import QiskitRuntimeService
 
 from mitiq.interface.mitiq_qiskit import to_qiskit
 from mitiq import ddd, QPROGRAM
@@ -146,8 +146,8 @@ correct_bitstring=[0, 0]
 
 ```{code-cell} ipython3
 if USE_REAL_HARDWARE:
-    provider = IBMProvider()
-    backend = provider.get_backend("ibm_brisbane")
+    service = QiskitRuntimeService()
+    backend = service.least_busy(operational=True, simulator=False)
 else:
     from qiskit_ibm_runtime.fake_provider import FakeLimaV2 as FakeLima
     backend = FakeLima()
@@ -171,7 +171,7 @@ def ibm_executor(
     """
     if noisy:
         transpiled = qiskit.transpile(circuit, backend=backend, optimization_level=0)
-        job = backend.run(transpiled, optimization_level=0, shots=shots)
+        job = backend.run(transpiled, shots=shots)
     else:
         ideal_backend = AerSimulator()
         job = ideal_backend.run(circuit, optimization_level=0, shots=shots)

--- a/docs/source/examples/ibmq-backends.md
+++ b/docs/source/examples/ibmq-backends.md
@@ -21,7 +21,7 @@ This tutorial shows an example of how to mitigate noise on IBMQ backends.
 ```{code-cell} ipython3
 import qiskit
 from qiskit_aer import QasmSimulator
-from qiskit_ibm_provider import IBMProvider
+from qiskit_ibm_runtime import QiskitRuntimeService
 
 from mitiq import zne
 from mitiq.interface.mitiq_qiskit.qiskit_utils import initialized_depolarizing_noise
@@ -70,9 +70,10 @@ We define this function in the following code block. Because we are using IBMQ b
 for instructions to create an account, save credentials, and see online quantum computers.
 
 ```{code-cell} ipython3
-if IBMProvider.saved_accounts() and USE_REAL_HARDWARE:
-    provider = IBMProvider()
-    backend = provider.get_backend("ibm_brisbane")  # Set quantum computer here!
+if QiskitRuntimeService.saved_accounts() and USE_REAL_HARDWARE:
+    service = QiskitRuntimeService()
+    backend = service.least_busy(operational=True, simulator=False)
+    noise_model = False
 else:
     # Simulate the circuit with noise
     noise_model = initialized_depolarizing_noise(noise_level=0.02)

--- a/docs/source/examples/layerwise-folding.md
+++ b/docs/source/examples/layerwise-folding.md
@@ -60,7 +60,6 @@ from mitiq.interface.mitiq_cirq.cirq_utils import sample_bitstrings
 
 from cirq.contrib.svg import SVGCircuit
 from qiskit_aer import QasmSimulator
-from qiskit_ibm_provider import IBMProvider
 
 # Default to a simulator.
 noise_model = initialized_depolarizing_noise(noise_level=0.02)

--- a/docs/source/examples/mitiq-paper/mitiq-paper-codeblocks.md
+++ b/docs/source/examples/mitiq-paper/mitiq-paper-codeblocks.md
@@ -17,7 +17,7 @@ Codeblocks from the main text of the [Mitiq whitepaper](https://quantum-journal.
 
 **Codeblock 1**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -29,7 +29,7 @@ outputId: 38c2ce43-463f-4ab8-e402-fbc1d5877ce3
 
 **Codeblock 2**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -45,7 +45,7 @@ mitiq.about()
 
 > Note: The paper just shows the signature of an executor function, but here we explicitly define one to use in examples.
 
-```{code-cell}
+```{code-cell} ipython3
 :id: PyPWG95HhYfj
 
 import cirq
@@ -61,7 +61,7 @@ def executor(circuit: mitiq.QPROGRAM) -> float:
 
 **Codeblock 5**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -82,7 +82,7 @@ print("ZNE value:", zne_value)
 
 > Note: The paper shows pseudocode; here we show an example.
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -102,7 +102,7 @@ print("ZNE value:", zne_value)
 
 > Note: The paper shows pseudocode; here we show an example.
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -127,7 +127,7 @@ print("\n\nPEC value:", pec_value)
 
 **Codeblock 8**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -171,7 +171,7 @@ print("Folded circuit:", folded, sep="\n")
 
 **Codeblock 11**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -187,7 +187,7 @@ print("Folded circuit:", folded, sep="\n")
 
 > Note: The paper shows pseudocode; here we show an example.
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -207,7 +207,7 @@ print("\nScaled circuit:", scaled, sep="\n")
 
 > Note: The paper shows pseudocode; here we show an example.
 
-```{code-cell}
+```{code-cell} ipython3
 from functools import partial
 from mitiq.zne.scaling import compute_parameter_variance, scale_parameters
 
@@ -229,7 +229,7 @@ print("ZNE value via parameter noise scaling:", zne_value)
 
 **Codeblock 14**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -246,7 +246,7 @@ print("ZNE value:", zne_value)
 
 **Codeblock 15**
 
-```{code-cell}
+```{code-cell} ipython3
 :id: AhnilvXffoF2
 
 linear_factory = zne.inference.LinearFactory(scale_factors=[1.0, 2.0, 3.0])
@@ -254,7 +254,7 @@ linear_factory = zne.inference.LinearFactory(scale_factors=[1.0, 2.0, 3.0])
 
 **Codeblock 16**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -271,7 +271,7 @@ print("ZNE value:", zne_value)
 
 **Codeblock 17**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -290,7 +290,7 @@ print("ZNE value:", zne_value)
 
 **Codeblock 18**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -309,7 +309,7 @@ print("ZNE value:", zne_value)
 
 **Codeblock 19**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -341,7 +341,7 @@ print("ZNE value:", zne_value)
 
 **Codeblock 20**
 
-```{code-cell}
+```{code-cell} ipython3
 :id: qqndfKFIGLy6
 
 from mitiq import pec
@@ -360,7 +360,7 @@ noisy_z = pec.NoisyOperation(
 
 **Codeblock 21 & 22**
 
-```{code-cell}
+```{code-cell} ipython3
 :id: UsxGtCrAGL-h
 
 h_rep = pec.OperationRepresentation(
@@ -372,7 +372,7 @@ h_rep = pec.OperationRepresentation(
 
 **Codeblock 23**
 
-```{code-cell}
+```{code-cell} ipython3
 :id: Civ6U2OSGMQV
 
 noisy_op, sign, coeff = h_rep.sample()
@@ -380,7 +380,7 @@ noisy_op, sign, coeff = h_rep.sample()
 
 **Codeblock 24**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -404,7 +404,7 @@ See https://mitiq.readthedocs.io/en/stable/examples/cdr_api.html.
 
 **Codeblock 27**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -420,7 +420,7 @@ print("ZNE value:", zne_value)
 
 **Codeblock 28**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -440,7 +440,7 @@ print("ZNE value:", zne_value)
 
 **Codeblock 29**
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/
@@ -464,12 +464,12 @@ print("ZNE then PEC value:", zne_then_pec_value)  # Note this is not accurate (b
 
 **Codeblock 30**
 
-```{code-cell}
+```{code-cell} ipython3
 :id: dyk7Hj1nPB48
 
 import qiskit
 from qiskit_aer import QasmSimulator
-from qiskit_ibm_provider import IBMProvider
+from qiskit_ibm_runtime import QiskitRuntimeService
 
 
 def execute(
@@ -478,12 +478,16 @@ def execute(
     shots: int = 1024
 ) -> float:
     backend = QasmSimulator()  # Use of a simulator as backend.
-    # backend = IBMProvider().get_backend("backend_name")  # Alternative way to run the blocks, with saved credentials.
-    
-    job = backend.run(
+    # backend = QiskitRuntimeService().least_busy(operational=True, simulator=False)  # Alternative way to run the blocks, with saved credentials.
+
+    exec_circuit = qiskit.transpile(
         circuit,
         backend=backend,
-        optimization_level=0,
+        optimization_level=0, # Important to preserve folded gates.
+    )
+    
+    job = backend.run(
+        exec_circuit,
         shots=shots,
     )
 
@@ -491,7 +495,7 @@ def execute(
     return counts.get("00", 0.0) / shots
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 ---
 colab:
   base_uri: https://localhost:8080/

--- a/docs/source/examples/pennylane-ibmq-backends.md
+++ b/docs/source/examples/pennylane-ibmq-backends.md
@@ -57,20 +57,20 @@ First, we get our devices set up depending on whether we would like to use real 
 
 ```{code-cell} ipython3
 import qiskit
-from qiskit_ibm_provider import IBMProvider
+from qiskit_ibm_runtime import QiskitRuntimeService
 
 USE_REAL_HARDWARE = False
 
 # TODO: Remove the below comment when PennyLane supports Qiskit 1.0
-# As of 14 April 2024, PennyLane is not compatible with Qiskit 1.0,
+# As of 03 May 2024, PennyLane is not compatible with Qiskit 1.0,
 # but PennyLane plans to support the upgrade, soon
-if IBMProvider.saved_accounts() and USE_REAL_HARDWARE:
-    provider = IBMProvider()
+if QiskitRuntimeService.saved_accounts() and USE_REAL_HARDWARE:
+    service = QiskitRuntimeService()
+    backend = service.least_busy(operational=True, simulator=False)
     dev = qml.device(
         "qiskit.ibmq",
         wires=1,
-        backend="ibm_brisbane",
-        provider=provider
+        backend=backend,
     )
 else:
     noise_strength = 0.05
@@ -78,7 +78,7 @@ else:
     dev = qml.transforms.insert(
         dev_noise_free,
         qml.AmplitudeDamping,
-        noise_strength
+        noise_strength,
     )
 ```
 

--- a/docs/source/examples/quantum_simulation_scars_ibmq.md
+++ b/docs/source/examples/quantum_simulation_scars_ibmq.md
@@ -155,10 +155,10 @@ USE_REAL_HARDWARE = False
 
 ```{code-cell} ipython3
 if USE_REAL_HARDWARE:
-    from qiskit_ibm_provider import IBMProvider
+    from qiskit_ibm_runtime import QiskitRuntimeService
     
-    provider = IBMProvider(token="MY_IBM_QUANTUM_TOKEN")   # Get the API token in https://quantum-computing.ibm.com/account
-    backend = provider.get_backend("ibm_brisbane")  # Set quantum computer here!
+    service = QiskitRuntimeService(channel="ibm_quantum", token="MY_IBM_QUANTUM_TOKEN")   # Get the API token in https://quantum-computing.ibm.com/account
+    backend = service.least_busy(operational=True, simulator=False)
 else:
     from qiskit_aer import QasmSimulator
 

--- a/requirements/requirements-pennylane.txt
+++ b/requirements/requirements-pennylane.txt
@@ -1,4 +1,4 @@
-pennylane-qiskit~=0.35.1
-pennylane~=0.35.1
-# TODO: Remove qiskit-ibm-provider when upgrading pennylane-qiskit
+pennylane-qiskit~=0.36.0
+pennylane~=0.36.0
+# TODO: Remove qiskit-ibm-provider when upgrading qiskit-ibm-runtime in requirements-qiskit
 qiskit-ibm-provider~=0.11.0; python_version == '3.9'

--- a/requirements/requirements-pennylane.txt
+++ b/requirements/requirements-pennylane.txt
@@ -1,2 +1,4 @@
 pennylane-qiskit~=0.35.1
 pennylane~=0.35.1
+# TODO: Remove qiskit-ibm-provider
+qiskit-ibm-provider~=0.10.0 # Needed for Python 3.9 with pennylane-qiskit~=0.35.1

--- a/requirements/requirements-pennylane.txt
+++ b/requirements/requirements-pennylane.txt
@@ -1,4 +1,4 @@
 pennylane-qiskit~=0.35.1
 pennylane~=0.35.1
-# TODO: Remove qiskit-ibm-provider
-qiskit-ibm-provider~=0.11.0 # Needed for Python 3.9 with pennylane-qiskit~=0.35.1
+# TODO: Remove qiskit-ibm-provider when upgrading pennylane-qiskit
+qiskit-ibm-provider~=0.11.0; python_version == '3.9'

--- a/requirements/requirements-pennylane.txt
+++ b/requirements/requirements-pennylane.txt
@@ -1,4 +1,4 @@
 pennylane-qiskit~=0.35.1
 pennylane~=0.35.1
 # TODO: Remove qiskit-ibm-provider
-qiskit-ibm-provider~=0.10.0 # Needed for Python 3.9 with pennylane-qiskit~=0.35.1
+qiskit-ibm-provider~=0.11.0 # Needed for Python 3.9 with pennylane-qiskit~=0.35.1

--- a/requirements/requirements-qiskit.txt
+++ b/requirements/requirements-qiskit.txt
@@ -1,5 +1,4 @@
 qiskit~=1.0.2
 qiskit-aer~=0.14.0.1
-qiskit-ibm-provider~=0.10.0
 qiskit-ibm-runtime~=0.20.0
 ply==3.11


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

Removes `qiskit-ibm-provider`.

`qiskit-ibm-provider` is deprecated, and should be migrated to `qiskit-ibm-runtime` using the [migration guide](https://docs.quantum.ibm.com/api/migration-guides/qiskit-runtime-from-ibm-provider). The only use of `qiskit-ibm-provider` was in the docs, so this MR updates the docs to no longer use the deprecated module and drops the module from the mitiq[qiskit] requirements.

I let most of the examples send a circuit to IBM Quantum, and minor discrepancies in the code have been corrected from that as well.

This MR should also make dependabot MR #2306 unnecessary.

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [X] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file
