### PR TITLE
allow list/tuple constructor in executor typehints

### DIFF
--- a/docs/source/guide/executors.md
+++ b/docs/source/guide/executors.md
@@ -123,17 +123,14 @@ Notice in the above output that the executor has been called once for each circu
 
 Several quantum computing services allow running a sequence, or "batch," of circuits at once. This is important for error mitigation when running many circuits to speed up the computation.
 
-+++
-
-To define a batched executor, annotate it with `Sequence[T]`, `List[T]`, `Tuple[T]`, or `Iterable[T]` where `T` is a `QuantumResult`. Here is an example:
+To define a batched executor, annotate it with `Sequence[T]`, `list[T]`, `tuple[T]`, or `Iterable[T]` where `T` is a `QuantumResult`.
+Here is an example:
 
 ```{code-cell} ipython3
-from typing import List
-
 import numpy as np
 
 
-def batch_compute_density_matrix(circuits: List[cirq.Circuit]) -> List[np.ndarray]:
+def batch_compute_density_matrix(circuits: list[cirq.Circuit]) -> list[np.ndarray]:
     return [mitiq_cirq.compute_density_matrix(circuit) for circuit in circuits]
 
 

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -39,6 +39,7 @@ DensityMatrixLike = [
     Tuple[np.ndarray],
     npt.NDArray[np.complex64],
     list[npt.NDArray[np.complex64]],
+    list[np.ndarray],  # type: ignore
     tuple[npt.NDArray[np.complex64]],
 ]
 FloatLike = [

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -6,6 +6,7 @@
 """Defines utilities for efficiently running collections of circuits generated
 by error mitigation techniques to compute expectation values."""
 
+import collections
 import inspect
 import warnings
 from collections import Counter
@@ -117,7 +118,15 @@ class Executor:
 
         return return_type in (
             BatchedType[T]  # type: ignore[index]
-            for BatchedType in [Iterable, List, Sequence, Tuple, list, tuple]
+            for BatchedType in [
+                Iterable,
+                List,
+                Sequence,
+                Tuple,
+                list,
+                tuple,
+                collections.abc.Sequence,
+            ]
             for T in get_args(QuantumResult)
         )
 

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -105,7 +105,7 @@ class Executor:
 
         Otherwise, it is considered "serial".
 
-        Batched executors can _run several quantum programs in a single call_.
+        Batched executors can *run several quantum programs in a single call*.
 
         Returns:
             True if the executor is detected as batched, else False.

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -19,6 +19,7 @@ from typing import (
     Tuple,
     Union,
     cast,
+    get_args,
 )
 
 import numpy as np
@@ -36,6 +37,8 @@ DensityMatrixLike = [
     Sequence[np.ndarray],  # type: ignore
     Tuple[np.ndarray],
     npt.NDArray[np.complex64],
+    list[npt.NDArray[np.complex64]],
+    tuple[npt.NDArray[np.complex64]],
 ]
 FloatLike = [
     None,  # Untyped executors are assumed to return floats.
@@ -44,6 +47,8 @@ FloatLike = [
     List[float],
     Sequence[float],
     Tuple[float],
+    list[float],
+    tuple[float],
 ]
 MeasurementResultLike = [
     MeasurementResult,
@@ -51,6 +56,8 @@ MeasurementResultLike = [
     List[MeasurementResult],
     Sequence[MeasurementResult],
     Tuple[MeasurementResult],
+    list[MeasurementResult],
+    tuple[MeasurementResult],
 ]
 
 
@@ -84,10 +91,34 @@ class Executor:
 
     @property
     def can_batch(self) -> bool:
-        return self._executor_return_type in (
-            BatchedType[T]  # type: ignore[index]
-            for BatchedType in [Iterable, List, Sequence, Tuple]
-            for T in QuantumResult.__args__  # type: ignore[attr-defined]
+        """Returns True if the executor is recognized as a "batched executor",
+        else False.
+
+        The executor is detected as "batched" if and only if it is annotated
+        with a return type that is a subclass of ``Iterable``. Common examples
+        include:
+
+        * ``Iterable[QuantumResult]``
+        * ``List[QuantumResult]``/``list[QuantumResult]``
+        * ``Sequence[QuantumResult]``
+        * ``Tuple[QuantumResult]``/``tuple[QuantumResult]``
+
+        Otherwise, it is considered "serial".
+
+        Batched executors can _run several quantum programs in a single call_.
+
+        Returns:
+            True if the executor is detected as batched, else False.
+        """
+        return_type = self._executor_return_type
+
+        if return_type is None:
+            return False
+
+        return return_type in (
+            BatchedType[T]
+            for BatchedType in [Iterable, List, Sequence, Tuple, list, tuple]
+            for T in get_args(QuantumResult)
         )
 
     @property
@@ -317,43 +348,3 @@ class Executor:
         else:
             self._quantum_results.append(result)
             self._executed_circuits.append(to_run)
-
-    @staticmethod
-    def is_batched_executor(
-        executor: Callable[[Union[QPROGRAM, Sequence[QPROGRAM]]], Any],
-    ) -> bool:
-        """Returns True if the input function is recognized as a "batched
-        executor", else False.
-
-        The executor is detected as "batched" if and only if it is annotated
-        with a return type that is one of the following:
-
-        * ``Iterable[QuantumResult]``
-        * ``List[QuantumResult]``
-        * ``Sequence[QuantumResult]``
-        * ``Tuple[QuantumResult]``
-
-        Otherwise, it is considered "serial".
-
-        Batched executors can _run several quantum programs in a single call.
-        See below.
-
-        Args:
-            executor: A "serial executor" (1) or a "batched executor" (2).
-
-                #. A function which inputs a single ``QPROGRAM`` and outputs a
-                   single ``QuantumResult``.
-                #. A function which inputs a list of ``QPROGRAM`` objects and
-                   returns a list of ``QuantumResult`` instances (one for each
-                   ``QPROGRAM``).
-
-        Returns:
-            True if the executor is detected as batched, else False.
-        """
-        executor_annotation = inspect.getfullargspec(executor).annotations
-
-        return executor_annotation.get("return") in (
-            BatchedType[T]  # type: ignore[index]
-            for BatchedType in [Iterable, List, Sequence, Tuple]
-            for T in QuantumResult.__args__  # type: ignore[attr-defined]
-        )

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -116,7 +116,7 @@ class Executor:
             return False
 
         return return_type in (
-            BatchedType[T]
+            BatchedType[T]  # type: ignore[index]
             for BatchedType in [Iterable, List, Sequence, Tuple, list, tuple]
             for T in get_args(QuantumResult)
         )

--- a/mitiq/executor/tests/test_executor.py
+++ b/mitiq/executor/tests/test_executor.py
@@ -67,7 +67,7 @@ def executor_measurements_typed(circuit) -> MeasurementResult:
     return sample_bitstrings(circuit, noise_level=(0,))
 
 
-def executor_measurements_batched(circuits) -> List[MeasurementResult]:
+def executor_measurements_batched(circuits) -> list[MeasurementResult]:
     return [executor_measurements_typed(circuit) for circuit in circuits]
 
 
@@ -95,12 +95,13 @@ def test_executor_simple():
     assert collector.calls_to_executor == 0
 
 
-def test_executor_is_batched_executor():
-    assert Executor.is_batched_executor(executor_batched)
-    assert not Executor.is_batched_executor(executor_serial_typed)
-    assert not Executor.is_batched_executor(executor_serial)
-    assert not Executor.is_batched_executor(executor_measurements_typed)
-    assert Executor.is_batched_executor(executor_measurements_batched)
+def test_executors_can_batch():
+    assert Executor(executor_batched).can_batch
+    assert not Executor(executor_serial_typed).can_batch
+    assert not Executor(executor_serial).can_batch
+    assert not Executor(executor_measurements_typed).can_batch
+    assert not Executor(executor_density_matrix_typed).can_batch
+    assert Executor(executor_measurements_batched).can_batch
 
 
 def test_executor_non_hermitian_observable():


### PR DESCRIPTION
## Description

This PR started really simple, but ended up taking me a bit longer because of all the cases we need to support. This PR does two main things:

1. DRYs up duplicated logic to see if an executor can batch (**removing the `is_batched_executor` static method**)
2. Ensures support for executors typehinted with `list` and `tuple` constructors instead of just `typing.List`/`typing.Tuple`.

fixes https://github.com/unitaryfund/mitiq/issues/2669

### Details

I originally tried to make a much more robust solution revolving around checking if the return type is a subclass of `Iterable` which works well, but resulted in cascade of issues.

1. **Numpy arrays are iterable.** Not a problem, add an exception for any numpy object. Doable (albeit somewhat messy).
2. There are **more undesirable subclasses of `Iterable`** that we don't want to allow. E.g. `str` and `dict`. Either add another exception, or ignore those as they are pathological since they are not typical executor return types.
3. Once `list[MeasurementResult]` is supported as a batche-able return type in `can_batch`, it causes a cirq simulator error (thankfully caught in out tests) since it is not in [**`MeasurementResultLike`**](https://github.com/unitaryfund/mitiq/blob/5bd29cebc1ebcd87d7a24348eae0f1e653703307/mitiq/executor/executor.py#L48-L54).

At this point it made sense to me to go the simple route and just manually add a few new types to the existing lists instead of putting in a bunch of time to reconstruct how we manage typehints across Mitiq.