### PR TITLE
Fixed typo in documentation

### DIFF
--- a/docs/source/guide/executors.md
+++ b/docs/source/guide/executors.md
@@ -76,7 +76,7 @@ print("\nExecuted circuits:\n", *executor.executed_circuits, sep="\n")
 print("\nQuantum results:\n", *executor.quantum_results, sep="\n")
 ```
 
-To run a circuit of sequence of circuits, use the `Executor.evaluate` method.
+To run a circuit or sequence of circuits, use the `Executor.evaluate` method.
 
 ```{code-cell} ipython3
 import cirq

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -118,7 +118,7 @@ class Executor:
         quantum results are stored in ``self.quantum_results``.
 
         Args:
-            circuits: A single circuit of list of circuits.
+            circuits: A single circuit or list of circuits.
             observable: Observable O in the expression Tr[ρ O]. If None,
                 the ``executor`` must return a float (which corresponds to
                 Tr[ρ O] for a specific, fixed observable O).


### PR DESCRIPTION
## Description

- I fixed typos in two places in the documentation.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file
