### PR TITLE
git ignore all coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .vscode
 .python-version
 .idea/
-.coverage
 *.dat
 *.ipynb
 *.hdf5
@@ -14,5 +13,9 @@ docs/build/
 mitiq.egg-info/
 dist/
 build/
-coverage.xml
 jupyter_execute/
+
+# Coverage reports
+coverage.xml
+.coverage
+.coverage.*

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 	rm -rf dist
 	rm -rf mitiq.egg-info
 	rm -rf .mypy_cache .pytest_cache .ruff_cache
-	rm -rf htmlcov coverage.xml .coverage
+	rm -rf htmlcov coverage.xml .coverage .coverage.*
 	rm -rf .ipynb_checkpoints
 
 .PHONY: dist


### PR DESCRIPTION
E.g. coverage reports with filename `.coverage.Alessandros-MacBook.local.*` are not git ignored at the moment.