### PR TITLE
Pretty print Supported Program Types enum

### DIFF
--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -16,15 +16,31 @@
 
 from collections import Counter
 from dataclasses import dataclass
-from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from enum import Enum, EnumMeta
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 import numpy as np
 import numpy.typing as npt
 from cirq import Circuit as _Circuit
 
 
-class EnhancedEnum(Enum):
+class EnhancedEnumMeta(EnumMeta):
+    def __str__(cls) -> str:
+        return ", ".join([member.value for member in cast(Type[Enum], cls)])
+
+
+class EnhancedEnum(Enum, metaclass=EnhancedEnumMeta):
     # This is for backwards compatibility with the old representation
     # of SUPPORTED_PROGRAM_TYPES, which was a dictionary
     @classmethod


### PR DESCRIPTION
Since the introduction of the Supported Program Types enum in #2276, some error messages are not printed in a pretty way. This PR fixes that.
From
```
...
Circuit types supported by Mitiq are 
<enum 'SUPPORTED_PROGRAM_TYPES'>.
```
to
```
...
Circuit types supported by Mitiq are 
braket, cirq, pennylane, pyquil, qibo, qiskit.
```
