### PR TITLE
Auxilliary code for VD to apply a Bi matrix on a circuit

### DIFF
--- a/mitiq/vd/tests/test_vd_utils.py
+++ b/mitiq/vd/tests/test_vd_utils.py
@@ -148,4 +148,5 @@ def test_generate_diagonalizing_gate():
     )
 
     assert np.allclose(
-        _generate_diagonalizing_gate(2)._matrix, expected_matrix)
+        _generate_diagonalizing_gate(2)._matrix, expected_matrix
+    )

--- a/mitiq/vd/tests/test_vd_utils.py
+++ b/mitiq/vd/tests/test_vd_utils.py
@@ -96,10 +96,11 @@ def test_copy_circuit_parallel_gridqubits():
 
 def test_apply_diagonalizing_gate():
     num_copies = 2
-    qubits = cirq.LineQubit.range(2)
+    qubits = cirq.LineQubit.range(3)
     original_circuit = cirq.Circuit(
         cirq.H(qubits[0]),
         cirq.CNOT(qubits[0], qubits[1]),
+        cirq.X(qubits[2]),
     )
     N = len(original_circuit.all_qubits())
 
@@ -126,14 +127,13 @@ def test_apply_diagonalizing_gate():
         ]
     )
 
-    # fetch the operations in the last moment of the circuit
-    last_moment = new_circuit[-1]
-    last_moment_ops = list(last_moment.operations)
+    # fetch the last N operations of the new circuit
+    last_N_ops = list(new_circuit.all_operations())[-N:]
 
     # check that the last moment consists of
     # the right amount of diagonalizing gates
-    assert len(last_moment_ops) == len(original_circuit.all_qubits())
-    for op in last_moment_ops:
+    assert len(last_N_ops) == len(original_circuit.all_qubits())
+    for op in last_N_ops:
         assert op.gate == cirq.MatrixGate(expected_matrix)
 
 

--- a/mitiq/vd/tests/test_vd_utils.py
+++ b/mitiq/vd/tests/test_vd_utils.py
@@ -94,7 +94,9 @@ def test_apply_Bi_gate_default():
     circuit = cirq.Circuit(
         cirq.H(qubits[0]),
         cirq.CNOT(qubits[0], qubits[1]),
-    )
+        cirq.H(qubits[2]),
+        cirq.CNOT(qubits[2], qubits[3]),
+    ) # TODO: replace this circuit definition using the copy function we already defined
 
     updated_circuit = apply_Bi_gate(circuit)
 
@@ -115,6 +117,7 @@ def test_apply_Bi_gate_default():
     for op in updated_circuit.all_operations():
         if isinstance(op.gate, cirq.MatrixGate):
             np.testing.assert_array_almost_equal(op.gate._matrix, expected_matrix)
+    # TODO: replace this test with a test that the last layer of operations are B gates
 
 
 def test_apply_Bi_gate_custom():
@@ -160,11 +163,12 @@ def test_apply_Bi_gate_unitary():
     circuit = cirq.Circuit(
         cirq.H(qubits[0]),
         cirq.CNOT(qubits[0], qubits[1]),
-    )
+        cirq.I(qubits[2]),
+        cirq.I(qubits[3]),
+    ) # TODO: replace this circuit definition with copy in parallel function
 
     updated_circuit = apply_Bi_gate(circuit)
 
     # Verify unitary of updated circuit is valid
     new_unitary = cirq.unitary(updated_circuit)
     assert new_unitary.shape == (2**len(qubits), 2**len(qubits))
-    assert np.allclose(new_unitary @ new_unitary.conj().T, np.eye(new_unitary.shape[0]))

--- a/mitiq/vd/tests/test_vd_utils.py
+++ b/mitiq/vd/tests/test_vd_utils.py
@@ -1,7 +1,10 @@
 import cirq
 import numpy as np
 
-from mitiq.vd.vd_utils import _copy_circuit_parallel, apply_Bi_gate
+from mitiq.vd.vd_utils import (
+    _copy_circuit_parallel,
+    _generate_diagonalizing_gate,
+)
 
 
 def test_copy_circuit_parallel_lengths():
@@ -172,3 +175,13 @@ def test_apply_Bi_gate_unitary():
     # Verify unitary of updated circuit is valid
     new_unitary = cirq.unitary(updated_circuit)
     assert new_unitary.shape == (2**len(qubits), 2**len(qubits))
