### PR TITLE
Hide primary sidebar from certain pages of the documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,8 +100,8 @@ extensions = [
     "sphinx_gallery.load_style",
 ]
 
-# hide primary sidebar from apidoc page
-html_sidebars = {"apidoc": []}
+# hide primary sidebar from the following pages
+html_sidebars = {"apidoc": [], "changelog": [], "bibliography": []}
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.9", None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,6 +100,11 @@ extensions = [
     "sphinx_gallery.load_style",
 ]
 
+# hide primary sidebar from apidoc page
+html_sidebars = {
+  "apidoc": []
+}
+
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.9", None),
     "numpy": ("https://numpy.org/doc/stable/", None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -101,9 +101,7 @@ extensions = [
 ]
 
 # hide primary sidebar from apidoc page
-html_sidebars = {
-  "apidoc": []
-}
+html_sidebars = {"apidoc": []}
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.9", None),


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description
Remove the left sidebar from `API-doc`, `Changelog`, and `References` because the primary sidebar is blank. 

Related to #2331 where we want to hide the blank sidebar on the left for some pages of the documentation. 

Note that the behavior from https://github.com/unitaryfund/mitiq/issues/2405#issuecomment-2183583772 is still present even if we hide the primary sidebar. 

This is not fixable by `navigation_with_keys=False` which makes me think the behavior from the screencast is unrelated to #2405 

https://github.com/unitaryfund/mitiq/assets/66048318/7cef51f8-f2c7-4276-80fd-a12c23700685

---

### License

- [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file
