### PR TITLE
Update Calibrator method docstrings for formatting

### DIFF
--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -94,30 +94,32 @@ class ExperimentResults:
         return noisy_error, mitigated_error
 
     def log_results_flat(self) -> None:
-        """Prints calibration results in the following form
-        ┌──────────────────────────┬──────────────────────────────┬────────────────────────────┐
-        │ benchmark                │ strategy                     │ performance                │
-        ├──────────────────────────┼──────────────────────────────┼────────────────────────────┤
-        │ Type: rb                 │ Technique: ZNE               │ ✔                          │
-        │ Num qubits: 2            │ Factory: Richardson          │ Noisy error: 0.101         │
-        │ Circuit depth: 323       │ Scale factors: 1.0, 3.0, 5.0 │ Mitigated error: 0.0294    │
-        │ Two qubit gate count: 77 │ Scale method: fold_global    │ Improvement factor: 3.4398 │
-        ├──────────────────────────┼──────────────────────────────┼────────────────────────────┤
-        │ Type: rb                 │ Technique: ZNE               │ ✔                          │
-        │ Num qubits: 2            │ Factory: Richardson          │ Noisy error: 0.101         │
-        │ Circuit depth: 323       │ Scale factors: 1.0, 2.0, 3.0 │ Mitigated error: 0.0501    │
-        │ Two qubit gate count: 77 │ Scale method: fold_global    │ Improvement factor: 2.016  │
-        ├──────────────────────────┼──────────────────────────────┼────────────────────────────┤
-        │ Type: ghz                │ Technique: ZNE               │ ✔                          │
-        │ Num qubits: 2            │ Factory: Richardson          │ Noisy error: 0.0128        │
-        │ Circuit depth: 2         │ Scale factors: 1.0, 2.0, 3.0 │ Mitigated error: 0.0082    │
-        │ Two qubit gate count: 1  │ Scale method: fold_global    │ Improvement factor: 1.561  │
-        ├──────────────────────────┼──────────────────────────────┼────────────────────────────┤
-        │ Type: ghz                │ Technique: ZNE               │ ✘                          │
-        │ Num qubits: 2            │ Factory: Richardson          │ Noisy error: 0.0128        │
-        │ Circuit depth: 2         │ Scale factors: 1.0, 3.0, 5.0 │ Mitigated error: 0.0137    │
-        │ Two qubit gate count: 1  │ Scale method: fold_global    │ Improvement factor: 0.9369 │
-        └──────────────────────────┴──────────────────────────────┴────────────────────────────┘
+        """
+        Prints the results of the calibrator in flat form::
+
+            ┌──────────────────────────┬──────────────────────────────┬────────────────────────────┐
+            │ benchmark                │ strategy                     │ performance                │
+            ├──────────────────────────┼──────────────────────────────┼────────────────────────────┤
+            │ Type: rb                 │ Technique: ZNE               │ ✔                          │
+            │ Num qubits: 2            │ Factory: Richardson          │ Noisy error: 0.101         │
+            │ Circuit depth: 323       │ Scale factors: 1.0, 3.0, 5.0 │ Mitigated error: 0.0294    │
+            │ Two qubit gate count: 77 │ Scale method: fold_global    │ Improvement factor: 3.4398 │
+            ├──────────────────────────┼──────────────────────────────┼────────────────────────────┤
+            │ Type: rb                 │ Technique: ZNE               │ ✔                          │
+            │ Num qubits: 2            │ Factory: Richardson          │ Noisy error: 0.101         │
+            │ Circuit depth: 323       │ Scale factors: 1.0, 2.0, 3.0 │ Mitigated error: 0.0501    │
+            │ Two qubit gate count: 77 │ Scale method: fold_global    │ Improvement factor: 2.016  │
+            ├──────────────────────────┼──────────────────────────────┼────────────────────────────┤
+            │ Type: ghz                │ Technique: ZNE               │ ✔                          │
+            │ Num qubits: 2            │ Factory: Richardson          │ Noisy error: 0.0128        │
+            │ Circuit depth: 2         │ Scale factors: 1.0, 2.0, 3.0 │ Mitigated error: 0.0082    │
+            │ Two qubit gate count: 1  │ Scale method: fold_global    │ Improvement factor: 1.561  │
+            ├──────────────────────────┼──────────────────────────────┼────────────────────────────┤
+            │ Type: ghz                │ Technique: ZNE               │ ✘                          │
+            │ Num qubits: 2            │ Factory: Richardson          │ Noisy error: 0.0128        │
+            │ Circuit depth: 2         │ Scale factors: 1.0, 3.0, 5.0 │ Mitigated error: 0.0137    │
+            │ Two qubit gate count: 1  │ Scale method: fold_global    │ Improvement factor: 0.9369 │
+            └──────────────────────────┴──────────────────────────────┴────────────────────────────┘
         """  # noqa: E501
         table: List[List[Union[str, float]]] = []
         headers: List[str] = ["benchmark", "strategy", "performance"]
@@ -140,23 +142,25 @@ class ExperimentResults:
         return print(tabulate(table, headers, tablefmt="simple_grid"))
 
     def log_results_cartesian(self) -> None:
-        """Prints calibration results in the following form
-        ┌──────────────────────────────┬────────────────────────────┬────────────────────────────┐
-        │ strategy\benchmark           │ Type: rb                   │ Type: ghz                  │
-        │                              │ Num qubits: 2              │ Num qubits: 2              │
-        │                              │ Circuit depth: 337         │ Circuit depth: 2           │
-        │                              │ Two qubit gate count: 80   │ Two qubit gate count: 1    │
-        ├──────────────────────────────┼────────────────────────────┼────────────────────────────┤
-        │ Technique: ZNE               │ ✔                          │ ✘                          │
-        │ Factory: Richardson          │ Noisy error: 0.1128        │ Noisy error: 0.0117        │
-        │ Scale factors: 1.0, 2.0, 3.0 │ Mitigated error: 0.0501    │ Mitigated error: 0.0439    │
-        │ Scale method: fold_global    │ Improvement factor: 2.2515 │ Improvement factor: 0.2665 │
-        ├──────────────────────────────┼────────────────────────────┼────────────────────────────┤
-        │ Technique: ZNE               │ ✔                          │ ✘                          │
-        │ Factory: Richardson          │ Noisy error: 0.1128        │ Noisy error: 0.0117        │
-        │ Scale factors: 1.0, 3.0, 5.0 │ Mitigated error: 0.0408    │ Mitigated error: 0.0171    │
-        │ Scale method: fold_global    │ Improvement factor: 2.7672 │ Improvement factor: 0.6852 │
-        └──────────────────────────────┴────────────────────────────┴────────────────────────────┘
+        """
+        Prints the results of the calibrator in cartesian form::
+
+            ┌──────────────────────────────┬────────────────────────────┬────────────────────────────┐
+            │ strategy\\benchmark           │ Type: rb                   │ Type: ghz                  │
+            │                              │ Num qubits: 2              │ Num qubits: 2              │
+            │                              │ Circuit depth: 337         │ Circuit depth: 2           │
+            │                              │ Two qubit gate count: 80   │ Two qubit gate count: 1    │
+            ├──────────────────────────────┼────────────────────────────┼────────────────────────────┤
+            │ Technique: ZNE               │ ✔                          │ ✘                          │
+            │ Factory: Richardson          │ Noisy error: 0.1128        │ Noisy error: 0.0117        │
+            │ Scale factors: 1.0, 2.0, 3.0 │ Mitigated error: 0.0501    │ Mitigated error: 0.0439    │
+            │ Scale method: fold_global    │ Improvement factor: 2.2515 │ Improvement factor: 0.2665 │
+            ├──────────────────────────────┼────────────────────────────┼────────────────────────────┤
+            │ Technique: ZNE               │ ✔                          │ ✘                          │
+            │ Factory: Richardson          │ Noisy error: 0.1128        │ Noisy error: 0.0117        │
+            │ Scale factors: 1.0, 3.0, 5.0 │ Mitigated error: 0.0408    │ Mitigated error: 0.0171    │
+            │ Scale method: fold_global    │ Improvement factor: 2.7672 │ Improvement factor: 0.6852 │
+            └──────────────────────────────┴────────────────────────────┴────────────────────────────┘
         """  # noqa: E501
         table: List[List[str]] = []
         headers: List[str] = ["strategy\\benchmark"]


### PR DESCRIPTION
## Description

Fixes #2517

Also, this was discussed in #2567 

This PR addresses the poorly formatted tables in the `log_results_flat()` and `log_results_cartesian()` docstrings of the Calibrator module when the HTML is created for [Mitiq's ReadTheDocs](https://mitiq.readthedocs.io/en/stable/apidoc.html#module-mitiq.calibration.calibrator).


Previous formatting:
![image](https://github.com/user-attachments/assets/15c53294-ba48-4c6e-84be-faecbd7b7944)

New formatting:
![image](https://github.com/user-attachments/assets/1cbbd1c7-5e74-4bbf-9fbb-86bbe66e87a6)

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.