### PR TITLE
Simulate noise for CNOT and CZ gates in Pauli Twirling

### DIFF
--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -4,9 +4,13 @@
 # LICENSE file in the root directory of this source tree.
 
 import random
+from functools import singledispatch
 from typing import List, Optional
 
 import cirq
+import pennylane as qml
+from cirq import Circuit as _Circuit
+from pennylane.tape import QuantumTape
 
 from mitiq import QPROGRAM
 from mitiq.interface import accept_qprogram_and_validate
@@ -49,11 +53,22 @@ CZ_twirling_gates = [
     (cirq.Z, cirq.Z, cirq.Z, cirq.Z),
 ]
 
+CIRQ_NOISE_OP = {
+    "bit-flip": cirq.bit_flip,
+    "depolarize": cirq.depolarize,
+}
+
+PENNYLANE_NOISE_OP = {
+    "bit-flip": qml.BitFlip,
+    "depolarize": qml.DepolarizingChannel,
+}
+
 
 def pauli_twirl_circuit(
     circuit: QPROGRAM,
     num_circuits: int = 10,
-    noise_op: Optional[cirq.Gate] = None,
+    noise_name: Optional[str] = None,
+    **kwargs,
 ) -> List[QPROGRAM]:
     r"""Return the Pauli twirled versions of the input circuit.
 
@@ -64,12 +79,13 @@ def pauli_twirl_circuit(
     Args:
         circuit: The input circuit to execute with twirling.
         num_circuits: Number of circuits to be twirled, and averaged.
-        noise_op: Noisy operator acting on CNOT and CZ gates. See warning.
+        noise_name: Name of the noisy operator acting on CNOT and CZ gates.
+        See warning.
 
     Warning:
         If this function is executed with a simulator backend, it is
         necessary to use the `noise_op` argument to apply noise on CNOT
-        and CZ gates. Otherwise, the twirled circuits will not include the
+        and CZ gates. Otherwise, the twirled circuits will not wrap the
         noise on these gates.
 
     Returns:
@@ -80,25 +96,39 @@ def pauli_twirl_circuit(
         twirl_CZ_gates(c, num_circuits=1)[0] for c in CNOT_twirled_circuits
     ]
 
-    if noise_op is not None:
+    if noise_name is not None:
         twirled_circuits = [
-            add_noise_to_two_qubit_gates(circuit, noise_op)
+            add_noise_to_two_qubit_gates(circuit, noise_name, **kwargs)
             for circuit in twirled_circuits
         ]
 
     return twirled_circuits
 
 
-@accept_qprogram_and_validate
 def add_noise_to_two_qubit_gates(
-    circuit: cirq.Circuit, noise_op: cirq.Gate
-) -> cirq.Circuit:
+    circuit: QPROGRAM, noise_name: str, **kwargs
+) -> QPROGRAM:
     """Add noise to CNOT and CZ gates on pre-twirled circuits.
 
     Args:
         circuit: Pre-twirled circuit
