### PR TITLE
execute_with_cdr does not use seed but random_state

### DIFF
--- a/docs/source/guide/cdr-1-intro.md
+++ b/docs/source/guide/cdr-1-intro.md
@@ -138,7 +138,7 @@ mitigated_expval = cdr.execute_with_cdr(
     compute_density_matrix,
     observable=obs,
     simulator=simulate,
-    seed=0,
+    random_state=0,
 ).real
 print(f"mitigated expectation value: {mitigated_expval:.2f}")
 ```


### PR DESCRIPTION
## Description

In the CDR section of the User Guide, the `execute_with_cdr` example includes the parameter `seed` which should be `random_state` [per the cdr.py file](https://github.com/unitaryfund/mitiq/blob/af7b992b3be15d9560a8adda698e729e7e17c933/mitiq/cdr/cdr.py#L93)

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.