### PR TITLE
bump min python version for intersphinx map

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -101,7 +101,7 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.9", None),
+    "python": ("https://docs.python.org/3.10", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     # Cirq is no longer using sphinx docs so interlinking is not possible.


### PR DESCRIPTION
missed this in https://github.com/unitaryfund/mitiq/pull/2066. does what it says on the 🥫.