### PR TITLE
Raise TypeError when a dictionary is passed to MeasurementResult constructor

### DIFF
--- a/mitiq/tests/test_measurement_result.py
+++ b/mitiq/tests/test_measurement_result.py
@@ -38,6 +38,11 @@ def test_measurement_result_not_bits():
         MeasurementResult(result=[[0, 0], [0, 1], [-1, 0]])
 
 
+def test_measurement_result_invoked_with_dict():
+    with pytest.raises(TypeError, match="from_counts"):
+        MeasurementResult({"001": 123, "010": 456})
+
+
 def test_filter_qubits():
     result = MeasurementResult([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
     assert np.allclose(result.filter_qubits([0]), np.array([[0], [0], [1]]))

--- a/mitiq/tests/test_typing.py
+++ b/mitiq/tests/test_typing.py
@@ -1,3 +1,8 @@
+# Copyright (C) Unitary Fund
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 
 from mitiq.typing import SUPPORTED_PROGRAM_TYPES

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -112,6 +112,11 @@ class MeasurementResult:
             ``tuple(range(self.nqubits))``, where ``self.nqubits``
             is the bitstring length deduced from ``result``.
 
+    Example:
+        >>> mr = MeasurementResult(["001", "010", "001"])
+        >>> mr.get_counts()
+        {'001': 2, '010': 1}
+
     Note:
         Use caution when selecting the default option for ``qubit_indices``,
         especially when estimating an :class:`.Observable`

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -125,6 +125,11 @@ class MeasurementResult:
 
     def __post_init__(self) -> None:
         # Validate arguments
+        if isinstance(self.result, dict):
+            raise TypeError(
+                "Use the MeasurementResult.from_counts method to instantiate "
+                "a MeasurementResult object from a dictionary."
+            )
         symbols = set(b for bits in self.result for b in bits)
         if not (symbols.issubset({0, 1}) or symbols.issubset({"0", "1"})):
             raise ValueError("Bitstrings should look like '011' or [0, 1, 1].")

--- a/mitiq/typing.py
+++ b/mitiq/typing.py
@@ -117,7 +117,7 @@ class MeasurementResult:
         >>> mr.get_counts()
         {'001': 2, '010': 1}
 
-    Note:
+    Warning:
         Use caution when selecting the default option for ``qubit_indices``,
         especially when estimating an :class:`.Observable`
         acting on a subset of qubits. In this case Mitiq


### PR DESCRIPTION
**Motivation**: Multiple students at the UMass Amherst summer school attempted to pass a dictionary to instantiate a `MeasurementResult` object while working through the [challenges](https://github.com/unitaryfund/qnumerics/blob/main/challenge.ipynb). This silently accepts, but provides erroneous results. E.g.:
```py
>>> from mitiq import MeasurementResult
>>> MeasurementResult({'001': 23, '000': 43})
MeasurementResult: {'nqubits': 3, 'qubit_indices': (0, 1, 2), 'shots': 2, 'counts': {'001': 1, '000': 1}}
```

**Considerations**: I could see the following two potential solutions to help with this issue.

1. Add a typecheck at runtime and raise a [`TypeError`](https://docs.python.org/3/library/exceptions.html#TypeError), letting the user know we have a method `MeasurementResult.from_counts` for this specific pattern.
2. Call `MeasurementResult.from_counts` in the `__post_init__` method to **re-instantiate** `self`.

I chose to raise solution 1 as it seems to be a simple approach to address the problem. Admittedly, I am less familiar with the technical details of re-instantiating an object within the `__post_init__` function, but happy to test that out if reviewers think it is more appropriate.