### PR TITLE
Modularize PEC functionality

### DIFF
--- a/mitiq/pec/__init__.py
+++ b/mitiq/pec/__init__.py
@@ -5,7 +5,13 @@
 
 from mitiq.pec.types import NoisyOperation, OperationRepresentation, NoisyBasis
 from mitiq.pec.sampling import sample_sequence, sample_circuit
-from mitiq.pec.pec import execute_with_pec, mitigate_executor, pec_decorator
+from mitiq.pec.pec import (
+    execute_with_pec,
+    mitigate_executor,
+    pec_decorator,
+    combine_results,
+    intermediary_sampled_circuits,
+)
 
 from mitiq.pec.representations import (
     represent_operation_with_global_depolarizing_noise,

--- a/mitiq/pec/__init__.py
+++ b/mitiq/pec/__init__.py
@@ -10,7 +10,7 @@ from mitiq.pec.pec import (
     mitigate_executor,
     pec_decorator,
     combine_results,
-    intermediary_sampled_circuits,
+    generate_sampled_circuits,
 )
 
 from mitiq.pec.representations import (

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -83,8 +83,8 @@ def intermediary_sampled_circuits(
             sampled circuits. Default is False.
 
     Returns:
-        A list of sampled circuits. If return_signs is True, also returns a
-        list of signs and the norm.
+        A list of sampled circuits. If ``return_signs`` is True, also returns a
+        list of signs, the norm and the number of samples used.
 
     Raises:
         ValueError: If the precision is not within the interval (0, 1].
@@ -136,7 +136,9 @@ def combine_results(
 
     Args:
         results: Results as obtained from running circuits.
-        norm:
+        norm: The one-norm of the circuit representation.
+        signs: The signs corresponding to the positivity of the sampled
+            circuits.
 
     Returns:
         The PEC estimate of the expectation value.

--- a/mitiq/pec/pec.py
+++ b/mitiq/pec/pec.py
@@ -45,7 +45,7 @@ def generate_sampled_circuits(
     num_samples: int | None = None,
     random_state: int | np.random.RandomState | None = None,
     full_output: bool = False,
-) -> list[QPROGRAM] | tuple[list[QPROGRAM], list[int], float, int]:
+) -> list[QPROGRAM] | tuple[list[QPROGRAM], list[int], float]:
     """Generates a list of sampled circuits based on the given
     quasi-probability representations.
 
@@ -63,7 +63,7 @@ def generate_sampled_circuits(
 
     Returns:
         A list of sampled circuits. If ``full_output`` is True, also returns a
-        list of signs, the norm and the number of samples used.
+        list of signs, the norm.
 
     Raises:
         ValueError: If the precision is not within the interval (0, 1].
@@ -99,7 +99,7 @@ def generate_sampled_circuits(
     )
 
     if full_output:
-        return sampled_circuits, signs, norm, num_samples
+        return sampled_circuits, signs, norm
     return sampled_circuits
 
 
@@ -186,10 +186,10 @@ def execute_with_pec(
         The error is estimated as ``pec_std / sqrt(num_samples)``, where
         ``pec_std`` is the standard deviation of the PEC samples, i.e., the
         square root of the mean squared deviation of the sampled values from
-        ``pec_value``. If ``full_output`` is ``True``, only ``pec_value`` is
+        ``pec_value``. If ``full_output`` is ``False``, only ``pec_value`` is
         returned.
     """
-    sampled_circuits, signs, norm, num_circuits = generate_sampled_circuits(
+    sampled_circuits, signs, norm = generate_sampled_circuits(
         circuit,
         representations,
         precision,
@@ -212,6 +212,7 @@ def execute_with_pec(
     if not full_output:
         return pec_value
 
+    num_circuits = len(sampled_circuits)
     # Build dictionary with additional results and data
     pec_data: Dict[str, Any] = {
         "num_samples": num_circuits,

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -23,7 +23,7 @@ from mitiq.pec import (
     OperationRepresentation,
     combine_results,
     execute_with_pec,
-    intermediary_sampled_circuits,
+    generate_sampled_circuits,
     mitigate_executor,
     pec_decorator,
 )
@@ -369,11 +369,11 @@ def test_execute_with_pec_error_scaling(num_samples: int):
 @pytest.mark.parametrize("precision", [0.2, 0.1])
 def test_precision_option_used_in_num_samples(precision):
     """Tests that the 'precision' argument is used to deduce num_samples."""
-    _, _, _, num_samples = intermediary_sampled_circuits(
+    _, _, _, num_samples = generate_sampled_circuits(
         oneq_circ,
         representations=pauli_representations,
         precision=precision,
-        return_signs=True,
+        full_output=True,
         random_state=1,
     )
     # we expect num_samples = 1/precision^2:
@@ -383,12 +383,12 @@ def test_precision_option_used_in_num_samples(precision):
 def test_precision_ignored_when_num_samples_present():
     """Check precision is ignored when num_samples is given."""
     num_samples_expected = 123
-    _, _, _, num_samples = intermediary_sampled_circuits(
+    _, _, _, num_samples = generate_sampled_circuits(
         oneq_circ,
         representations=pauli_representations,
         precision=0.1,
         num_samples=num_samples_expected,
-        return_signs=True,
+        full_output=True,
         random_state=1,
     )
     assert num_samples == num_samples_expected
@@ -398,7 +398,7 @@ def test_precision_ignored_when_num_samples_present():
 def test_bad_precision_argument(bad_value):
     """Tests that if 'precision' is not within (0, 1] an error is raised."""
     with pytest.raises(ValueError, match="The value of 'precision' should"):
-        intermediary_sampled_circuits(
+        generate_sampled_circuits(
             oneq_circ,
             representations=pauli_representations,
             precision=bad_value,
@@ -412,7 +412,7 @@ def test_large_sample_size_warning(mock_sample_circuit):
     mock_sample_circuit.return_value = ([], [], 0.911)
 
     with pytest.warns(LargeSampleWarning):
-        intermediary_sampled_circuits(
+        generate_sampled_circuits(
             oneq_circ,
             representations=[],
             num_samples=100_001,

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -258,8 +258,6 @@ def test_execute_with_pec_mitigates_noise(circuit, executor, circuit_type):
             base_noise=BASE_NOISE,
             qubits=[cirq.NamedQubit(name) for name in ("q_0", "q_1")],
         )
-        # TODO: PEC with Qiskit is slow.
-        #  See https://github.com/unitaryfund/mitiq/issues/507.
         circuit, _ = convert_to_mitiq(circuit)
     else:
         reps = pauli_representations

--- a/mitiq/pec/tests/test_pec.py
+++ b/mitiq/pec/tests/test_pec.py
@@ -369,29 +369,31 @@ def test_execute_with_pec_error_scaling(num_samples: int):
 @pytest.mark.parametrize("precision", [0.2, 0.1])
 def test_precision_option_used_in_num_samples(precision):
     """Tests that the 'precision' argument is used to deduce num_samples."""
-    _, _, _, num_samples = generate_sampled_circuits(
+    circuits, _, _ = generate_sampled_circuits(
         oneq_circ,
         representations=pauli_representations,
         precision=precision,
         full_output=True,
         random_state=1,
     )
+    num_circuits = len(circuits)
     # we expect num_samples = 1/precision^2:
-    assert np.isclose(precision**2 * num_samples, 1, atol=0.2)
+    assert np.isclose(precision**2 * num_circuits, 1, atol=0.2)
 
 
 def test_precision_ignored_when_num_samples_present():
     """Check precision is ignored when num_samples is given."""
-    num_samples_expected = 123
-    _, _, _, num_samples = generate_sampled_circuits(
+    num_expected_circuits = 123
+    circuits, _, _ = generate_sampled_circuits(
         oneq_circ,
         representations=pauli_representations,
         precision=0.1,
-        num_samples=num_samples_expected,
+        num_samples=num_expected_circuits,
         full_output=True,
         random_state=1,
     )
-    assert num_samples == num_samples_expected
+    num_circuits = len(circuits)
+    assert num_circuits == num_expected_circuits
 
 
 @pytest.mark.parametrize("bad_value", (0, -1, 2))


### PR DESCRIPTION
## Description

This PR introduces two functions

- `intermediary_sampled_circuits`, and
- `combine_results`

for generating PEC sampled circuits, and combining results from having run those circuits. The first function is used to simplify the code in `execute_with_pec`, but the second function cannot be used due to the ability to output PEC data via the `full_output` flag.

It also "simplifies" some of the PEC tests to move testing to the new `intermediary_sampled_circuits` function.

fixes https://github.com/unitaryfund/mitiq/issues/2563