+
+def test_generate_diagonalizing_gate():
+    expected_matrix = np.array([
+        [1, 0, 0, 0],
+        [0, np.sqrt(2) / 2, np.sqrt(2) / 2, 0],
+        [0, np.sqrt(2) / 2, -np.sqrt(2) / 2, 0],
+        [0, 0, 0, 1]
+    ])
+
+    assert np.allclose(_generate_diagonalizing_gate(2)._matrix, expected_matrix)

--- a/mitiq/vd/vd_utils.py
+++ b/mitiq/vd/vd_utils.py
@@ -4,7 +4,7 @@ import cirq
 import numpy as np
 
 
-def _copy_circuit_parallel(circuit: cirq.Circuit, 
+def _copy_circuit_parallel(circuit: cirq.Circuit,
                            num_copies: int = 2) -> cirq.Circuit:
     """Copies a circuit num_copies times in parallel.
 
@@ -53,28 +53,28 @@ def _copy_circuit_parallel(circuit: cirq.Circuit,
     return new_circuit
 
 
-def _apply_diagonalizing_gate(circuit: cirq.Circuit, 
+def _apply_diagonalizing_gate(circuit: cirq.Circuit,
                               num_copies: int) -> cirq.Circuit:
     """
-    Apply the VD diagonalizing gate to a circuit. 
+    Apply the VD diagonalizing gate to a circuit.
     The gate has to be applied in a specific way.
-    Based on the number of copies of the original circuit, 
+    Based on the number of copies of the original circuit,
     the diagonalizing gate is a num_copies-qubit gate
-    that is applied N times where N is the amount of 
+    that is applied N times where N is the amount of
     qubits in the original circuit.
     The diagonalizing gate is applied as follows:
-    first apply the gate to qubit 1 of copy 1, 
+    first apply the gate to qubit 1 of copy 1,
         qubit 1 of copy 2, ..., qubit 1 of copy num_copies.
-    second apply the gate to qubit 2 of copy 1, 
+    second apply the gate to qubit 2 of copy 1,
         qubit 2 of copy 2, ..., qubit 2 of copy num_copies, and so on.
 
     Args:
         circuit:
             The circuit to apply the diagonalizing gate to.
         num_copies:
-            The number of copies of the original 
+            The number of copies of the original
             circuit that this circuit consists of.
-            The diagonalizing matrix depends on 
+            The diagonalizing matrix depends on
             num_copies and it is a 'num_copies'-qubit gate.
 
     Returns:
@@ -92,6 +92,9 @@ def _apply_diagonalizing_gate(circuit: cirq.Circuit,
         qubits = [
             cirq.LineQubit(i + N * j) for j in range(num_copies)
         ]  # select qubit i of each copy
+
+        print(qubits)
+
         new_circuit.append(diag_gate(*qubits))
 
     return new_circuit
@@ -120,6 +123,7 @@ def _generate_diagonalizing_gate(num_copies: int = 2) -> cirq.Gate:
         )
     else:
         raise NotImplementedError(
-            "Only num_copies = 2 is currently supported.")
+            "Only num_copies = 2 is currently supported."
+            )
 
     return cirq.MatrixGate(diagonalizing_matrix)

--- a/mitiq/vd/vd_utils.py
+++ b/mitiq/vd/vd_utils.py
@@ -4,8 +4,9 @@ import cirq
 import numpy as np
 
 
-def _copy_circuit_parallel(circuit: cirq.Circuit,
-                           num_copies: int = 2) -> cirq.Circuit:
+def _copy_circuit_parallel(
+    circuit: cirq.Circuit, num_copies: int = 2
+) -> cirq.Circuit:
     """Copies a circuit num_copies times in parallel.
 
     Given a circuit that acts on N qubits,
@@ -53,8 +54,9 @@ def _copy_circuit_parallel(circuit: cirq.Circuit,
     return new_circuit
 
 
-def _apply_diagonalizing_gate(circuit: cirq.Circuit,
-                              num_copies: int) -> cirq.Circuit:
+def _apply_diagonalizing_gate(
+    circuit: cirq.Circuit, num_copies: int
+) -> cirq.Circuit:
     """
     Apply the VD diagonalizing gate to a circuit.
     The gate has to be applied in a specific way.
