### PR TITLE
Fix import of mirror qv circuit function

### DIFF
--- a/mitiq/benchmarks/__init__.py
+++ b/mitiq/benchmarks/__init__.py
@@ -8,6 +8,7 @@ from mitiq.benchmarks.rotated_randomized_benchmarking import (
     generate_rotated_rb_circuits,
 )
 from mitiq.benchmarks.mirror_circuits import generate_mirror_circuit
+from mitiq.benchmarks.mirror_qv_circuits import generate_mirror_qv_circuit
 from mitiq.benchmarks.ghz_circuits import generate_ghz_circuit
 from mitiq.benchmarks.quantum_volume_circuits import (
     generate_quantum_volume_circuit,


### PR DESCRIPTION
An explicit import of the mirror qv circuit function was missing; adding it for coherence with the rest of the module. 

This solves the issue reported by @Shivansh20128 while working on https://github.com/unitaryfund/mitiq/issues/2274 

> I ran this line
> ```
> circuit= benchmarks.mirror_qv_circuits.generate_mirror_qv_circuit(num_qubits=10, depth=2)
> ```
> But I got the attribute error:
> ```
> AttributeError: module 'mitiq.benchmarks' has no attribute 'mirror_qv_circuits'.
> ```

# Note
Absolute vs. relative, and explicit vs. implicit imports is somehow a recurrent source of confusion/issue for users in Mitiq (more so than in another Python packages it seems.) This is because we haven't done a great job at pre-importing modules in dunder init files, neither we have defined a dynamic loading rule of the modules. For an explanation of the issue, see https://github.com/unitaryfund/mitiq/issues/2471#issuecomment-2298522676

That being said, for this specific case, the fix is straightforward, it was just a miss of a previous PR.