### PR TITLE
Fix converting Rxx and similar Qiskit gates 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,3 +59,4 @@ Vladimir Kozhukalov
 Francesc Sabater
 Emiliano Godinez
 Tommy Nguyen
+Duong H. D. Tran

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -249,17 +249,19 @@ def from_qiskit(circuit: qiskit.QuantumCircuit) -> cirq.Circuit:
     Returns:
         Mitiq circuit representation equivalent to the input Qiskit circuit.
     """
+
     try:
         mitiq_circuit = from_qasm(qasm2.dumps(circuit))
     except QasmException:
         # Try to decompose circuit before running
         # This is necessary for converting qiskit circuits with
         # custom packaged gates, e.g., QFT gates
+        gates_to_decompose = ["rxx", "rzz", "rzx", "ryy", "QFT"]
         circuit = circuit.decompose(
-            gates_to_decompose=["u3", "cx", "rx", "ry", "rz"]
+            gates_to_decompose=gates_to_decompose, reps=10
         )
-        circuit = circuit.decompose()
         mitiq_circuit = from_qasm(qasm2.dumps(circuit))
+
     return mitiq_circuit
 
 

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -52,7 +52,9 @@ def _remove_qasm_barriers(qasm: QASMType) -> QASMType:
     return "".join(lines)
 
 
-def _map_bit_index(bit_index: int, new_register_sizes: List[int]) -> Tuple[int, int]:
+def _map_bit_index(
+    bit_index: int, new_register_sizes: List[int]
+) -> Tuple[int, int]:
     """Returns the register index and (qu)bit index in this register for the
     mapped bit_index.
 

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -52,7 +52,9 @@ def _remove_qasm_barriers(qasm: QASMType) -> QASMType:
     return "".join(lines)
 
 
-def _map_bit_index(bit_index: int, new_register_sizes: List[int]) -> Tuple[int, int]:
+def _map_bit_index(
+    bit_index: int, new_register_sizes: List[int]
+) -> Tuple[int, int]:
     """Returns the register index and (qu)bit index in this register for the
     mapped bit_index.
 
@@ -253,7 +255,9 @@ def from_qiskit(circuit: qiskit.QuantumCircuit) -> cirq.Circuit:
         # Try to decompose circuit before running
         # This is necessary for converting qiskit circuits with
         # custom packaged gates, e.g., QFT gates
-        circuit = circuit.decompose(gates_to_decompose=["u3", "cx", "rx", "ry", "rz"])
+        circuit = circuit.decompose(
+            gates_to_decompose=["u3", "cx", "rx", "ry", "rz"]
+        )
         circuit = circuit.decompose()
         mitiq_circuit = from_qasm(qasm2.dumps(circuit))
     return mitiq_circuit

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -16,6 +16,7 @@ import qiskit
 from cirq.contrib.qasm_import import circuit_from_qasm
 from cirq.contrib.qasm_import.exception import QasmException
 from qiskit import qasm2
+from qiskit import transpile
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.passes import SetLayout
@@ -52,9 +53,7 @@ def _remove_qasm_barriers(qasm: QASMType) -> QASMType:
     return "".join(lines)
 
 
-def _map_bit_index(
-    bit_index: int, new_register_sizes: List[int]
-) -> Tuple[int, int]:
+def _map_bit_index(bit_index: int, new_register_sizes: List[int]) -> Tuple[int, int]:
     """Returns the register index and (qu)bit index in this register for the
     mapped bit_index.
 
@@ -255,6 +254,7 @@ def from_qiskit(circuit: qiskit.QuantumCircuit) -> cirq.Circuit:
         # Try to decompose circuit before running
         # This is necessary for converting qiskit circuits with
         # custom packaged gates, e.g., QFT gates
+        circuit = circuit.decompose(gates_to_decompose=["qft"])
         circuit = circuit.decompose()
         mitiq_circuit = from_qasm(qasm2.dumps(circuit))
     return mitiq_circuit

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -15,7 +15,7 @@ import numpy as np
 import qiskit
 from cirq.contrib.qasm_import import circuit_from_qasm
 from cirq.contrib.qasm_import.exception import QasmException
-from qiskit import qasm2
+from qiskit import qasm2, transpile
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.passes import SetLayout
@@ -52,9 +52,7 @@ def _remove_qasm_barriers(qasm: QASMType) -> QASMType:
     return "".join(lines)
 
 
