### PR TITLE
typo corrected from supeconducting to superconducting

### DIFF
--- a/docs/source/guide/error-mitigation.md
+++ b/docs/source/guide/error-mitigation.md
@@ -230,7 +230,7 @@ A list of research articles academic resources on error mitigation:
       {cite}`Endo_2018_PRX`
     - Experiment on trapped ions, S. Zhang *et al.*, *Nature
       Comm.* 2020 {cite}`Zhang_2020_NatComm`
-    - Experiment with gate set tomography on a supeconducting
+    - Experiment with gate set tomography on a superconducting
       circuit device, J. Sun *et al.*, 2019 arXiv
       {cite}`Sun_2021_PRAppl`
 


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description
Typo correction has been done in references under users guide [14] from "supeconducting" to "superconducting". 
#resolves #2616
<!-- Please explain the changes you made here. -->

---

### License

- [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file
