### PR TITLE
Add log param to calibration guide

### DIFF
--- a/docs/source/guide/calibrators.md
+++ b/docs/source/guide/calibrators.md
@@ -1,6 +1,5 @@
 ---
 jupytext:
-  formats: ipynb,md:myst
   text_representation:
     extension: .md
     format_name: myst

--- a/docs/source/guide/calibrators.md
+++ b/docs/source/guide/calibrators.md
@@ -62,7 +62,7 @@ cal.run()
 
 To print results from the experiments the calibrator performs, the `log` parameter can be passed in to the `run` method with either the value of `flat` or `cartesian`. By using the `log` parameter, detailed information about each experiment is printed when the `run` method completes. 
 
-The detailed information can also be generated from the results of the calibrator after `run` is called by calling either {func}`.log_results_flat()` or {func}`.log_results_cartesian()`.
+The detailed information can also be generated from the results of the calibrator after `run` is called by calling either {meth}`.log_results_flat` or {meth}`.log_results_cartesian`.
 
 The two options display the information in different formats, though both use a cross (✘) or a check (✔) to signal whether the error mitigation expirement obtained an expectation value better than the non-mitigated one.
 
@@ -100,12 +100,10 @@ def execute(circuit, noise_level=0.001):
 cal.execute_with_mitigation(circuit, execute)
 ```
 
-```{code-cell} ipython3
-
-```
-
 ## Tutorial
 
 You can find an example on quantum error mitigation calibration in the **[Examples](../examples/calibration-tutorial.md)** section of the documentation.
 This example illustrates functionalities from the calibration module using ZNE
 on a simulated IBM Quantum backend using Qiskit, defining a new settings object.
+
++++

--- a/docs/source/guide/calibrators.md
+++ b/docs/source/guide/calibrators.md
@@ -1,12 +1,13 @@
 ---
 jupytext:
+  formats: ipynb,md:myst
   text_representation:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.16.1
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: mitiq
   language: python
   name: python3
 ---
@@ -59,17 +60,14 @@ cal.run()
 
 ## Verbose Log Output
 
-The `log` parameter can be passed in to the `run` method with either the value of `flat` or `cartesian`. By using the `log` parameter, detailed information about each experiment is shown. 
+To print results from the experiments the calibrator performs, the `log` parameter can be passed in to the `run` method with either the value of `flat` or `cartesian`. By using the `log` parameter, detailed information about each experiment is printed when the `run` method completes. 
 
-The log output can be generated from the results of the calibrator by calling either [`log_results_flat()`](https://mitiq.readthedocs.io/en/stable/apidoc.html#mitiq.calibration.calibrator.ExperimentResults.log_results_flat) or [`log_results_cartesian()`](https://mitiq.readthedocs.io/en/stable/apidoc.html#mitiq.calibration.calibrator.ExperimentResults.log_results_cartesian). 
+The detailed information can also be generated from the results of the calibrator after `run` is called by calling either {func}`.log_results_flat()` or {func}`.log_results_cartesian()`.
 
 The two options display the information in different formats, though both use a cross (✘) or a check (✔) to signal whether the error mitigation expirement obtained an expectation value better than the non-mitigated one.
 
 ```{code-cell} ipython3
-cal.results.log_results_flat()
-```
-
-```{code-cell} ipython3
+# cal.results.log_results_flat()
 cal.results.log_results_cartesian()
 ```
 

--- a/docs/source/guide/calibrators.md
+++ b/docs/source/guide/calibrators.md
@@ -5,9 +5,9 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.1
+    jupytext_version: 1.14.1
 kernelspec:
-  display_name: mitiq
+  display_name: Python 3 (ipykernel) 
   language: python
   name: python3
 ---

--- a/docs/source/guide/calibrators.md
+++ b/docs/source/guide/calibrators.md
@@ -61,7 +61,7 @@ cal.run()
 
 The `log` parameter can be passed in to the `run` method with either the value of `flat` or `cartesian`. By using the `log` parameter, detailed information about each experiment is shown. 
 
-The log output can be generated from the results of the calibrator by calling either [`log_results_flat()`](../../build/html/apidoc.html#mitiq.calibration.calibrator.ExperimentResults.log_results_flat) or [`log_results_cartesian()`](../../build/html/apidoc.html#mitiq.calibration.calibrator.ExperimentResults.log_results_cartesian). 
+The log output can be generated from the results of the calibrator by calling either [`log_results_flat()`](https://mitiq.readthedocs.io/en/stable/apidoc.html#mitiq.calibration.calibrator.ExperimentResults.log_results_flat) or [`log_results_cartesian()`](https://mitiq.readthedocs.io/en/stable/apidoc.html#mitiq.calibration.calibrator.ExperimentResults.log_results_cartesian). 
 
 The two options display the information in different formats, though both use a cross (✘) or a check (✔) to signal whether the error mitigation expirement obtained an expectation value better than the non-mitigated one.
 

--- a/docs/source/guide/calibrators.md
+++ b/docs/source/guide/calibrators.md
@@ -57,6 +57,22 @@ print(cal.get_cost())
 cal.run()
 ```
 
+## Verbose Log Output
+
+The `log` parameter can be passed in to the `run` method with either the value of `flat` or `cartesian`. By using the `log` parameter, detailed information about each experiment is shown. 
+
+The log output can be generated from the results of the calibrator by calling either [`log_results_flat()`](../../build/html/apidoc.html#mitiq.calibration.calibrator.ExperimentResults.log_results_flat) or [`log_results_cartesian()`](../../build/html/apidoc.html#mitiq.calibration.calibrator.ExperimentResults.log_results_cartesian). 
+
+The two options display the information in different formats, though both use a cross (✘) or a check (✔) to signal whether the error mitigation expirement obtained an expectation value better than the non-mitigated one.
+
+```{code-cell} ipython3
+cal.results.log_results_flat()
+```
+
+```{code-cell} ipython3
+cal.results.log_results_cartesian()
+```
+
 ## Applying the optimal error mitigation strategy
 
 We first define randomized benchmarking circuit to test the effect of error mitigation.

--- a/docs/source/guide/calibrators.md
+++ b/docs/source/guide/calibrators.md
@@ -7,7 +7,7 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.14.1
 kernelspec:
-  display_name: Python 3 (ipykernel) 
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 ---

--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -293,7 +293,13 @@ class Calibrator:
         }
 
     def run(self, log: Optional[OutputForm] = None) -> None:
-        """Runs all the circuits required for calibration."""
+        """Runs all the circuits required for calibration.
+
+        args:
+             log: If set, detailed results of each experiment run by the
+                calibrator are printed. The value corresponds to the format of
+                the information and can be set to “flat” or “cartesian”.
+        """
         if not self.results.is_missing_data():
             self.results.reset_data()
 


### PR DESCRIPTION
## Description
Fixes #2515
Fixes #2575 

This PR adds information about the `run()` method's `log` param and also the `log_results_flat()` and `log_results_cartesian()` methods to the [Calibration Guide](https://mitiq.readthedocs.io/en/stable/guide/calibrators.html).

Also, the `run()` method's docstring was update with information about the `log` parameter.

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.
- [X] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
