### PR TITLE
remove qosss banner

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -394,9 +394,6 @@ html_favicon = "img/mitiq.ico"
 html_extra_path = ["robots.txt"]
 
 html_theme_options = {
-    "announcement": "The Unitary Fund 2024 Quantum Open Source Software Survey\
-        is here! <a href='https://www.surveymonkey.com/r/qosssurvey24'>Take \
-        the survey now!</a>",
     "icon_links": [
         {
             "name": "Source Repository",


### PR DESCRIPTION
## Description

Removing the banner so it doesn't go out with the next release of Mitiq as the survey is closing on Friday (Nov 1, 2024).