### PR TITLE
Add log param to run function docstring

### DIFF
--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -297,7 +297,13 @@ class Calibrator:
         }
 
     def run(self, log: Optional[OutputForm] = None) -> None:
-        """Runs all the circuits required for calibration."""
+        """Runs all the circuits required for calibration.
+
+        args:
+             log: If set, detailed results of each experiment run by the
+                calibrator are printed. The value corresponds to the format of
+                the information and can be set to “flat” or “cartesian”.
+        """
         if not self.results.is_missing_data():
             self.results.reset_data()
 


### PR DESCRIPTION
## Description
Fixes #2516 

Adds the `log` parameter to the `run` function's docstring so that it is included in the API-docs (https://mitiq.readthedocs.io/en/stable/apidoc.html#mitiq.calibration.calibrator.Calibrator.run)

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.
