### PR TITLE
Refactor ghz_Circuits Error Handling and Update Random Generator in mirror_circuits

### DIFF
--- a/mitiq/benchmarks/ghz_circuits.py
+++ b/mitiq/benchmarks/ghz_circuits.py
@@ -32,7 +32,7 @@ def generate_ghz_circuit(
     """
     if n_qubits <= 0:
         raise ValueError(
-            "Cannot prepare a GHZ circuit with {} qubits", n_qubits
+             f"Cannot prepare a GHZ circuit with {n_qubits} qubits"
         )
 
     qubits = cirq.LineQubit.range(n_qubits)

--- a/mitiq/benchmarks/mirror_circuits.py
+++ b/mitiq/benchmarks/mirror_circuits.py
@@ -23,7 +23,7 @@ paulis = [cirq.X, cirq.Y, cirq.Z, cirq.I]
 
 
 def random_paulis(
-    connectivity_graph: nx.Graph, random_state: random.RandomState
+    connectivity_graph: nx.Graph, random_state: random.Generator
 ) -> cirq.Circuit:
     """Returns a circuit with randomly selected Pauli gates on each qubit.
 
@@ -33,7 +33,7 @@ def random_paulis(
             random.
     """
     return cirq.Circuit(
-        paulis[random_state.randint(len(paulis))](cirq.LineQubit(x))
+        paulis[random_state.integers(len(paulis))](cirq.LineQubit(x))
         for x in connectivity_graph.nodes
     )
 
@@ -41,7 +41,7 @@ def random_paulis(
 def edge_grab(
     two_qubit_gate_prob: float,
     connectivity_graph: nx.Graph,
-    random_state: random.RandomState,
+    random_state: random.Generator,
 ) -> nx.Graph:
     """
     Args:
@@ -63,7 +63,7 @@ def edge_grab(
     final_edges.add_nodes_from(connectivity_graph)
 
     while connectivity_graph.edges:
-        num = random_state.randint(connectivity_graph.size())
+        num = random_state.integers(connectivity_graph.size())
         edges = list(connectivity_graph.edges)
         curr_edge = edges[num]
         candidate_edges.add_edge(*curr_edge)
@@ -77,7 +77,7 @@ def edge_grab(
 
 def random_cliffords(
     connectivity_graph: nx.Graph,
-    random_state: random.RandomState,
+    random_state: random.Generator,
     two_qubit_gate: cirq.Gate = cirq.CNOT,
 ) -> cirq.Circuit:
     """
@@ -105,7 +105,7 @@ def random_cliffords(
 
 
 def random_single_cliffords(
-    connectivity_graph: nx.Graph, random_state: random.RandomState
+    connectivity_graph: nx.Graph, random_state: random.Generator
 ) -> cirq.Circuit:
     """
     Args:
@@ -119,7 +119,7 @@ def random_single_cliffords(
     """
     gates: List[cirq.Operation] = []
     for qubit in connectivity_graph.nodes:
-        num = random_state.randint(len(cliffords))
+        num = random_state.integers(len(cliffords))
         for clifford_gate in cliffords[num]:
             gates.append(clifford_gate(cirq.LineQubit(qubit)))
     return cirq.Circuit(gates)
@@ -164,7 +164,7 @@ def generate_mirror_circuit(
         )
     two_qubit_gate = supported_two_qubit_gates[two_qubit_gate_name]
 
-    random_state = random.RandomState(seed)
+    random_state = random.default_rng(seed)
 
     single_qubit_cliffords = random_single_cliffords(
         connectivity_graph, random_state=random_state

--- a/mitiq/benchmarks/randomized_benchmarking.py
+++ b/mitiq/benchmarks/randomized_benchmarking.py
@@ -57,7 +57,7 @@ def generate_rb_circuits(
         )
     qubits = cirq.LineQubit.range(n_qubits)
     cliffords = _single_qubit_cliffords()
-    rng = np.random.RandomState(seed)
+    rng = np.random.default_rng(seed)
     if n_qubits == 1:
         c1 = cliffords.c1_in_xy
         circuits = []

--- a/mitiq/benchmarks/randomized_clifford_t_circuit.py
+++ b/mitiq/benchmarks/randomized_clifford_t_circuit.py
@@ -41,14 +41,14 @@ def generate_random_clifford_t_circuit(
 
     if num_qubits <= 0:
         raise ValueError(
-            "Cannot prepare a circuit with {} qubits.", num_qubits
+            f"Cannot prepare a circuit with {num_qubits} qubits.", 
         )
     elif num_qubits == 1 and num_twoq_cliffords > 0:
         raise ValueError(
             "Need more than 2 qubits for two-qubit Clifford gates."
         )
 
-    rnd_state = np.random.RandomState(seed)
+    rnd_state = np.random.default_rng(seed)
 
     oneq_cliffords = [cirq.S, cirq.H]
     twoq_cliffords = [cirq.CNOT, cirq.CZ]

--- a/mitiq/benchmarks/w_state_circuits.py
+++ b/mitiq/benchmarks/w_state_circuits.py
@@ -30,7 +30,7 @@ def generate_w_circuit(
         A W-state circuit of linear complexity acting on ``n_qubits`` qubits.
     """
     if n_qubits <= 0:
-        raise ValueError("{} is invalid for the number of qubits. ", n_qubits)
+        raise ValueError(f"{n_qubits} is invalid for the number of qubits. ")
 
     qubits = cirq.LineQubit.range(n_qubits)
     circuit = cirq.Circuit()

--- a/mitiq/cdr/clifford_utils.py
+++ b/mitiq/cdr/clifford_utils.py
@@ -45,7 +45,7 @@ def count_non_cliffords(circuit: Circuit) -> int:
 
 
 def random_clifford(
-    num_angles: int, random_state: np.random.RandomState
+    num_angles: int, random_state: np.random.Generator
 ) -> npt.NDArray[np.float64]:
     """Returns an array of Clifford angles chosen uniformly at random.
 
@@ -63,7 +63,7 @@ def closest_clifford(angles: npt.NDArray[np.float64]) -> float:
     """Returns the nearest Clifford angles to the input angles.
 
     Args:
-        non_Clifford_ops: Non-Clifford opperations.
+        non_Clifford_ops: Non-Clifford operations.
     """
     ang_scaled = angles / (np.pi / 2)
     # if just one min value, return the corresponding nearest cliff.
@@ -144,7 +144,7 @@ def angle_to_proximity(angle: float, sigma: float) -> float:
 def probabilistic_angle_to_clifford(
     angles: float,
     sigma: float,
-    random_state: np.random.RandomState,
+    random_state: np.random.Generator,
 ) -> npt.NDArray[np.float64]:
     """Returns a Clifford angle sampled from the distribution
 


### PR DESCRIPTION
Update GHZ Circuit Preparation and Mirror Circuit Random Generator

### Changes:
1. **Modified GHZ Circuits** (`mitiq/benchmarks/ghz_circuits.py`)
   - **Old Code**: 
     ```python
     raise ValueError("Cannot prepare a GHZ circuit with {} qubits" , n_qubits)
     ```
   - **New Code**: 
     ```python
     raise ValueError(f"Cannot prepare a GHZ circuit with {n_qubits} qubits")
     ```
   - **Description**: Updated the error message to use f-string formatting for better clarity and consistency.

2. **Modified Mirror Circuits** (`mitiq/benchmarks/mirror_circuits.py`)
   - **Old Code**:
     ```python
     random_state = random.RandomState(seed)
     ```
   - **New Code**:
     ```python
     random_state = random.default_rng(seed)
     ```
   - **Description**: Replaced `RandomState` with `default_rng()` to utilize the modern NumPy random number generator, improving randomness quality and performance.

### Summary:
- Enhanced error messaging in GHZ circuit preparation.
- Updated the random generator method in mirror circuits for better randomness and performance.

