### PR TITLE
set version variable and pass it on

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -12,6 +12,8 @@ jobs:
     name: Build Mitiq
     if: github.repository_owner == 'unitaryfund'
     runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.export-version.outputs.VERSION }}
     steps:
       - name: Check out mitiq
         uses: actions/checkout@v4
@@ -23,6 +25,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install build
+      - name: Export version variable
+        id: export-version
+        run: echo "VERSION=$(cat VERSION.txt)" >> "$GITHUB_OUTPUT"
       - name: Build mitiq
         run: python -m build
       - name: Store build artifacts
@@ -52,22 +57,19 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
   verify-version:
-    needs: test-publish
+    needs: [build, test-publish]
     runs-on: ubuntu-latest
     environment: testpypi
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install package from TestPyPI
         run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.python.org/simple/ mitiq
-      - name: Set version variable
-        run: |
-          VER=$(cat VERSION.txt)
-          echo "VERSION=$VER" >> $GITHUB_ENV
-
       - name: Verify the published version
+        env:
+          VERSION: ${{ needs.build.outputs.VERSION }}
         run: |
           TEST_IMPORT_VERSION=$(python -c "import mitiq; print(mitiq.__version__)")
           if [ "$TEST_IMPORT_VERSION" != "$VERSION" ]; then


### PR DESCRIPTION
## Description

The upload to testpypi action is failing at the last stage where it compares the downloaded version against what's in `VERSION.txt`. This is because Mitiq is (rightfully) not checked out when downloading Mitiq from testpypi. Details [here](https://github.com/unitaryfund/mitiq/actions/runs/9705189820/job/26786831916#step:4:13). To fix this I've set a `VERSION` variable when Mitiq is checked out and passed the data to the verify version portion of the action.

I have a concern that even though the first two stages passed, the uploaded version seems to be [`0.38.0.dev0`](https://test.pypi.org/project/mitiq/0.38.0.dev0/) (with an extra 0 on the end). Hence even if this works, we might still have a problem.