### PR TITLE
Issue #2354 Fix - qiskit QFT gates error during conversion

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,3 +58,4 @@ Yash Prabhat
 Vladimir Kozhukalov
 Francesc Sabater
 Emiliano Godinez
+Tommy Nguyen

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -253,6 +253,8 @@ def from_qiskit(circuit: qiskit.QuantumCircuit) -> cirq.Circuit:
         mitiq_circuit = from_qasm(qasm2.dumps(circuit))
     except QasmException:
         # Try to decompose circuit before running
+        # This is necessary for converting qiskit circuits with
+        # custom packaged gates, e.g., QFT gates
         circuit = circuit.decompose()
         mitiq_circuit = from_qasm(qasm2.dumps(circuit))
     return mitiq_circuit

--- a/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -203,6 +203,27 @@ def test_random_circuit_to_from_qasm():
     )
 
 
+def test_qft_circuit_from_qasm():
+    """Tests QASM string --> cirq.Circuit
+    with a qft of 1 qubit.
+    """
+    qft_string = """
+OPENQASM 2.0;
+include "qelib1.inc";
+gate gate_QFT q0 { h q0; }
+qreg q[1];
+creg meas[1];
+gate_QFT q[0];
+measure q[0] -> meas[0];
+"""
+    qft_cirq = from_qasm(qft_string)
+    qreg = cirq.LineQubit.range(1)
+    cirq_circuit = cirq.Circuit(
+        [cirq.ops.H.on(qreg[0]), cirq.ops.measure(qreg[0], key="meas")]
+    )
+    assert _equal(cirq_circuit, qft_cirq)
+
+
 @pytest.mark.parametrize("as_qasm", (True, False))
 def test_convert_with_barrier(as_qasm):
     """Tests converting a Qiskit circuit with a barrier to a Cirq circuit."""

--- a/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -203,20 +203,12 @@ def test_random_circuit_to_from_qasm():
     )
 
 
-def test_qft_circuit_from_qasm():
-    """Tests QASM string --> cirq.Circuit
-    with a qft of 1 qubit.
-    """
-    qft_string = """
-OPENQASM 2.0;
-include "qelib1.inc";
-gate gate_QFT q0 { h q0; }
-qreg q[1];
-creg meas[1];
-gate_QFT q[0];
-measure q[0] -> meas[0];
-"""
-    qft_cirq = from_qasm(qft_string)
+def test_convert_with_qft():
+    """Tests converting a Qiskit circuit with a QFT to a Cirq circuit."""
+    circuit = qiskit.QuantumCircuit(1)
+    circuit &= qiskit.circuit.library.QFT(1)
+    circuit.measure_all()
+    qft_cirq = from_qiskit(circuit)
     qreg = cirq.LineQubit.range(1)
     cirq_circuit = cirq.Circuit(
         [cirq.ops.H.on(qreg[0]), cirq.ops.measure(qreg[0], key="meas")]

--- a/mitiq/zne/tests/test_zne.py
+++ b/mitiq/zne/tests/test_zne.py
@@ -12,6 +12,7 @@ import cirq
 import numpy as np
 import pytest
 import qiskit
+import qiskit.circuit
 from qiskit_aer import AerSimulator
 
 from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES
@@ -540,3 +541,22 @@ def test_execute_with_zne_transpiled_qiskit_circuit():
     # Note: Unmitigated value is also (usually) within 10% of the true value.
     # This is more to test usage than effectiveness.
     assert abs(zne_value - true_value) < 0.1
+
+
+def test_execute_zne_transpiled_qiskit_circuit_with_noise_and_QFT():
+    """Tests ZNE when transpiling to a Qiskit device with a QFT gate."""
+
+    def qs_noisy_simulation(
+        circuit: qiskit.QuantumCircuit, shots: int = 1
+    ) -> float:
+        noise_model = initialized_depolarizing_noise(noise_level=0.02)
+        backend = AerSimulator(noise_model=noise_model)
+        job = backend.run(circuit.decompose(), shots=shots)
+        return job.result().get_counts().get("0", 0.0) / shots
+
+    circuit = qiskit.QuantumCircuit(1)
+    circuit &= qiskit.circuit.library.QFT(1)
+    circuit.measure_all()
+
+    mitigated = execute_with_zne(circuit, qs_noisy_simulation)
+    assert abs(mitigated) < 1000

--- a/mitiq/zne/tests/test_zne.py
+++ b/mitiq/zne/tests/test_zne.py
@@ -543,8 +543,8 @@ def test_execute_with_zne_transpiled_qiskit_circuit():
     assert abs(zne_value - true_value) < 0.1
 
 
-def test_execute_zne_transpiled_qiskit_circuit_with_noise_and_QFT():
-    """Tests ZNE when transpiling to a Qiskit device with a QFT gate."""
+def test_execute_zne_on_qiskit_circuit_with_QFT():
+    """Tests ZNE of a Qiskit device with a QFT gate."""
 
     def qs_noisy_simulation(
         circuit: qiskit.QuantumCircuit, shots: int = 1


### PR DESCRIPTION
fixes issue #2354 where a QFT qiskit circuit would error out during conversion. Implemented a fallback mechanism to decompose and transpile the qiskit circuit into native gates. Added a unit test in the ZNE module to test this with qiskit's QFT gate. 

This is my first open source contribution via unitary hack so any feedback would be appreciated! 
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->

---

### License

- [ x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [x ] I added unit tests for new code.
- [ x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x ] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ x] Added myself / the copyright holder to the AUTHORS file
