### PR TITLE
Update executor and observable docs

### DIFF
--- a/docs/source/guide/executors.md
+++ b/docs/source/guide/executors.md
@@ -30,7 +30,9 @@ To instantiate an `Executor`, provide a function which either:
 1. Inputs a `mitiq.QPROGRAM` and outputs a `mitiq.QuantumResult`.
 2. Inputs a sequence of `mitiq.QPROGRAM`s and outputs a sequence of `mitiq.QuantumResult`s.
 
-**The function must be [annotated](https://peps.python.org/pep-3107/) to tell Mitiq which type of `QuantumResult` it returns. Functions with no annotations are assumed to return `float`s.**
+```{warning}
+To avoid confusion and invalid results, the executor function must be [annotated](https://peps.python.org/pep-3107/) to tell Mitiq which type of `QuantumResult` it returns. Functions without annotations are assumed to return `float`s.
+```
 
 A `QPROGRAM` is "something which a quantum computer inputs" and a `QuantumResult` is "something which a quantum computer outputs." The latter is canonically a bitstring for real quantum hardware, but can be other objects for testing, e.g. a density matrix.
 

--- a/docs/source/guide/observables.md
+++ b/docs/source/guide/observables.md
@@ -128,8 +128,8 @@ obs.expectation(circuit, execute=mitiq_cirq.sample_bitstrings)
 
 In error mitigation techniques, you can provide an observable to specify the expectation value to mitigate.
 
-```{admonition} Note:
-When specifying an `Observable`, you must ensure that the return type of the executor function is `MeasurementResultLike` or `DensityMatrixLike`.
+```{warning}
+As note in the [executor documentation](./executors.md#the-input-function), the executor must be annotated with the appropriate type hinting for the return type. Additionally, when specifying an `Observable`, you must ensure that the return type of the executor function is `MeasurementResultLike` or `DensityMatrixLike`.
 ```
 
 ```{code-cell} ipython3


### PR DESCRIPTION
## Description

This PR updates the docs for the executor and observable to ensure clear warnings to help users with the compatibility.

In https://github.com/unitaryfund/mitiq/issues/2449#issuecomment-2330370454, @natestemen recommended the following changes to the documentation that are addressed by this PR:

These suggestions are independent of code changes. The warnings should highlight what the needs are for our API.

1. We do mention in the [_The input function_](https://mitiq.readthedocs.io/en/stable/guide/executors.html#the-input-function) section of the Executors core concept page that type hinting or annotation is required. This should be upgraded to a warning[^directives] and flushed out.
 
2. The [_Using observables in error mitigation techniques_](https://mitiq.readthedocs.io/en/stable/guide/observables.html#using-observables-in-error-mitigation-techniques) section of the Observables core concept page should also have a warning and be flushed out.

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.