### PR TITLE
Allow for Executor class and batched Executors for LRE

### DIFF
--- a/mitiq/lre/tests/test_lre.py
+++ b/mitiq/lre/tests/test_lre.py
@@ -56,10 +56,13 @@ def test_lre_exp_value(degree, fold_multiplier):
     assert abs(lre_exp_val - ideal_val) <= abs(noisy_val - ideal_val)
 
 
-@pytest.mark.parametrize("degree, fold_multiplier", [(2, 2), (2, 3), (3, 4)])
+@pytest.mark.parametrize(
+    "degree, fold_multiplier",
+    [(2, 2), (2, 3), (3, 4)],
+)
 def test_batch_lre_exp_value(degree, fold_multiplier):
     """Verify LRE batch executor works as expected."""
-    test_batched_executor = Executor(batched_executor)
+    test_batched_executor = Executor(batched_executor, max_batch_size=200)
     test_executor = Executor(execute)
     lre_exp_val = execute_with_lre(
         test_cirq,

--- a/mitiq/lre/tests/test_lre.py
+++ b/mitiq/lre/tests/test_lre.py
@@ -10,7 +10,11 @@ import pytest
 from cirq import DensityMatrixSimulator, depolarize
 
 from mitiq import SUPPORTED_PROGRAM_TYPES, Executor, benchmarks
-from mitiq.lre import execute_with_lre, lre_decorator, mitigate_executor
+from mitiq.lre import (
+    execute_with_lre,
+    lre_decorator,
+    mitigate_executor,
+)
 from mitiq.lre.multivariate_scaling.layerwise_folding import _get_chunks
 from mitiq.zne.scaling import fold_all, fold_global
 
@@ -93,6 +97,14 @@ def test_lre_mitigate_executor(degree, fold_multiplier):
     assert abs(exp_val_from_mitigate_executor - ideal_val) <= abs(
         noisy_val - ideal_val
     )
+    batched_mitigated_executor = mitigate_executor(
+        batched_executor, degree=2, fold_multiplier=2
+    )
+    batched_exp_vals = batched_mitigated_executor([test_cirq] * 3)
+    assert [
+        abs(batched_exp_val - ideal_val) <= abs(noisy_val - ideal_val)
+        for batched_exp_val in batched_exp_vals
+    ]
 
 
 def test_lre_decorator():

--- a/mitiq/lre/tests/test_lre.py
+++ b/mitiq/lre/tests/test_lre.py
@@ -64,7 +64,6 @@ def test_batch_lre_exp_value(degree, fold_multiplier):
         fold_multiplier=fold_multiplier,
     )
     assert abs(lre_exp_val - ideal_val) <= abs(noisy_val - ideal_val)
-    assert test_executor.calls_to_executor == 1
 
 
 @pytest.mark.parametrize("circuit_type", SUPPORTED_PROGRAM_TYPES.keys())

--- a/mitiq/lre/tests/test_lre.py
+++ b/mitiq/lre/tests/test_lre.py
@@ -91,6 +91,10 @@ def test_lre_batched_executor(degree, fold_multiplier):
     assert isinstance(lre_exp_val_batched, float)
 
     assert test_batched_executor.calls_to_executor == 1
+    assert (
+        test_batched_executor.executed_circuits
+        == multivariate_layer_scaling(test_cirq, degree, fold_multiplier)
+    )
 
 
 @pytest.mark.parametrize("circuit_type", SUPPORTED_PROGRAM_TYPES.keys())


### PR DESCRIPTION
Fixes #2668
Fixes #2675

This PR updates the LRE technique to allow for Executor class objects to be passed in to `execute_with_lre`. Along with that update, there is also an update to allow for a batched executor.


### License

- [X] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [X] I added unit tests for new code.
- [X] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [X] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
