### PR TITLE
Adding docstrings to Observable class

### DIFF
--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -139,8 +139,8 @@ class Observable:
         self._ngroups = len(self._groups)
 
     def measure_in(self, circuit: QPROGRAM) -> List[QPROGRAM]:
-        """Given a quantum circuit, this method returns a list of circuits where
-        each circuit corresponds to a different group of commuting Pauli
+        """Given a quantum circuit, this method returns a list of circuits
+        where each circuit corresponds to a different group of commuting Pauli
         strings, which allows measurement in the appropriate basis.
 
         Args:

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -139,9 +139,7 @@ class Observable:
         self._ngroups = len(self._groups)
 
     def measure_in(self, circuit: QPROGRAM) -> List[QPROGRAM]:
-        """Generates measurement circuits for the observable.
-
-        Given a quantum circuit, this method returns a list of circuits where
+        """Given a quantum circuit, this method returns a list of circuits where
         each circuit corresponds to a different group of commuting Pauli
         strings, which allows measurement in the appropriate basis.
 

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -42,7 +42,7 @@ class Observable:
                 used to define the observable.
 
         Returns:
-            An Observable containing the given Pauli string collections.
+            An ``Observable`` containing the given Pauli string collections.
         """
         obs = Observable()
         obs._groups = list(pauli_string_collections)
@@ -105,7 +105,7 @@ class Observable:
     def partition(self, seed: Optional[int] = None) -> None:
         """Partitions the observable's Pauli strings into commuting groups.
 
-        This method groups the PauliStringCollection instances such that each
+        This method groups the ``PauliStringCollection`` instances such that each
         group consists of mutually commuting operators, which can be measured
         together in a quantum circuit.
 
@@ -159,7 +159,7 @@ class Observable:
         self,
         qubit_indices: Optional[List[int]] = None,
     ) -> npt.NDArray[np.complex64]:
-        """Returns the (potentially very large) matrix of the Observable.
+        """Returns the (potentially very large) matrix of the ``Observable``.
 
         Args:
             qubit_indices: Optional list of qubit indices specifying the order
@@ -167,7 +167,7 @@ class Observable:
             ordering from `self.qubit_indices` is used.
 
         Returns:
-            A NumPy array representing the matrix form of the observable.
+            A ``NumPy`` array representing the matrix form of the observable.
         """
         if qubit_indices is None:
             qubit_indices = self.qubit_indices

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -105,9 +105,9 @@ class Observable:
     def partition(self, seed: Optional[int] = None) -> None:
         """Partitions the observable's Pauli strings into commuting groups.
 
-        This method groups the ``PauliStringCollection`` instances such that each
-        group consists of mutually commuting operators, which can be measured
-        together in a quantum circuit.
+        This method groups the ``PauliStringCollection`` instances such that
+        each group consists of mutually commuting operators, which can be
+        measured together in a quantum circuit.
 
         Note:
             This method randomizes the way in which the list of

--- a/mitiq/observable/observable.py
+++ b/mitiq/observable/observable.py
@@ -109,6 +109,10 @@ class Observable:
         group consists of mutually commuting operators, which can be measured
         together in a quantum circuit.
 
+        Note:
+            This method randomizes the way in which the list of
+            paulis is partitioned.
+
         Args:
             seed: An optional seed for shuffling to ensure deterministic
                 behavior when partitioning.


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short, comprehensive, and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

<!--
If the validation checks fail
  1. Run `make check-types` (from the root directory of the repository) and fix any mypy (https://mypy.readthedocs.io/en/stable/) errors.
  2. Run `make format` to fix any linting/formatting errors. There may be some issues that require manual intervention for you to fix.

For more information, check the Mitiq style guidelines (https://mitiq.readthedocs.io/en/stable/contributing.html#style-guidelines).
-->

## Description
#Resolves #2324
This PR adds docstrings to methods in the `Observable` class. The following methods are documented in this PR as discussed in the mentioned issue.
1. measure_in
2. expectation
3. partition
4. from_pauli_string_collections

Also, the arguments of matrix have been flushed out using the Args: ... pattern.

<!-- Please explain the changes you made here. -->

---

### License

- [ ] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Fund the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [ ] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] Added myself / the copyright holder to the AUTHORS file
