### PR TITLE
Remove bot greeting for issues

### DIFF
--- a/.github/workflows/greeting.yml
+++ b/.github/workflows/greeting.yml
@@ -10,6 +10,3 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         pr-message:  'Hello @${{ github.actor }}, thank you for submitting a PR to Mitiq! We will respond as soon as possible, and if you have any questions in the meantime, you can ask us on the [Unitary Fund Discord](http://discord.unitary.fund).'
-        issue-message: |
-          Hello @${{ github.actor }}, thank you for your interest in Mitiq!
-          If this is a bug report, please provide screenshots and/or **minimum viable code to reproduce your issue**, so we can do our best to help get it fixed. If you have any questions in the meantime, you can also ask us on the [Unitary Fund Discord](http://discord.unitary.fund).


### PR DESCRIPTION
## Description

The bot message is redundant to the information we have in the [issue templates](https://github.com/unitaryfund/mitiq/tree/411e234894eb6329783d032dc12c144d89b99f12/.github/ISSUE_TEMPLATE).


**History**: Originally raised in discussion post https://github.com/unitaryfund/mitiq/discussions/2473, and discussed at the Mitiq community call with no strong feelings either way. I feel strong enough to remove it 🌞.