### PR TITLE
make upload versions unique for TestPyPI

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -23,6 +23,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install build
+      - name: change mitiq version
+        run: |
+          truncate -s -1 VERSION.txt
+          echo "$(date +"%Y%m%d")" >> VERSION.txt
       - name: Build mitiq
         run: python -m build
       - name: Store build artifacts
@@ -50,27 +54,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-
-  verify-version:
-    needs: test-publish
-    runs-on: ubuntu-latest
-    environment: testpypi
-    steps:
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install package from TestPyPI
-        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.python.org/simple/ mitiq
-      - name: Set version variable
-        run: |
-          VER=$(cat VERSION.txt)
-          echo "VERSION=$VER" >> $GITHUB_ENV
-
-      - name: Verify the published version
-        run: |
-          TEST_IMPORT_VERSION=$(python -c "import mitiq; print(mitiq.__version__)")
-          if [ "$TEST_IMPORT_VERSION" != "$VERSION" ]; then
-            echo "Imported version $TEST_IMPORT_VERSION does not match tag $VERSION"
-            exit 1
-          fi


### PR DESCRIPTION
## Description

TestPyPI uploads are failing (again) because once a version is uploaded with a specific version specifier (say 0.38.0dev), another with the same version **cannot** be uploaded. To work around this, we added a date the end of the `VERSION.txt` file so each upload is unique. We also removed the `verify-version` portion of the action since as long as the upload passes, this gives us enough confidence that our workflow is effective.