### PR TITLE
Ignore _about.py in pytest coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,8 @@
 [run]
 omit =
     */tests/*
+    mitiq/_about.py
+
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,6 @@ requirements: requirements/requirements.txt
 .PHONY: test
 test:
 	pytest -n auto -v --cov=mitiq --cov-report=term --cov-report=xml --ignore=mitiq/interface/mitiq_pyquil
-	pytest -rP mitiq/tests/test_about.py
-
 .PHONY: test-%
 test-%:
 	pytest -n auto -v --cov=mitiq --cov-report=term --cov-report=xml */$(*)/*
@@ -74,4 +72,3 @@ test-pyquil:
 .PHONY: test-all
 test-all:
 	pytest -n auto -v --cov=mitiq --cov-report=term --cov-report=xml
-	pytest -rP mitiq/tests/test_about.py

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ requirements: requirements/requirements.txt
 .PHONY: test
 test:
 	pytest -n auto -v --cov=mitiq --cov-report=term --cov-report=xml --ignore=mitiq/interface/mitiq_pyquil
+
 .PHONY: test-%
 test-%:
 	pytest -n auto -v --cov=mitiq --cov-report=term --cov-report=xml */$(*)/*

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ requirements: requirements/requirements.txt
 .PHONY: test
 test:
 	pytest -n auto -v --cov=mitiq --cov-report=term --cov-report=xml --ignore=mitiq/interface/mitiq_pyquil
+	pytest -rP mitiq/tests/test_about.py
 
 .PHONY: test-%
 test-%:
@@ -73,3 +74,4 @@ test-pyquil:
 .PHONY: test-all
 test-all:
 	pytest -n auto -v --cov=mitiq --cov-report=term --cov-report=xml
+	pytest -rP mitiq/tests/test_about.py

--- a/mitiq/_about.py
+++ b/mitiq/_about.py
@@ -24,9 +24,9 @@ def about() -> None:
         pyquil_version = "Not installed"
 
     try:
-        from qiskit import __qiskit_version__  # pragma: no cover
+        from qiskit import __qiskit_version__
 
-        qiskit_version = __qiskit_version__["qiskit"]  # pragma: no cover
+        qiskit_version = __qiskit_version__["qiskit"]
     except ImportError:
         qiskit_version = "Not installed"
 

--- a/mitiq/pec/representations/optimal.py
+++ b/mitiq/pec/representations/optimal.py
@@ -146,7 +146,7 @@ def find_optimal_representation(
                 " which are initialized with a numerical superoperator matrix."
             )
         else:
-            raise err  # pragma no cover
+            raise err  # pragma: no cover
 
     # Run numerical optimization problem
     quasi_prob_dist = minimize_one_norm(

--- a/mitiq/tests/test_about.py
+++ b/mitiq/tests/test_about.py
@@ -8,6 +8,9 @@
 import mitiq
 
 
-def test_stdout():
-    """Tests function prints a str."""
+def test_result_and_stdout(capsys):
     mitiq.about()
+    captured = capsys.readouterr()
+    assert captured.out.startswith(
+        "\nMitiq: A Python toolkit for implementing"
+    )

--- a/mitiq/tests/test_about.py
+++ b/mitiq/tests/test_about.py
@@ -1,0 +1,13 @@
+# Copyright (C) Unitary Fund
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for mitiq.about()."""
+
+import mitiq
+
+
+def test_stdout():
+    """Tests function prints a str."""
+    mitiq.about()


### PR DESCRIPTION
Related to two of the items in #2365 

1. mitiq/_about.py
2. mitiq/pec/representations/optimal.py