### PR TITLE
fix docstring formatting

### DIFF
--- a/mitiq/zne/zne.py
+++ b/mitiq/zne/zne.py
@@ -23,7 +23,7 @@ def scaled_circuits(
 
     Args:
         circuit: The input circuit to execute with ZNE.
-        scale_factors: A list of ``float``s to scale the circuit with.
+        scale_factors: An array of noise scale factors.
         scale_method: The function for scaling the noise of a quantum circuit.
             A list of built-in functions can be found in ``mitiq.zne.scaling``.
 
@@ -47,9 +47,8 @@ def combine_results(
     of zero-noise extrapolation (ZNE).
 
     Args:
-        scale_factors: A list of ``float``s to scale the circuit with.
-        results: A list of ``float``s that is the result of applying an
-            executor to the scaled circuits.
+        scale_factors: An array of noise scale factors.
+        results: An array storing the results of running the scaled circuits.
         extrapolation_method: The function for scaling the noise of a
             quantum circuit. A list of built-in functions can be found
             in ``mitiq.zne.scaling``.


### PR DESCRIPTION
## Description

TIL "string literals" (sphinx's name for inline code formatted text: `like this`) must be separated by whitespace, or punctuation. Hence **``` ``float``s ```** is invalid, according to sphinx.

### Postmortem

@FarLab merged https://github.com/unitaryfund/mitiq/pull/2452 while the docs build was failing. Normally it is okay to merge PRs that have a failure when the issue is a flaky test and is unrelated to the PR, but in this instance it should not have been merged until the documentation built successfully. Not a big deal by any means, just something to be mindful of in the future.