### PR TITLE
Throw Erorr on Multiple Measurements per Qubit with Observables

### DIFF
--- a/mitiq/observable/pauli.py
+++ b/mitiq/observable/pauli.py
@@ -279,10 +279,25 @@ class PauliStringCollection:
 
         basis_rotations = set()
         support = set()
+        qubits_with_measurements = set[cirq.Qid]()
+
+        # Find any existing measurement gates in the circuit
+        for _, op, _ in circuit.findall_operations_with_gate_type(
+            cirq.MeasurementGate
+        ):
+            qubits_with_measurements.update(op.qubits)
+
         for pauli in paulis.elements:
             basis_rotations.update(pauli._basis_rotations())
             support.update(pauli._qubits_to_measure())
         measured = circuit + basis_rotations + cirq.measure(*sorted(support))
+
+        if support & qubits_with_measurements:
+            raise ValueError(
+                f"More than one measurement found for qubits: "
+                f"{support & qubits_with_measurements}. Only a single "
+                f"measurement is allowed per qubit."
+            )
 
         # Transform circuit back to original qubits.
         reverse_qubit_map = dict(zip(qubit_map.values(), qubit_map.keys()))

--- a/mitiq/observable/tests/test_pauli.py
+++ b/mitiq/observable/tests/test_pauli.py
@@ -137,6 +137,17 @@ def test_pauli_measure_in_bad_qubits_error():
         pauli.measure_in(circuit)
 
 
+def test_pauli_measure_in_multi__measurement_per_qubit():
+    n = 4
+    pauli = PauliString(spec="Z" * n)
+    circuit = cirq.Circuit(cirq.H.on_each(cirq.LineQubit.range(n)))
+
+    # add a measurement to qubit 0 and 1
+    circuit = circuit + cirq.measure(cirq.LineQubit(0), cirq.LineQubit(1))
+    with pytest.raises(ValueError, match="More than one measurement"):
+        pauli.measure_in(circuit)
+
+
 def test_can_be_measured_with_single_qubit():
     pauli = PauliString(spec="Z")
 


### PR DESCRIPTION
## Description

This PR addresses the issue of a circuit already including a measurement on a qubit and an observable being passed to the executor resulting in another measurement on the qubit.

To address this, before adding the measurement from the observable (PauliString), we check to if a measurement gate has already been applied to the qubit in the circuit.

Also, a test was added to confirm this is behaving properly.

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [X] I added unit tests for new code.