### PR TITLE
fix extension tag in Qibo tutorial

### DIFF
--- a/docs/source/examples/qibo-noisy-simulation.md
+++ b/docs/source/examples/qibo-noisy-simulation.md
@@ -1,7 +1,7 @@
 ---
 jupytext:
   text_representation:
-    extension: .myst
+    extension: .md
     format_name: myst
     format_version: 0.13
     jupytext_version: 1.11.1


### PR DESCRIPTION
With the wrong extension value, `jupytext` doesn't convert the file to ipynb correctly. 