### PR TITLE
remove failing test; simplify layerwise ZNE tests

### DIFF
--- a/mitiq/lre/tests/test_lre.py
+++ b/mitiq/lre/tests/test_lre.py
@@ -101,20 +101,6 @@ def test_lre_executor_with_chunking():
     assert abs(lre_exp_val - ideal_val) <= abs(noisy_val - ideal_val)
 
 
-@pytest.mark.parametrize("num_chunks", [(1), (2), (3), (4), (5), (6), (7)])
-def test_large_circuit_with_small_chunks_poor_performance(num_chunks):
-    """Verify chunking performs poorly when a large number of layers are
-    chunked into a smaller number of circuit chunks."""
-    # define a larger circuit
-    test_cirq = benchmarks.generate_rb_circuits(n_qubits=1, num_cliffords=15)[
-        0
-    ]
-    lre_exp_val = execute_with_lre(
-        test_cirq, execute, degree=2, fold_multiplier=2, num_chunks=num_chunks
-    )
-    assert abs(lre_exp_val - ideal_val) >= abs(noisy_val - ideal_val)
-
-
 @pytest.mark.parametrize("input_method", [(fold_global), (fold_all)])
 def test_lre_executor_with_different_folding_methods(input_method):
     """Verify the executor works as expected for using non-default unitary

--- a/mitiq/zne/scaling/tests/test_layer_scaling.py
+++ b/mitiq/zne/scaling/tests/test_layer_scaling.py
@@ -5,9 +5,16 @@
 
 """Unit tests for scaling by layer."""
 
+import random
+from itertools import product
+from unittest.mock import patch
+
+import pytest
 from cirq import Circuit, LineQubit, ops
 
-from mitiq.zne.scaling import layer_folding
+from mitiq import SUPPORTED_PROGRAM_TYPES
+from mitiq.interface import convert_from_mitiq, convert_to_mitiq
+from mitiq.zne.scaling import get_layer_folding, layer_folding
 
 
 def test_layer_folding_with_measurements():
@@ -53,24 +60,59 @@ def test_layer_folding():
     # Iterate over every possible combination of layerwise folds for a maximum
     # number of 5-folds.
     total_folds = 5
-    for i1 in range(total_folds):
-        for i2 in range(total_folds):
-            for i3 in range(total_folds):
-                layers_to_fold = [i1, i2, i3]
+    for i, j, k in product(range(total_folds), repeat=3):
+        folded_circuit = layer_folding(circ, [i, j, k])
 
-                folded_circuit = layer_folding(circ, layers_to_fold)
+        # For a given layer, the number of copies on a layer will be
+        # 2n + 1 where "n" is the number of folds to perform.
+        a, b, c = LineQubit.range(3)
+        correct = Circuit(
+            # Layer-1
+            [ops.H.on_each(*(a, b, c))] * (2 * i + 1),
+            # Layer-2
+            [ops.CNOT.on(a, b)] * (2 * j + 1),
+            [ops.X.on(c)] * (2 * j + 1),
+            # Layer-3
+            [ops.TOFFOLI.on(*(a, b, c))] * (2 * k + 1),
+        )
+        assert folded_circuit == correct
 
-                # For a given layer, the number of copies on a layer will be
-                # 2n + 1 where "n" is the number of folds to perform.
-                qreg = LineQubit.range(3)
-                correct = Circuit(
-                    # Layer-1
-                    [ops.H.on_each(*qreg)] * (2 * (layers_to_fold[0]) + 1),
-                    # Layer-2
-                    [ops.CNOT.on(qreg[0], qreg[1])]
-                    * (2 * (layers_to_fold[1]) + 1),
-                    [ops.X.on(qreg[2])] * (2 * (layers_to_fold[1]) + 1),
-                    # Layer-3
-                    [ops.TOFFOLI.on(*qreg)] * (2 * (layers_to_fold[2]) + 1),
-                )
-                assert folded_circuit == correct
+
+@pytest.mark.parametrize("circuit_type", SUPPORTED_PROGRAM_TYPES.keys())
+def test_layer_folding_all_qprograms(circuit_type):
+    """This test only ensures proper depth of layer-folded non-cirq circuits
+    as the mitiq conversion functions alter structure/gate composition."""
+    qreg = LineQubit.range(3)
+    circuit = Circuit(
+        [ops.H.on_each(*qreg)],
+        [ops.CNOT.on(qreg[0], qreg[1])],
+        [ops.X.on(qreg[2])],
+        [ops.TOFFOLI.on(*qreg)],
+    )
+    num_layers = len(circuit)
+    circuit = convert_from_mitiq(circuit, circuit_type)
+    layers_to_fold = random.choices(range(5), k=num_layers)
+    folded_circuit = layer_folding(circuit, layers_to_fold)
+    folded_mitiq_circuit = convert_to_mitiq(folded_circuit)[0]
+    num_ideal_layers = sum(2 * n + 1 for n in layers_to_fold)
+    if circuit_type == "pyquil":
+        # this block is needed for pyquil because of some quirks that pop up
+        # when converting to and from pyquil that does not make exact equality.
+        assert len(folded_mitiq_circuit) >= num_ideal_layers
+    else:
+        assert len(folded_mitiq_circuit) == num_ideal_layers
+
+
+@patch("mitiq.zne.scaling.layer_scaling.layer_folding")
+def test_get_layer_folding(mock_layer_folding):
+    a, b = LineQubit.range(2)
+    circuit = Circuit(ops.X(a), ops.CNOT(a, b), ops.Y(b))
+    layer_index = 1
+    scale_factor = 3
+
+    folding_func = get_layer_folding(layer_index)
+    folding_func(circuit, scale_factor)
+
+    mock_layer_folding.assert_called_once_with(
+        circuit, layers_to_fold=[0, 1, 0]
+    )

--- a/mitiq/zne/scaling/tests/test_layer_scaling.py
+++ b/mitiq/zne/scaling/tests/test_layer_scaling.py
@@ -60,20 +60,20 @@ def test_layer_folding():
     # Iterate over every possible combination of layerwise folds for a maximum
     # number of 5-folds.
     total_folds = 5
-    for i, j, k in product(range(total_folds), repeat=3):
-        folded_circuit = layer_folding(circ, [i, j, k])
+    for i1, i2, i3 in product(range(total_folds), repeat=3):
+        folded_circuit = layer_folding(circ, [i1, i2, i3])
 
         # For a given layer, the number of copies on a layer will be
         # 2n + 1 where "n" is the number of folds to perform.
         a, b, c = LineQubit.range(3)
         correct = Circuit(
             # Layer-1
-            [ops.H.on_each(*(a, b, c))] * (2 * i + 1),
+            [ops.H.on_each(*(a, b, c))] * (2 * i1 + 1),
             # Layer-2
-            [ops.CNOT.on(a, b)] * (2 * j + 1),
-            [ops.X.on(c)] * (2 * j + 1),
+            [ops.CNOT.on(a, b)] * (2 * i2 + 1),
+            [ops.X.on(c)] * (2 * i2 + 1),
             # Layer-3
-            [ops.TOFFOLI.on(*(a, b, c))] * (2 * k + 1),
+            [ops.TOFFOLI.on(*(a, b, c))] * (2 * i3 + 1),
         )
         assert folded_circuit == correct
 


### PR DESCRIPTION
## Description

1. Remove a test that has been randomly failing on CI (https://github.com/unitaryfund/mitiq/commit/e6210e6add29c5aab8b2a8ac54438e93bc14f85c)
2. As part of a Mitiq coding call we found an instance of using an integration test instead of small unit tests. We moved the testing of layerwise folding with all `QPROGRAM` types into a smaller unit test so we do not need to E2E test the entire workflow with every `QPROGRAM` instance. (https://github.com/unitaryfund/mitiq/commit/60528db816f61a05ed7bf4bddd66987ebfc4bcff)

#### Reviewer 👀 

I kept a modified version of `test_layerwise_folding_with_zne`, but struggled with knowing what to `assert` at the end since we'd like to move away from making assertions about the accuracy of techniques unless there are proofs to back the claims. As far as I understand, the assertions in `test_layerwise_folding_with_zne` are redundant to the the unit tests in `test_layer_scaling.py`, but am not 100% sure. WDYT? Should we keep this test? Should it be altered?