### PR TITLE
Separate docs build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,52 +34,6 @@ jobs:
       - name: Check code style/formatting
         run: make check-format
 
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out mitiq
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          make install requirements
-
-      - name: Run the quilc & qvm Docker images
-        run: |
-          docker run --rm -idt -p 5000:5000 rigetti/qvm -S
-          docker run --rm -idt -p 5555:5555 rigetti/quilc -R
-
-      - name: Generate hash from all files excluding example notebooks
-        id: gen_hash
-        run: |
-          HASH=$(find . -type f -not -path './docs/source/examples/*' | sort | xargs cat | sha256sum | awk '{print $1}')
-          echo "hash=$HASH" >> $GITHUB_OUTPUT
-
-      - name: Fetch Jupyter cache
-        uses: actions/cache@v4
-        with:
-          path: ./docs/build/.jupyter_cache
-          key: jupyter-cache-${{ steps.gen_hash.outputs.hash }}
-
-      - name: Build and test Sphinx docs
-        run: |
-          export BQSKIT_DOC_CHECK_OVERRIDE=1
-          export PYDEVD_DISABLE_FILE_VALIDATION=1
-          make docs
-
-      - name: Run linkcheck on 'release' PRs
-        if: github.event_name == 'pull_request'
-        run: |
-          pr_title_lower=$(echo "${{ github.event.pull_request.title }}" | tr '[:upper:]' '[:lower:]')
-          if [[ "$pr_title_lower" == *"release"* ]]; then
-            make linkcheck
-          fi
 
   # This is to make sure Mitiq works without optional 3rd party packages like Qiskit, pyQuil, etc.
   # E.g., if we accidentally `import qiskit` in Mitiq where we shouldn't, this test will catch that.

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          make install requirements
+          make install
 
       - name: Run the quilc & qvm Docker images
         run: |

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,62 @@
+name: docs-build
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out mitiq
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make install requirements
+
+      - name: Run the quilc & qvm Docker images
+        run: |
+          docker run --rm -idt -p 5000:5000 rigetti/qvm -S
+          docker run --rm -idt -p 5555:5555 rigetti/quilc -R
+
+      - name: Generate hash from all files excluding example notebooks
+        id: gen_hash
+        run: |
+          HASH=$(find . -type f -not -path './docs/source/examples/*' | sort | xargs cat | sha256sum | awk '{print $1}')
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+
+      - name: Fetch Jupyter cache
+        uses: actions/cache@v4
+        with:
+          path: ./docs/build/.jupyter_cache
+          key: jupyter-cache-${{ steps.gen_hash.outputs.hash }}
+
+      - name: Build and test Sphinx docs
+        run: |
+          export BQSKIT_DOC_CHECK_OVERRIDE=1
+          export PYDEVD_DISABLE_FILE_VALIDATION=1
+          make docs
+
+      - name: Run linkcheck on 'release' PRs
+        if: github.event_name == 'pull_request'
+        run: |
+          pr_title_lower=$(echo "${{ github.event.pull_request.title }}" | tr '[:upper:]' '[:lower:]')
+          if [[ "$pr_title_lower" == *"release"* ]]; then
+            make linkcheck
+          fi


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

As discussed during the community call today, this PR splits the docs build job into a separate workflow. This makes it easier for us to rerun pytest related jobs without waiting for the docs build to be completed. 

After this PR is merged, #2437 will be rebased. 

---

### License

- [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file