-def _map_bit_index(
-    bit_index: int, new_register_sizes: List[int]
-) -> Tuple[int, int]:
+def _map_bit_index(bit_index: int, new_register_sizes: List[int]) -> Tuple[int, int]:
     """Returns the register index and (qu)bit index in this register for the
     mapped bit_index.
 
@@ -255,7 +253,9 @@ def from_qiskit(circuit: qiskit.QuantumCircuit) -> cirq.Circuit:
         # Try to decompose circuit before running
         # This is necessary for converting qiskit circuits with
         # custom packaged gates, e.g., QFT gates
-        circuit = circuit.decompose(gates_to_decompose=["qft"])
+        circuit = circuit.decompose(
+            gates_to_decompose=["u1", "u2", "u3", "cx", "rx", "ry"]
+        )
         circuit = circuit.decompose()
         mitiq_circuit = from_qasm(qasm2.dumps(circuit))
     return mitiq_circuit

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -256,10 +256,8 @@ def from_qiskit(circuit: qiskit.QuantumCircuit) -> cirq.Circuit:
         # Try to decompose circuit before running
         # This is necessary for converting qiskit circuits with
         # custom packaged gates, e.g., QFT gates
-        gates_to_decompose = ["rxx", "rzz", "rzx", "ryy", "QFT"]
-        circuit = circuit.decompose(
-            gates_to_decompose=gates_to_decompose, reps=10
-        )
+        GATES_TO_DECOMPOSE = ["rxx", "rzz", "rzx", "ryy", "QFT"]
+        circuit = circuit.decompose(gates_to_decompose=GATES_TO_DECOMPOSE)
         mitiq_circuit = from_qasm(qasm2.dumps(circuit))
 
     return mitiq_circuit

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -16,7 +16,6 @@ import qiskit
 from cirq.contrib.qasm_import import circuit_from_qasm
 from cirq.contrib.qasm_import.exception import QasmException
 from qiskit import qasm2
-from qiskit import transpile
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.passes import SetLayout

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -15,7 +15,7 @@ import numpy as np
 import qiskit
 from cirq.contrib.qasm_import import circuit_from_qasm
 from cirq.contrib.qasm_import.exception import QasmException
-from qiskit import qasm2, transpile
+from qiskit import qasm2
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.passes import SetLayout

--- a/mitiq/interface/mitiq_qiskit/conversions.py
+++ b/mitiq/interface/mitiq_qiskit/conversions.py
@@ -52,9 +52,7 @@ def _remove_qasm_barriers(qasm: QASMType) -> QASMType:
     return "".join(lines)
 
 
-def _map_bit_index(
-    bit_index: int, new_register_sizes: List[int]
-) -> Tuple[int, int]:
+def _map_bit_index(bit_index: int, new_register_sizes: List[int]) -> Tuple[int, int]:
     """Returns the register index and (qu)bit index in this register for the
     mapped bit_index.
 
@@ -255,9 +253,7 @@ def from_qiskit(circuit: qiskit.QuantumCircuit) -> cirq.Circuit:
         # Try to decompose circuit before running
         # This is necessary for converting qiskit circuits with
         # custom packaged gates, e.g., QFT gates
-        circuit = circuit.decompose(
-            gates_to_decompose=["u1", "u2", "u3", "cx", "rx", "ry"]
-        )
+        circuit = circuit.decompose(gates_to_decompose=["u3", "cx", "rx", "ry", "rz"])
         circuit = circuit.decompose()
         mitiq_circuit = from_qasm(qasm2.dumps(circuit))
     return mitiq_circuit

--- a/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -477,6 +477,7 @@ def test_remove_identity_from_idle_with_multiple_registers():
     assert circuit_multi_reg == input_multi
     assert circuit_single_reg == input_single
 
+
 def test_convert_to_mitiq_with_rx_and_rzz():
     """Tests that convert_to_mitiq works with RX and RZZ gates."""
     test_qc = qiskit.QuantumCircuit(2)

--- a/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
+++ b/mitiq/interface/mitiq_qiskit/tests/test_conversions_qiskit.py
@@ -476,3 +476,10 @@ def test_remove_identity_from_idle_with_multiple_registers():
     input_multi, input_single = _multi_reg_circuits()
     assert circuit_multi_reg == input_multi
     assert circuit_single_reg == input_single
+
+def test_convert_to_mitiq_with_rx_and_rzz():
+    """Tests that convert_to_mitiq works with RX and RZZ gates."""
+    test_qc = qiskit.QuantumCircuit(2)
+    test_qc.rx(0.1, 0)
+    test_qc.rzz(0.1, 0, 1)
+    assert convert_to_mitiq(test_qc)


### PR DESCRIPTION
## Description
Resolves issue #2578

Basically, the error happens technically due to the fact that `rzz` is not recognized by QASM.
In general, this can also happen to other gates that are pre-built in any framework but not existing in QASM.
So, the idea is that we should `decompose()` some parts of the argument circuit such that these gate are more recognizable to QASM, and then `decompose()` one more time to obtain the decomposition by the basis gates.

My original thought was:

> Basically, the error happens technically due to the fact that rzz is not recognized by QASM.
> In general, this can also happen to other gates that are pre-built in any framework but not existing in QASM.
> So, the idea is that we should decompose() the argument circuit to semi-basic gate using QFT such that these gate are recognizable to QASM, and then decompose() one more time to obtain the decomposition by the basis gates. Turns out it was not working even passing all tests.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] ~~I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.~~ no doc updated.
- [x] Added myself / the copyright holder to the AUTHORS file
