### PR TITLE
Update README with Github discussion link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Error mitigation seeks to reduce these effects at the software level by
 compiling quantum programs in clever ways.
 
 Want to know more? Check out our
-[documentation](https://mitiq.readthedocs.io/en/stable/guide/guide.html), chat with us on [Discord](http://discord.unitary.fund), and join our weekly community call ([public agenda](https://docs.google.com/document/d/1lZfct4AOCS7fdyWkudcGyER0n0nsCxSFKSicUEeJgtA/)).
+[documentation](https://mitiq.readthedocs.io/en/stable/guide/guide.html), chat with us on [Discord](http://discord.unitary.fund), open a [Github Discussion](https://github.com/unitaryfund/mitiq/discussions), and join our weekly community call ([public agenda](https://docs.google.com/document/d/1lZfct4AOCS7fdyWkudcGyER0n0nsCxSFKSicUEeJgtA/)).
 
 ## Quickstart
 


### PR DESCRIPTION
## Description
fixes #2418 

This adds the Github discussion link to the main README page.

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.