### PR TITLE
Add example near-Clifford circuit simulators with links

### DIFF
--- a/docs/source/guide/cdr-1-intro.md
+++ b/docs/source/guide/cdr-1-intro.md
@@ -97,7 +97,8 @@ The CDR method creates a set of "training circuits" which are related to the inp
 These circuits are simulated on a classical (noiseless) simulator to collect data for regression.
 The simulator should also return a `QuantumResult`.
 
-To use CDR at scale, an efficient near-Clifford circuit simulator must be specified.
+To use CDR at scale, an efficient near-Clifford circuit simulator must be specified. Two examples of efficient near-Clifford circuit simulators are [Qrack with the stabilizer hybrid (Clifford+Rz)](https://github.com/vm6502q/pyqrack-jupyter/blob/main/Clifford_RZ.ipynb)  and [IBM's extended stabilizer simulator](https://qiskit.github.io/qiskit-aer/tutorials/6_extended_stabilizer_tutorial.html).
+
 In this example, the circuit is small enough to use any classical simulator, and we use the same density matrix simulator as above but without noise.
 
 ```{code-cell} ipython3


### PR DESCRIPTION
Fixes #2241 

In order to make the documentation more helpful, we should provide users with examples of near-Clifford circuit simulators that are necessary when using CDR at scale. In particular, this should happen in the [CDR guide](https://mitiq.readthedocs.io/en/stable/guide/cdr.html).

This PR includes the changes that takes the documentation from:
To use CDR at scale, an efficient near-Clifford circuit simulator must be specified. In this example, the circuit is small enough to use any classical simulator, and we use the same density matrix simulator as above but without noise.

To the new version:
To use CDR at scale, an efficient near-Clifford circuit simulator must be specified. Two examples of efficient near-Clifford circuit simulators are [Qrack with the stabilizer hybrid (Clifford+Rz)](https://github.com/vm6502q/pyqrack-jupyter/blob/main/Clifford_RZ.ipynb) and [IBM's extended stabilizer simulator](https://qiskit.github.io/qiskit-aer/tutorials/6_extended_stabilizer_tutorial.html).

In this example, the circuit is small enough to use any classical simulator, and we use the same density matrix simulator as above but without noise.

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [X] Added myself / the copyright holder to the AUTHORS file
