### PR TITLE
Correcting run-on sentences in API-doc

### DIFF
--- a/mitiq/cdr/cdr.py
+++ b/mitiq/cdr/cdr.py
@@ -205,8 +205,7 @@ def mitigate_executor(
             noisy and data and parameters returning a float. See
             ``cdr.linear_fit_function`` for an example.
         num_fit_parameters: The number of parameters the fit_function takes.
-        scale_noise: scale_noise: Function for scaling the noise of a quantum
-            circuit.
+        scale_noise: Function for scaling the noise of a quantum circuit.
         scale_factors: Factors by which to scale the noise.
 
             - When 1.0 is the only scale factor, the method is known as CDR.
@@ -319,8 +318,7 @@ def cdr_decorator(
             noisy and data and parameters returning a float. See
             ``cdr.linear_fit_function`` for an example.
         num_fit_parameters: The number of parameters the fit_function takes.
-        scale_noise: scale_noise: Function for scaling the noise of a quantum
-            circuit.
+        scale_noise: Function for scaling the noise of a quantum circuit.
         scale_factors: Factors by which to scale the noise.
 
             - When 1.0 is the only scale factor, the method is known as CDR.

--- a/mitiq/cdr/cdr.py
+++ b/mitiq/cdr/cdr.py
@@ -71,8 +71,7 @@ def execute_with_cdr(
             noisy and data and parameters returning a float. See
             ``cdr.linear_fit_function`` for an example.
         num_fit_parameters: The number of parameters the fit_function takes.
-        scale_noise: scale_noise: Function for scaling the noise of a quantum
-            circuit.
+        scale_noise: Function for scaling the noise of a quantum circuit.
         scale_factors: Factors by which to scale the noise.
 
             - When 1.0 is the only scale factor, the method is known as CDR.

--- a/mitiq/cdr/cdr.py
+++ b/mitiq/cdr/cdr.py
@@ -214,7 +214,7 @@ def mitigate_executor(
 
             - Note: When scale factors larger than 1.0 are provided, the method
             is known as "variable-noise CDR."
-            
+
         kwargs: Available keyword arguments are:
 
             - method_select (string): Specifies the method used to select the
@@ -324,22 +324,30 @@ def cdr_decorator(
         scale_noise: scale_noise: Function for scaling the noise of a quantum
             circuit.
         scale_factors: Factors by which to scale the noise.
+
             - When 1.0 is the only scale factor, the method is known as CDR.
+
             - Note: When scale factors larger than 1.0 are provided, the method
             is known as "variable-noise CDR."
+
         kwargs: Available keyword arguments are:
+
             - method_select (string): Specifies the method used to select the
             non-Clifford gates to replace when constructing the
             near-Clifford training circuits. Can be 'uniform' or
             'gaussian'.
+
             - method_replace (string): Specifies the method used to replace
             the selected non-Clifford gates with a Clifford when
             constructing the near-Clifford training circuits. Can be
             'uniform', 'gaussian', or 'closest'.
+
             - sigma_select (float): Width of the Gaussian distribution used for
             ``method_select='gaussian'``.
+
             - sigma_replace (float): Width of the Gaussian distribution used
             for ``method_replace='gaussian'``.
+
             - random_state (int): Seed for sampling.
     """
 

--- a/mitiq/cdr/cdr.py
+++ b/mitiq/cdr/cdr.py
@@ -78,24 +78,24 @@ def execute_with_cdr(
             - When 1.0 is the only scale factor, the method is known as CDR.
 
             - Note: When scale factors larger than 1.0 are provided, the method
-            is known as "variable-noise CDR."
+              is known as "variable-noise CDR."
 
         kwargs: Available keyword arguments are:
 
             - method_select (string): Specifies the method used to select the
-            non-Clifford gates to replace when constructing the near-Clifford
-            training circuits. Can be 'uniform' or 'gaussian'.
+              non-Clifford gates to replace when constructing the near-Clifford
+              training circuits. Can be 'uniform' or 'gaussian'.
 
             - method_replace (string): Specifies the method used to replace the
-            selected non-Clifford gates with a Clifford when constructing the
-            near-Clifford training circuits. Can be 'uniform', 'gaussian', or
-            'closest'.
+              selected non-Clifford gates with a Clifford when constructing the
+              near-Clifford training circuits. Can be 'uniform', 'gaussian', or
+              'closest'.
 
             - sigma_select (float): Width of the Gaussian distribution used for
-            ``method_select='gaussian'``.
+              ``method_select='gaussian'``.
 
             - sigma_replace (float): Width of the Gaussian distribution used
-            for ``method_replace='gaussian'``.
+              for ``method_replace='gaussian'``.
 
             - random_state (int): Seed for sampling.
     """
@@ -212,24 +212,24 @@ def mitigate_executor(
             - When 1.0 is the only scale factor, the method is known as CDR.
 
             - Note: When scale factors larger than 1.0 are provided, the method
-            is known as "variable-noise CDR."
+              is known as "variable-noise CDR."
 
         kwargs: Available keyword arguments are:
 
             - method_select (string): Specifies the method used to select the
-            non-Clifford gates to replace when constructing the near-Clifford
-            training circuits. Can be 'uniform' or 'gaussian'.
+              non-Clifford gates to replace when constructing the near-Clifford
+              training circuits. Can be 'uniform' or 'gaussian'.
 
             - method_replace (string): Specifies the method used to replace
-            the selected non-Clifford gates with a Clifford when constructing
-            the near-Clifford training circuits. Can be 'uniform', 'gaussian',
-            or 'closest'.
+              the selected non-Clifford gates with a Clifford when constructing
+              the near-Clifford training circuits. Can be 'uniform', 'gaussian'
+              , or 'closest'.
 
             - sigma_select (float): Width of the Gaussian distribution used for
-            ``method_select='gaussian'``.
+              ``method_select='gaussian'``.
 
             - sigma_replace (float): Width of the Gaussian distribution used
-            for ``method_replace='gaussian'``.
+              for ``method_replace='gaussian'``.
 
             - random_state (int): Seed for sampling."""
     executor_obj = Executor(executor)
@@ -326,24 +326,24 @@ def cdr_decorator(
             - When 1.0 is the only scale factor, the method is known as CDR.
 
             - Note: When scale factors larger than 1.0 are provided, the method
-            is known as "variable-noise CDR."
+              is known as "variable-noise CDR."
 
         kwargs: Available keyword arguments are:
 
             - method_select (string): Specifies the method used to select the
-            non-Clifford gates to replace when constructing the near-Clifford
-            training circuits. Can be 'uniform' or 'gaussian'.
+              non-Clifford gates to replace when constructing the near-Clifford
+              training circuits. Can be 'uniform' or 'gaussian'.
 
             - method_replace (string): Specifies the method used to replace the
-            selected non-Clifford gates with a Clifford when constructing the
-            near-Clifford training circuits. Can be 'uniform', 'gaussian', or
-            'closest'.
+              selected non-Clifford gates with a Clifford when constructing the
+              near-Clifford training circuits. Can be 'uniform', 'gaussian', or
+              'closest'.
 
             - sigma_select (float): Width of the Gaussian distribution used for
-            ``method_select='gaussian'``.
+              ``method_select='gaussian'``.
 
             - sigma_replace (float): Width of the Gaussian distribution used
-            for ``method_replace='gaussian'``.
+              for ``method_replace='gaussian'``.
 
             - random_state (int): Seed for sampling.
     """

--- a/mitiq/cdr/cdr.py
+++ b/mitiq/cdr/cdr.py
@@ -74,22 +74,30 @@ def execute_with_cdr(
         scale_noise: scale_noise: Function for scaling the noise of a quantum
             circuit.
         scale_factors: Factors by which to scale the noise.
+
             - When 1.0 is the only scale factor, the method is known as CDR.
+
             - Note: When scale factors larger than 1.0 are provided, the method
             is known as "variable-noise CDR."
+
         kwargs: Available keyword arguments are:
+
             - method_select (string): Specifies the method used to select the
             non-Clifford gates to replace when constructing the
             near-Clifford training circuits. Can be 'uniform' or
             'gaussian'.
+
             - method_replace (string): Specifies the method used to replace
             the selected non-Clifford gates with a Clifford when
             constructing the near-Clifford training circuits. Can be
             'uniform', 'gaussian', or 'closest'.
+
             - sigma_select (float): Width of the Gaussian distribution used for
             ``method_select='gaussian'``.
+
             - sigma_replace (float): Width of the Gaussian distribution used
             for ``method_replace='gaussian'``.
+
             - random_state (int): Seed for sampling.
     """
     # Handle keyword arguments for generating training circuits.
@@ -201,22 +209,30 @@ def mitigate_executor(
         scale_noise: scale_noise: Function for scaling the noise of a quantum
             circuit.
         scale_factors: Factors by which to scale the noise.
+
             - When 1.0 is the only scale factor, the method is known as CDR.
+
             - Note: When scale factors larger than 1.0 are provided, the method
             is known as "variable-noise CDR."
+            
         kwargs: Available keyword arguments are:
+
             - method_select (string): Specifies the method used to select the
             non-Clifford gates to replace when constructing the
             near-Clifford training circuits. Can be 'uniform' or
             'gaussian'.
+
             - method_replace (string): Specifies the method used to replace
             the selected non-Clifford gates with a Clifford when
             constructing the near-Clifford training circuits. Can be
             'uniform', 'gaussian', or 'closest'.
+
             - sigma_select (float): Width of the Gaussian distribution used for
             ``method_select='gaussian'``.
+
             - sigma_replace (float): Width of the Gaussian distribution used
             for ``method_replace='gaussian'``.
+
             - random_state (int): Seed for sampling."""
     executor_obj = Executor(executor)
     if not executor_obj.can_batch:

--- a/mitiq/cdr/cdr.py
+++ b/mitiq/cdr/cdr.py
@@ -83,12 +83,12 @@ def execute_with_cdr(
         kwargs: Available keyword arguments are:
 
             - method_select (string): Specifies the method used to select the
-            non-Clifford gates to replace when constructing the near-Clifford 
+            non-Clifford gates to replace when constructing the near-Clifford
             training circuits. Can be 'uniform' or 'gaussian'.
 
             - method_replace (string): Specifies the method used to replace the
-            selected non-Clifford gates with a Clifford when constructing the 
-            near-Clifford training circuits. Can be 'uniform', 'gaussian', or 
+            selected non-Clifford gates with a Clifford when constructing the
+            near-Clifford training circuits. Can be 'uniform', 'gaussian', or
             'closest'.
 
             - sigma_select (float): Width of the Gaussian distribution used for
@@ -336,7 +336,7 @@ def cdr_decorator(
 
             - method_replace (string): Specifies the method used to replace the
             selected non-Clifford gates with a Clifford when constructing the
-            near-Clifford training circuits. Can be 'uniform', 'gaussian', or 
+            near-Clifford training circuits. Can be 'uniform', 'gaussian', or
             'closest'.
 
             - sigma_select (float): Width of the Gaussian distribution used for

--- a/mitiq/cdr/cdr.py
+++ b/mitiq/cdr/cdr.py
@@ -83,14 +83,13 @@ def execute_with_cdr(
         kwargs: Available keyword arguments are:
 
             - method_select (string): Specifies the method used to select the
-            non-Clifford gates to replace when constructing the
-            near-Clifford training circuits. Can be 'uniform' or
-            'gaussian'.
+            non-Clifford gates to replace when constructing the near-Clifford 
+            training circuits. Can be 'uniform' or 'gaussian'.
 
-            - method_replace (string): Specifies the method used to replace
-            the selected non-Clifford gates with a Clifford when
-            constructing the near-Clifford training circuits. Can be
-            'uniform', 'gaussian', or 'closest'.
+            - method_replace (string): Specifies the method used to replace the
+            selected non-Clifford gates with a Clifford when constructing the 
+            near-Clifford training circuits. Can be 'uniform', 'gaussian', or 
+            'closest'.
 
             - sigma_select (float): Width of the Gaussian distribution used for
             ``method_select='gaussian'``.
@@ -218,14 +217,13 @@ def mitigate_executor(
         kwargs: Available keyword arguments are:
 
             - method_select (string): Specifies the method used to select the
-            non-Clifford gates to replace when constructing the
-            near-Clifford training circuits. Can be 'uniform' or
-            'gaussian'.
+            non-Clifford gates to replace when constructing the near-Clifford
+            training circuits. Can be 'uniform' or 'gaussian'.
 
             - method_replace (string): Specifies the method used to replace
-            the selected non-Clifford gates with a Clifford when
-            constructing the near-Clifford training circuits. Can be
-            'uniform', 'gaussian', or 'closest'.
+            the selected non-Clifford gates with a Clifford when constructing
+            the near-Clifford training circuits. Can be 'uniform', 'gaussian',
+            or 'closest'.
 
             - sigma_select (float): Width of the Gaussian distribution used for
             ``method_select='gaussian'``.
@@ -333,14 +331,13 @@ def cdr_decorator(
         kwargs: Available keyword arguments are:
 
             - method_select (string): Specifies the method used to select the
-            non-Clifford gates to replace when constructing the
-            near-Clifford training circuits. Can be 'uniform' or
-            'gaussian'.
+            non-Clifford gates to replace when constructing the near-Clifford
+            training circuits. Can be 'uniform' or 'gaussian'.
 
-            - method_replace (string): Specifies the method used to replace
-            the selected non-Clifford gates with a Clifford when
-            constructing the near-Clifford training circuits. Can be
-            'uniform', 'gaussian', or 'closest'.
+            - method_replace (string): Specifies the method used to replace the
+            selected non-Clifford gates with a Clifford when constructing the
+            near-Clifford training circuits. Can be 'uniform', 'gaussian', or 
+            'closest'.
 
             - sigma_select (float): Width of the Gaussian distribution used for
             ``method_select='gaussian'``.

--- a/mitiq/cdr/clifford_training_data.py
+++ b/mitiq/cdr/clifford_training_data.py
@@ -55,7 +55,7 @@ def generate_training_circuits(
 
             - sigma_select (float): Width of the Gaussian distribution used for
             ``method_select='gaussian'``.
-            
+
             - sigma_replace (float): Width of the Gaussian distribution used
             for ``method_replace='gaussian'``.
     """

--- a/mitiq/cdr/clifford_training_data.py
+++ b/mitiq/cdr/clifford_training_data.py
@@ -52,8 +52,10 @@ def generate_training_circuits(
             'closest'.
         random_state: Seed for sampling.
         kwargs: Available keyword arguments are:
+
             - sigma_select (float): Width of the Gaussian distribution used for
             ``method_select='gaussian'``.
+            
             - sigma_replace (float): Width of the Gaussian distribution used
             for ``method_replace='gaussian'``.
     """
@@ -115,10 +117,12 @@ def _map_to_near_clifford(
             'closest'.
         random_state: Seed for sampling.
         kwargs: Additional options for selection / replacement methods.
-            sigma_select (float): Width of the Gaussian distribution used for
-                ``method_select='gaussian'``.
-            sigma_replace (float): Width of the Gaussian distribution used for
-                ``method_replace='gaussian'``.
+
+            - sigma_select (float): Width of the Gaussian distribution used for
+            ``method_select='gaussian'``.
+
+            - sigma_replace (float): Width of the Gaussian distribution used
+            for ``method_replace='gaussian'``.
     """
     sigma_select: float = kwargs.get("sigma_select", 0.5)
     sigma_replace: float = kwargs.get("sigma_replace", 0.5)

--- a/mitiq/cdr/clifford_training_data.py
+++ b/mitiq/cdr/clifford_training_data.py
@@ -54,10 +54,10 @@ def generate_training_circuits(
         kwargs: Available keyword arguments are:
 
             - sigma_select (float): Width of the Gaussian distribution used for
-            ``method_select='gaussian'``.
+              ``method_select='gaussian'``.
 
             - sigma_replace (float): Width of the Gaussian distribution used
-            for ``method_replace='gaussian'``.
+              for ``method_replace='gaussian'``.
     """
     if random_state is None or isinstance(random_state, int):
         random_state = np.random.RandomState(random_state)


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

<!-- Please explain the changes you made here. -->
This PR corrects the run-on sentences in the API Docs inside the `kwargs` and `scale factors`. It #Resolves #2422.
I have some blank lines before the bullet points and corrected indentations. The doc build looks good now.

This is how it looked earlier.
![image](https://github.com/user-attachments/assets/52f96ac5-b7dc-46d4-a703-0ea56f6bd1ac)

And this is how it looks now:
![image](https://github.com/user-attachments/assets/c75251db-c68a-4d66-86d3-4a6a3630f242)

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file
