### PR TITLE
Modularize DDD functionality

### DIFF
--- a/mitiq/ddd/__init__.py
+++ b/mitiq/ddd/__init__.py
@@ -14,4 +14,4 @@ from mitiq.ddd.insertion import (
     insert_ddd_sequences,
 )
 
-from mitiq.ddd.ddd import execute_with_ddd, mitigate_executor, ddd_decorator
+from mitiq.ddd.ddd import execute_with_ddd, mitigate_executor, ddd_decorator, generate_circuits_with_ddd, generate_ddd_value

--- a/mitiq/ddd/__init__.py
+++ b/mitiq/ddd/__init__.py
@@ -14,4 +14,4 @@ from mitiq.ddd.insertion import (
     insert_ddd_sequences,
 )
 
-from mitiq.ddd.ddd import execute_with_ddd, mitigate_executor, ddd_decorator, generate_circuits_with_ddd, generate_ddd_value
+from mitiq.ddd.ddd import execute_with_ddd, mitigate_executor, ddd_decorator, generate_circuits_with_ddd, combine_results

--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -95,7 +95,7 @@ def generate_ddd_value(results: list[float]) -> float:
     Returns:
         The expectation value estimated with DDD.
     """
-    return np.average(results)
+    return float(np.average(results))
 
 
 def generate_circuits_with_ddd(

--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -72,10 +72,7 @@ def execute_with_ddd(
 
     assert len(results) == num_trials
 
-    ddd_value = generate_ddd_value(results, num_trials)
-
-    # Brian test TODO check and remove
-    # check that np.average(results) == np.sum(results) / num_trials
+    ddd_value = generate_ddd_value(results)
 
     if not full_output:
         return ddd_value
@@ -88,18 +85,39 @@ def execute_with_ddd(
     return ddd_value, ddd_data
 
 
-# TODO rename and docstring
 def generate_ddd_value(results: list[float]) -> float:
+    """Averages over the DDD results to get the expectation value from using
+    DDD.
+
+    Args:
+        results: Results as obtained from running circuits.
+
+    Returns:
+        The expectation value estimated with DDD.
+    """
     return np.average(results)
 
 
-# TODO rename and docstring
 def generate_circuits_with_ddd(
     circuit: QPROGRAM,
     rule: Callable[[int], QPROGRAM],
     rule_args: Dict[str, Any] = {},
     num_trials: int = 1,
 ) -> list[QPROGRAM]:
+    """Generates a list of circuits with DDD sequences inserted.
+
+    Args:
+        circuit: The quantum circuit to be modified with DD.
+        rule: A function that takes as main argument a slack length (i.e. the
+            number of idle moments) of a slack window (i.e. a single-qubit idle
+            window in a circuit) and returns the DDD sequence of gates to be
+            applied in that window.
+        rule_args: An optional dictionary of keyword arguments for ``rule``.
+        num_trials: The number of circuits to generate with DDD insertions.
+
+    Returns:
+        A list of circuits with DDD inserted.
+    """
     rule_partial: Callable[[int], QPROGRAM]
     rule_partial = partial(rule, **rule_args)
 

--- a/mitiq/ddd/ddd.py
+++ b/mitiq/ddd/ddd.py
@@ -72,7 +72,7 @@ def execute_with_ddd(
 
     assert len(results) == num_trials
 
-    ddd_value = generate_ddd_value(results)
+    ddd_value = combine_results(results)
 
     if not full_output:
         return ddd_value
@@ -85,7 +85,7 @@ def execute_with_ddd(
     return ddd_value, ddd_data
 
 
-def generate_ddd_value(results: list[float]) -> float:
+def combine_results(results: list[float]) -> float:
     """Averages over the DDD results to get the expectation value from using
     DDD.
 

--- a/mitiq/ddd/tests/test_ddd.py
+++ b/mitiq/ddd/tests/test_ddd.py
@@ -233,7 +233,7 @@ def test_ddd_decorator_with_rule_args():
     assert not np.isclose(mitigated_large_spacing, mitigated_small_spacing)
 
 
-@mark.parametrize("num_trials", [1, 3, 5])
+@mark.parametrize("num_trials", [1, 10, 20, 30])
 def test_num_trials_generates_circuits(num_trials: int):
     """Test that the number of generated circuits follows num_trials."""
 

--- a/mitiq/ddd/tests/test_ddd.py
+++ b/mitiq/ddd/tests/test_ddd.py
@@ -12,7 +12,12 @@ import numpy as np
 from pytest import mark
 
 from mitiq import QPROGRAM, SUPPORTED_PROGRAM_TYPES, Executor
-from mitiq.ddd import ddd_decorator, execute_with_ddd, mitigate_executor
+from mitiq.ddd import (
+    ddd_decorator,
+    execute_with_ddd,
+    generate_circuits_with_ddd,
+    mitigate_executor,
+)
 from mitiq.ddd.rules import xx, xyxy, yy
 from mitiq.interface import convert_from_mitiq, convert_to_mitiq
 from mitiq.interface.mitiq_cirq import compute_density_matrix
@@ -226,3 +231,14 @@ def test_ddd_decorator_with_rule_args():
     # What is important to test is getting different results.
     assert not np.isclose(unmitigated, mitigated_small_spacing)
     assert not np.isclose(mitigated_large_spacing, mitigated_small_spacing)
+
+
+@mark.parametrize("num_trials", [1, 3, 5])
+def test_num_trials_generates_circuits(num_trials: int):
+    """Test that the number of generated circuits follows num_trials."""
+
+    circuits = generate_circuits_with_ddd(
+        circuit_cirq_a, rule=xx, num_trials=num_trials
+    )
+
+    assert num_trials == len(circuits)


### PR DESCRIPTION

## Description
---
This PR introduces two functions

- `generate_circuits_with_ddd`
- `generate_ddd_value`

for generating circuits with DDD sequences and using the results from running those circuits to get an expectation value. The first function moves generating the circuits outside of `execute_with_ddd`, allowing users to generate and return DDD circuits.

The second function takes the results from all of the DDD circuits used in `execute_with_ddd` and averages the results to produce a single expectation value (float) that is returned.

fixes #2562 
