### PR TITLE
Quick fix: Fix typo and headings in classical shadows tutorial

### DIFF
--- a/docs/source/examples/shadows_tutorial.md
+++ b/docs/source/examples/shadows_tutorial.md
@@ -426,7 +426,7 @@ When we realize this code, it's important to consider that we record the equival
 
 Consequently, computing the mean estimator involves counting the number of exact matches between the observable and the classical shadow, and then multiplying the result by the appropriate sign. In the following, we present the function `expectation_estimation_shadow`, which allows for estimating any observable based on a classical shadow. This is realised by the main function `execute_with_shadows` when *state_reconstruction =* **False**.
 
-###4.3 Shadow Estimation Bound on Estimation of Expectation Values of Observables
+### 4.3 Shadow Estimation Bound on Estimation of Expectation Values of Observables
 
 The shadow estimation bound of operator expectation values is given by the following theorem:
 _________________________________________________________________________

--- a/docs/source/examples/shadows_tutorial.md
+++ b/docs/source/examples/shadows_tutorial.md
@@ -159,11 +159,15 @@ Based on the theorem, if the error rate of fidelity is $\epsilon$, i.e.
 |F(\rho,\sigma)-1|\leq\epsilon,
 \end{equation}
 then the minimum number of measurements $N$ (number of snapshots) should be:
-\begin{equation}
+```{math}
+:label: eq-label
 N = \frac{34}{\epsilon^2}\left\|\rho-\mathrm{Tr}(\rho)/{2^n}\mathbb{I}\right\|_{\mathrm{shadow}}^2
-\end{equation}
+```
 with the shadow norm upper bound of the random Pauli measurement $\left\|\cdot\right\|_{\mathrm{shadow}}\leq 2^k\|\cdot\|_\infty$ when the operator acting on $k$ qubits, we have $N\leq 34\epsilon^{-2}2^{2n}+\mathcal{O}(e^{-n})$. Based on Fuchs–van de Graaf inequalities and properties of $L_p$ norm, $\|\rho-\sigma\|_2\leq \|\rho-\sigma\|_1 \leq (1-F(\rho,\sigma))^{1/2}$, the $L_2$ norm distance between the state reconstructed through classical shadow estimation and the state prepared by the circuit is upperbound by the fidelity error rate $\epsilon$. The dependency of the bound number of measurements $N$ to achieve the error rate $\epsilon$ is depicted in function `n_measurements_tomography_bound`.
 
+```{note}
+Equation {eq}`eq-label` comes from equation S13 in the paper {cite}`huang2020predicting`. It contains some numerical constants and as noted by Remark 1 these constants result from a worst case argument. You may see values much smaller in practice. 
+```
 
 ```{code-cell} ipython3
 # error rate of state reconstruction epsilon < 1.

--- a/docs/source/guide/shadows-5-theory.md
+++ b/docs/source/guide/shadows-5-theory.md
@@ -151,7 +151,7 @@ calculate $K$ estimators each of which is the average of $N$ single-round estima
 & \hat{f} = \mathrm{median}\{\bar{f}^{(1)},\cdots\bar{f}^{(K)}\}_{1\leq k\leq K}
 \end{eqnarray}
 The number of $\{f_m\}$ is related to the number of irreducible representations in the PTM[^1] representation of the twirling group. When the twirling group is the local Clifford group, the number of irreducible representations is $2^n$.
-### 2.2 Noiseless Pauli Fidelity --- Ideal Inverse channal vs Estimate Noisy Inverse channel
+### 2.2 Noiseless Pauli Fidelity --- Ideal Inverse channel vs Estimate Noisy Inverse channel
 One could check that in the absence of noise in the quantum gates ($\Lambda\equiv\mathbb{I}$), the value of the Pauli fidelity $\hat{f}_{b}^{\mathrm{ideal}}\equiv \mathrm{Tr}(\mathcal{M}_z \Pi_b)/\mathrm{Tr}\Pi_b = 3^{-|{b}|}$, where $|b|$ is the count of $|1\rangle$ found in z-eigenstates $|b\rangle:=|b_i\rangle^{\otimes n}$.
 
 When the noisy channel $\widehat{\mathcal{M}}$ is considered, the inverse of the noise channel $\widehat{\mathcal{M}}^{-1}$ can be obtained by:


### PR DESCRIPTION

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

I noticed some typos and an unrendered heading in the classical shadows documentation. These are fixed here. 

Additionally, if you (the maintainers) think it useful I think it would be good to highlight Remark 1 from the paper (https://arxiv.org/abs/2002.08953) 

> Remark 1 (Constants in Theorem 1). The numerical constants featuring in N and K result from a conservative
(worst case) argument that is designed to be simple, not tight. We expect that the actual constants are much
smaller in practice.

In the shadows_tutorial for equation (10). I think the sudden appearance of `34` is confusing in the guide. 

![image](https://github.com/user-attachments/assets/c98e71ea-a181-4f1e-8a50-bbac0252d44a)


<!-- Please explain the changes you made here. -->

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file
