### PR TITLE
Small fixes in docstrings

### DIFF
--- a/mitiq/pt/pt.py
+++ b/mitiq/pt/pt.py
@@ -74,9 +74,8 @@ def generate_pauli_twirl_variants(
 ) -> List[QPROGRAM]:
     r"""Return the Pauli twirled versions of the input circuit.
 
-    Only the $\mathrm{CZ}$ and $\mathrm{CNOT}$ gates in an
-    input circuit are Pauli twirled as specified in
-    :cite:`Saki_2023_arxiv`.
+    Only the CNOT and CZ gates in an input circuit are Pauli twirled
+    as specified in :cite:`Saki_2023_arxiv`.
 
     Args:
         circuit: The input circuit on which twirling is applied.

--- a/mitiq/shadows/shadows.py
+++ b/mitiq/shadows/shadows.py
@@ -34,7 +34,7 @@ def pauli_twirling_calibrate(
     The number of :math:`f_b` is :math:`2^n`, or :math:`\sum_{i=1}^d C_n^i` if
     the locality :math:`d` is given.
 
-    In the notation of arXiv:2011.09636, this function estimates the
+    In the notation of :cite:`chen2021robust`, this function estimates the
     coefficient :math:`f_b`, which are expansion coefficients of the twirled
     channel :math:`\mathcal{M}=\sum_b f_b\Pi_b`.
 


### PR DESCRIPTION
Fixes #2660 

For future reference, the syntax for math notation in docstrings is `:math:` (as opposed to `$`), but in this case, math notation wasn't needed at all.  