-        noise_op: noise operator to apply after CNOT and CZ gates
+        noise_name: name of noise operator to apply after CNOT and CZ gates
     """
+    # here we will validate if noise_op and kwargs are valid
+    return _add_noise_to_two_qubit_gates(circuit, noise_name, **kwargs)
+
+
+@singledispatch
+def _add_noise_to_two_qubit_gates(circuit, noise_name, **kwargs):
+    raise NotImplementedError(
+        f"Cannot add noise to Circuit of type {type(circuit)}."
+    )
+
+
+@_add_noise_to_two_qubit_gates.register
+def _cirq(circuit: _Circuit, noise_name: str, **kwargs):
+    noise_function = CIRQ_NOISE_OP[noise_name]
+    noise_op = noise_function(**kwargs)
 
     noisy_gates = [cirq.ops.CNOT, cirq.ops.CZ]
 
@@ -111,6 +141,24 @@ def add_noise_to_two_qubit_gates(
                 layer.append(noise_op.on_each(op.qubits))
         noisy_circuit += layer
     return noisy_circuit
+
+
+@_add_noise_to_two_qubit_gates.register
+def _pennylane(circuit: QuantumTape, noise_name: str, **kwargs):
+    new_ops = []
+    noise_function = PENNYLANE_NOISE_OP[noise_name]
+
+    noisy_gates = ["CNOT", "CZ"]
+    for op in circuit:
+        new_ops.append(op)
+        if op.name in noisy_gates:
+            for wire in op.wires:
+                noise_op = noise_function(**kwargs, wires=wire)
+                new_ops.append(noise_op)
+
+    return QuantumTape(
+        ops=new_ops, measurements=circuit.measurements, shots=circuit.shots
+    )
 
 
 def twirl_CNOT_gates(circuit: QPROGRAM, num_circuits: int) -> List[QPROGRAM]:

--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -93,7 +93,12 @@ def pauli_twirl_circuit(
 def add_noise_to_two_qubit_gates(
     circuit: cirq.Circuit, noise_op: cirq.Gate
 ) -> cirq.Circuit:
-    """Add noise to CNOT and CZ gates."""
+    """Add noise to CNOT and CZ gates on pre-twirled circuits.
+
+    Args:
+        circuit: Pre-twirled circuit
+        noise_op: noise operator to apply after CNOT and CZ gates
+    """
 
     noisy_gates = [cirq.ops.CNOT, cirq.ops.CZ]
 

--- a/mitiq/pt/tests/test_pt.py
+++ b/mitiq/pt/tests/test_pt.py
@@ -144,3 +144,20 @@ def test_no_CNOT_CZ_circuit(twirl_func):
 
     for i in range(5):
         assert _equal(circuit, twirled_output[i])
+
+
+@pytest.mark.parametrize(
+    "noise_op", [cirq.bit_flip(p=0.1), cirq.depolarize(p=0.01)]
+)
+def test_noisy_CNOT_CZ_circuit(noise_op):
+    a, b = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(cirq.H.on(a), cirq.CNOT.on(a, b), cirq.CZ.on(a, b))
+    twirled_circuit = pauli_twirl_circuit(
+        circuit, num_circuits=1, noise_op=noise_op
+    )[0]
+
+    for i, current_moment in enumerate(twirled_circuit):
+        for op in current_moment:
+            if op.gate in [cirq.CNOT, cirq.CZ]:
+                for next_op in twirled_circuit[i + 1]:
+                    assert next_op.gate == noise_op

--- a/mitiq/pt/tests/test_pt.py
+++ b/mitiq/pt/tests/test_pt.py
@@ -8,13 +8,16 @@ import random
 import cirq
 import networkx as nx
 import numpy as np
+import pennylane as qml
 import pytest
 import qiskit
+from pennylane.tape import QuantumTape
 
 from mitiq.benchmarks import generate_mirror_circuit
 from mitiq.interface.mitiq_cirq import compute_density_matrix
 from mitiq.pt.pt import (
     CIRQ_NOISE_OP,
+    PENNYLANE_NOISE_OP,
     CNOT_twirling_gates,
     CZ_twirling_gates,
     pauli_twirl_circuit,
@@ -148,7 +151,7 @@ def test_no_CNOT_CZ_circuit(twirl_func):
 
 
 @pytest.mark.parametrize("noise_name", ["bit-flip", "depolarize"])
-def test_noisy_CNOT_CZ_circuit(noise_name):
+def test_noisy_cirq(noise_name):
     p = 0.01
     a, b = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(cirq.H.on(a), cirq.CNOT.on(a, b), cirq.CZ.on(a, b))
@@ -161,3 +164,27 @@ def test_noisy_CNOT_CZ_circuit(noise_name):
             if op.gate in [cirq.CNOT, cirq.CZ]:
                 for next_op in twirled_circuit[i + 1]:
                     assert next_op.gate == CIRQ_NOISE_OP[noise_name](p=p)
+
+
+@pytest.mark.parametrize("noise_name", ["bit-flip", "depolarize"])
+def test_noisy_pennylane(noise_name):
+    p = 0.01
+    ops = [
+        qml.Hadamard(0),
+        qml.CNOT((0, 1)),
+        qml.CZ((0, 1)),
+    ]
+    circuit = QuantumTape(ops)
+    twirled_circuit = pauli_twirl_circuit(
+        circuit, num_circuits=1, noise_name=noise_name, p=p
+    )[0]
+
+    noisy_gates = ["CNOT", "CZ"]
+
+    for i, op in enumerate(twirled_circuit.operations):
+        if op.name in noisy_gates:
+            for j in range(1, len(op.wires) + 1):
+                assert (
+                    type(twirled_circuit.operations[i + j])
+                    == PENNYLANE_NOISE_OP[noise_name]
+                )


### PR DESCRIPTION

## Description

Currently, the `pauli_twirl_circuit` function does not wrap correctly noise applied on CNOT and CZ gates when used in a simulator. Instead, it adds the twirled operators in between the noise and the two-qubit gates.

This PR implements an argument in `pauli_twirl_circuit` to pass a `noise_op` acting between CNOT/CZ gates and the twirled layers. Thus, it allows to properly Taylor the noise using Pauli Twirling on a simulated backend. 

Example:

Circuit without noise:
```python
0: ───H───@───@───
          │   │
1: ───────X───@───
```

Pauli Twirling before this PR:

```python
0: ───H────I───@───I───D(0.01)───I───@───Z───D(0.01)───
               │                     │
1: ────────X───X───X───D(0.01)───Y───@───Y───D(0.01)───
```

Pauli Twirling after this PR:

```python
0: ───H───I───@───D(0.01)───I───I───@───D(0.01)───Z───
              │                     │
1: ───────X───X───D(0.01)───X───Y───@───D(0.01)───Y────
```

Contribution as part of the Unitary Hack 2024

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Closes [#2346]