@@ -124,6 +126,6 @@ def _generate_diagonalizing_gate(num_copies: int = 2) -> cirq.Gate:
     else:
         raise NotImplementedError(
             "Only num_copies = 2 is currently supported."
-            )
+        )
 
     return cirq.MatrixGate(diagonalizing_matrix)

--- a/mitiq/vd/vd_utils.py
+++ b/mitiq/vd/vd_utils.py
@@ -95,8 +95,6 @@ def _apply_diagonalizing_gate(
             cirq.LineQubit(i + N * j) for j in range(num_copies)
         ]  # select qubit i of each copy
 
-        print(qubits)
-
         new_circuit.append(diag_gate(*qubits))
 
     return new_circuit
@@ -105,7 +103,7 @@ def _apply_diagonalizing_gate(
 def _generate_diagonalizing_gate(num_copies: int = 2) -> cirq.Gate:
     """
     Generate the diagonalizing gate for the VD algorithm.
-    Currently only num_copies
+    Currently only num_copies=2 is supported.
 
     Args:
         num_qubits:

--- a/mitiq/vd/vd_utils.py
+++ b/mitiq/vd/vd_utils.py
@@ -77,9 +77,12 @@ def apply_Bi_gate(circuit: cirq.Circuit, gate: Optional[np.ndarray] = None) -> c
 
     B_gate = cirq.MatrixGate(gate)
 
-    N = len(circuit.all_qubits())
+    N = len(circuit.all_qubits()) // 2
+    # M = B_gate.num_qubits
 
-    for i in N:
-        circuit.append(B_gate(cirq.LineQubit(i), cirq.LineQubit(i+N)))
+    new_circuit = circuit.copy()
 
-    return circuit
+    for i in range(N):
+        new_circuit.append(B_gate(cirq.LineQubit(i), cirq.LineQubit(i+N)))
+
+    return new_circuit

--- a/mitiq/vd/vd_utils.py
+++ b/mitiq/vd/vd_utils.py
@@ -1,12 +1,11 @@
-from typing import List, cast, Optional
-import numpy as np
+from typing import List, cast
 
 import cirq
+import numpy as np
 
 
-def _copy_circuit_parallel(
-    circuit: cirq.Circuit, num_copies: int = 2
-) -> cirq.Circuit:
+def _copy_circuit_parallel(circuit: cirq.Circuit, 
+                           num_copies: int = 2) -> cirq.Circuit:
     """Copies a circuit num_copies times in parallel.
 
     Given a circuit that acts on N qubits,
@@ -24,9 +23,6 @@ def _copy_circuit_parallel(
         A cirq circuit that is the parallel composition of
           num_copies copies of circuit.
     """
-
-    if num_copies != 2:
-        raise NotImplementedError("Only num_copies = 2 is currently supported.")
 
     new_circuit = cirq.Circuit()
     N = len(circuit.all_qubits())
@@ -56,22 +52,31 @@ def _copy_circuit_parallel(
 
     return new_circuit
 
-def _apply_diagonalizing_gate(circuit: cirq.Circuit, num_copies: int) -> cirq.Circuit:
+
+def _apply_diagonalizing_gate(circuit: cirq.Circuit, 
+                              num_copies: int) -> cirq.Circuit:
     """
-    Apply the VD diagonalizing gate to a circuit. The gate has to be applied in a specific way.
-    Based on the number of copies of the original circuit, the diagonalizing gate is a num_copies-qubit gate
-    that is applied N times where N is the amount of qubits in the original circuit. 
-    The diagonalizing gate is applied as follows: 
-    first apply the gate to qubit 1 of copy 1, qubit 1 of copy 2, ..., qubit 1 of copy num_copies.
-    second apply the gate to qubit 2 of copy 1, qubit 2 of copy 2, ..., qubit 2 of copy num_copies, and so on.
+    Apply the VD diagonalizing gate to a circuit. 
+    The gate has to be applied in a specific way.
+    Based on the number of copies of the original circuit, 
+    the diagonalizing gate is a num_copies-qubit gate
+    that is applied N times where N is the amount of 
+    qubits in the original circuit.
+    The diagonalizing gate is applied as follows:
+    first apply the gate to qubit 1 of copy 1, 
+        qubit 1 of copy 2, ..., qubit 1 of copy num_copies.
+    second apply the gate to qubit 2 of copy 1, 
+        qubit 2 of copy 2, ..., qubit 2 of copy num_copies, and so on.
 
     Args:
         circuit:
             The circuit to apply the diagonalizing gate to.
         num_copies:
-            The number of copies of the original circuit that this circuit consists of.
-            The diagonalizing matrix depends on num_copies and it is a 'num_copies'-qubit gate.  
-            
+            The number of copies of the original 
+            circuit that this circuit consists of.
+            The diagonalizing matrix depends on 
+            num_copies and it is a 'num_copies'-qubit gate.
+
     Returns:
         The circuit with the diagonalizing gate applied.
     """
@@ -79,17 +84,20 @@ def _apply_diagonalizing_gate(circuit: cirq.Circuit, num_copies: int) -> cirq.Ci
     new_circuit = circuit.copy()
 
     # this is the number of qubits in the original circuit
-    N = len(circuit.all_qubits()) // num_copies 
+    N = len(circuit.all_qubits()) // num_copies
 
     diag_gate = _generate_diagonalizing_gate(num_copies)
 
     for i in range(num_copies):
-        qubits = [cirq.LineQubit(i+N*j) for j in range(num_copies)] # select qubit i of each copy
+        qubits = [
+            cirq.LineQubit(i + N * j) for j in range(num_copies)
+        ]  # select qubit i of each copy
         new_circuit.append(diag_gate(*qubits))
 
     return new_circuit
 
-def _generate_diagonalizing_gate(num_copies: int=2) -> cirq.Gate:
+
+def _generate_diagonalizing_gate(num_copies: int = 2) -> cirq.Gate:
     """
     Generate the diagonalizing gate for the VD algorithm.
     Currently only num_copies
@@ -97,16 +105,21 @@ def _generate_diagonalizing_gate(num_copies: int=2) -> cirq.Gate:
     Args:
         num_qubits:
             The number of qubits that the gate acts on.
-            
+
     Returns:
         The diagonalizing gate.
     """
     if num_copies == 2:
-        diagonalizing_matrix = np.array([[1, 0, 0, 0],
-                                         [0, np.sqrt(2)/2, np.sqrt(2)/2, 0],
-                                         [0, np.sqrt(2)/2, -np.sqrt(2)/2, 0],
-                                         [0, 0, 0, 1]])
+        diagonalizing_matrix = np.array(
+            [
+                [1, 0, 0, 0],
+                [0, np.sqrt(2) / 2, np.sqrt(2) / 2, 0],
+                [0, np.sqrt(2) / 2, -np.sqrt(2) / 2, 0],
+                [0, 0, 0, 1],
+            ]
+        )
     else:
-        raise NotImplementedError("Only num_copies = 2 is currently supported.")
-        
+        raise NotImplementedError(
+            "Only num_copies = 2 is currently supported.")
+
     return cirq.MatrixGate(diagonalizing_matrix)

--- a/mitiq/vd/vd_utils.py
+++ b/mitiq/vd/vd_utils.py
@@ -90,7 +90,7 @@ def _apply_diagonalizing_gate(
 
     diag_gate = _generate_diagonalizing_gate(num_copies)
 
-    for i in range(num_copies):
+    for i in range(N):
         qubits = [
             cirq.LineQubit(i + N * j) for j in range(num_copies)
         ]  # select qubit i of each copy

--- a/mitiq/vd/vd_utils.py
+++ b/mitiq/vd/vd_utils.py
@@ -1,4 +1,5 @@
 from typing import List, cast
+import numpy as np
 
 import cirq
 
@@ -51,3 +52,34 @@ def _copy_circuit_parallel(
             new_circuit += circuit.transform_qubits(map_for_grid_qubits)
 
     return new_circuit
+
+def apply_Bi_gate(circuit, gate=None):
+    """
+    Apply a Bi gate to a circuit.
+
+    Args:
+        circuit:
+            The circuit to apply the Bi gate to.
+        gate:
+            The matrix representation of the Bi gate.
+            Default is None, in which case the pre-defined Bi gate will be applied.
+
+    Returns:
+        The circuit with the Bi gate applied.
+    """
+    if gate is None:
+        gate = np.array([
+            [1, 0, 0, 0],
+            [0, np.sqrt(2)/2, np.sqrt(2)/2, 0],
+            [0, np.sqrt(2)/2, -np.sqrt(2)/2, 0],
+            [0, 0, 0, 1]
+        ])
+
+    B_gate = cirq.MatrixGate(gate)
+
+    N = len(circuit.all_qubits())
+
+    for i in N:
+        circuit.append(B_gate(cirq.LineQubit(i), cirq.LineQubit(i+N)))
+
+    return circuit

--- a/mitiq/vd/vd_utils.py
+++ b/mitiq/vd/vd_utils.py
@@ -1,4 +1,4 @@
-from typing import List, cast
+from typing import List, cast, Optional
 import numpy as np
 
 import cirq
@@ -53,9 +53,9 @@ def _copy_circuit_parallel(
 
     return new_circuit
 
-def apply_Bi_gate(circuit, gate=None):
+def apply_Bi_gate(circuit: cirq.Circuit, gate: Optional[np.ndarray] = None) -> cirq.Circuit:
     """
-    Apply a Bi gate to a circuit.
+    Apply a Bi gate to a circuit. We assume that N is even (from the other functions).
 
     Args:
         circuit:

--- a/mitiq/vd/vd_utils.py
+++ b/mitiq/vd/vd_utils.py
@@ -7,18 +7,13 @@ import numpy as np
 def _copy_circuit_parallel(
     circuit: cirq.Circuit, num_copies: int = 2
 ) -> cirq.Circuit:
-    """Copies a circuit num_copies times in parallel.
-
-    Given a circuit that acts on N qubits,
-    this function returns a circuit
-    that copies the circuit num_copies times in parallel.
-    This means the resulting circuit has N * num_copies qubits.
+    """Given a circuit that acts on N qubits, this function returns a circuit
+    that copies the circuit num_copies times in parallel. This means the
+    resulting circuit has N * num_copies qubits.
 
     Args:
-        circuit:
-            The circuit to be copied.
-        num_copies:
-            The number of copies of circuit to be made.
+        circuit: The circuit to be copied.
+        num_copies: The number of copies of circuit to be made.
 
     Returns:
         A cirq circuit that is the parallel composition of
@@ -57,27 +52,16 @@ def _copy_circuit_parallel(
 def _apply_diagonalizing_gate(
     circuit: cirq.Circuit, num_copies: int
 ) -> cirq.Circuit:
-    """
-    Apply the VD diagonalizing gate to a circuit.
-    The gate has to be applied in a specific way.
-    Based on the number of copies of the original circuit,
-    the diagonalizing gate is a num_copies-qubit gate
-    that is applied N times where N is the amount of
-    qubits in the original circuit.
-    The diagonalizing gate is applied as follows:
-    first apply the gate to qubit 1 of copy 1,
-        qubit 1 of copy 2, ..., qubit 1 of copy num_copies.
-    second apply the gate to qubit 2 of copy 1,
-        qubit 2 of copy 2, ..., qubit 2 of copy num_copies, and so on.
+    """Apply the diagonalizing gate to a circuit, assuming the circuit has been
+    copied in parallel ``num_copies`` times.
+
+    The diagonalizing gate is applied to the first qubit of all copies, to the
+    second qubit of all copies, etc.
 
     Args:
-        circuit:
-            The circuit to apply the diagonalizing gate to.
-        num_copies:
-            The number of copies of the original
-            circuit that this circuit consists of.
-            The diagonalizing matrix depends on
-            num_copies and it is a 'num_copies'-qubit gate.
+        circuit: The circuit to apply the diagonalizing gate to.
+        num_copies: The number of copies of the original circuit that the input
+            circuit consists of.
 
     Returns:
         The circuit with the diagonalizing gate applied.
@@ -101,16 +85,13 @@ def _apply_diagonalizing_gate(
 
 
 def _generate_diagonalizing_gate(num_copies: int = 2) -> cirq.Gate:
-    """
-    Generate the diagonalizing gate for the VD algorithm.
-    Currently only num_copies=2 is supported.
+    """Generate the diagonalizing gate for the VD algorithm. Currently only
+    ``num_copies=2`` is supported.
 
     Args:
-        num_qubits:
-            The number of qubits that the gate acts on.
+        num_qubits: The number of qubits that the gate acts on.
 
-    Returns:
-        The diagonalizing gate.
+    Returns: The diagonalizing gate.
     """
     if num_copies == 2:
         diagonalizing_matrix = np.array(

--- a/mitiq/vd/vd_utils.py
+++ b/mitiq/vd/vd_utils.py
@@ -25,6 +25,9 @@ def _copy_circuit_parallel(
           num_copies copies of circuit.
     """
 
+    if num_copies != 2:
+        raise NotImplementedError("Only num_copies = 2 is currently supported.")
+
     new_circuit = cirq.Circuit()
     N = len(circuit.all_qubits())
     qubits = list(circuit.all_qubits())
@@ -53,36 +56,57 @@ def _copy_circuit_parallel(
 
     return new_circuit
 
-def apply_Bi_gate(circuit: cirq.Circuit, gate: Optional[np.ndarray] = None) -> cirq.Circuit:
+def _apply_diagonalizing_gate(circuit: cirq.Circuit, num_copies: int) -> cirq.Circuit:
     """
-    Apply a Bi gate to a circuit. We assume that N is even (from the other functions).
+    Apply the VD diagonalizing gate to a circuit. The gate has to be applied in a specific way.
+    Based on the number of copies of the original circuit, the diagonalizing gate is a num_copies-qubit gate
+    that is applied N times where N is the amount of qubits in the original circuit. 
+    The diagonalizing gate is applied as follows: 
+    first apply the gate to qubit 1 of copy 1, qubit 1 of copy 2, ..., qubit 1 of copy num_copies.
+    second apply the gate to qubit 2 of copy 1, qubit 2 of copy 2, ..., qubit 2 of copy num_copies, and so on.
 
     Args:
         circuit:
-            The circuit to apply the Bi gate to.
-        gate:
-            The matrix representation of the Bi gate.
-            Default is None, in which case the pre-defined Bi gate will be applied.
-
+            The circuit to apply the diagonalizing gate to.
+        num_copies:
+            The number of copies of the original circuit that this circuit consists of.
+            The diagonalizing matrix depends on num_copies and it is a 'num_copies'-qubit gate.  
+            
     Returns:
-        The circuit with the Bi gate applied.
+        The circuit with the diagonalizing gate applied.
     """
-    if gate is None:
-        gate = np.array([
-            [1, 0, 0, 0],
-            [0, np.sqrt(2)/2, np.sqrt(2)/2, 0],
-            [0, np.sqrt(2)/2, -np.sqrt(2)/2, 0],
-            [0, 0, 0, 1]
-        ])
-
-    B_gate = cirq.MatrixGate(gate)
-
-    N = len(circuit.all_qubits()) // 2
-    # M = B_gate.num_qubits
 
     new_circuit = circuit.copy()
 
-    for i in range(N):
-        new_circuit.append(B_gate(cirq.LineQubit(i), cirq.LineQubit(i+N)))
+    # this is the number of qubits in the original circuit
+    N = len(circuit.all_qubits()) // num_copies 
+
+    diag_gate = _generate_diagonalizing_gate(num_copies)
+
+    for i in range(num_copies):
+        qubits = [cirq.LineQubit(i+N*j) for j in range(num_copies)] # select qubit i of each copy
+        new_circuit.append(diag_gate(*qubits))
 
     return new_circuit
+
+def _generate_diagonalizing_gate(num_copies: int=2) -> cirq.Gate:
+    """
+    Generate the diagonalizing gate for the VD algorithm.
+    Currently only num_copies
+
+    Args:
+        num_qubits:
+            The number of qubits that the gate acts on.
+            
+    Returns:
+        The diagonalizing gate.
+    """
+    if num_copies == 2:
+        diagonalizing_matrix = np.array([[1, 0, 0, 0],
+                                         [0, np.sqrt(2)/2, np.sqrt(2)/2, 0],
+                                         [0, np.sqrt(2)/2, -np.sqrt(2)/2, 0],
+                                         [0, 0, 0, 1]])
+    else:
+        raise NotImplementedError("Only num_copies = 2 is currently supported.")
+        
+    return cirq.MatrixGate(diagonalizing_matrix)


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description

Added a function and tests necessary for the new virtual distillation (VD) error mitigation method.

---

### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [X] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [X] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [X] Added myself / the copyright holder to the AUTHORS file
