### PR TITLE
Add interactive ZNE notebook

### DIFF
--- a/docs/source/examples/examples.md
+++ b/docs/source/examples/examples.md
@@ -43,4 +43,5 @@ GGI Summer School ZNE Hands-On Tutorial <ggi_summer_school_unsolved.md>
 Composing techniques: REM + ZNE <combine_rem_zne.md>
 Composing techniques: DDD + ZNE <combine_ddd_zne.md>
 The Mitiq paper code <mitiq-paper/mitiq-paper-codeblocks.md>
+Interactive ZNE noise slider <interactive-zne-slider.md>
 ```

--- a/docs/source/examples/interactive-zne-slider.md
+++ b/docs/source/examples/interactive-zne-slider.md
@@ -1,0 +1,101 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+```{tags} zne, interactive, cirq, beginner
+```
+
+# Interactive Zero Noise Extrapolation
+
+This tutorial demonstrates how Zero Noise Extrapolation (ZNE) improves the expectation value of a simple circuit as we vary the strength of depolarizing or dephasing noise. Use the slider to change the noise rate and observe the mitigated and unmitigated values.
+
+## Setup
+
+```{code-cell}
+import cirq
+import numpy as np
+import matplotlib.pyplot as plt
+import ipywidgets as widgets
+from IPython.display import display
+from mitiq import zne
+```
+
+## Circuit
+
+We use a single-qubit rotation about the $X$ axis and measure the $Z$ expectation value.
+
+```{code-cell}
+qubit = cirq.LineQubit(0)
+circuit = cirq.Circuit(cirq.rx(np.pi / 4).on(qubit), cirq.measure(qubit, key="m"))
+```
+
+Calculate the ideal expectation value.
+
+```{code-cell}
+sim = cirq.DensityMatrixSimulator()
+true_result = sim.run(circuit, repetitions=10_000)
+true_expectation = 1 - 2 * np.mean(true_result.measurements["m"])
+true_expectation
+```
+
+## Execution helpers
+
+The function below applies depolarizing or dephasing noise to a circuit and returns the noisy expectation value.
+
+```{code-cell}
+def expectation_with_noise(circ, noise_rate: float, noise_type: str) -> float:
+    if noise_type == "depolarizing":
+        noisy_circuit = circ.with_noise(cirq.depolarize(p=noise_rate))
+    else:
+        noisy_circuit = circ.with_noise(cirq.phase_damp(gamma=noise_rate))
+    result = sim.run(noisy_circuit, repetitions=10_000)
+    return 1 - 2 * np.mean(result.measurements["m"])
+```
+
+## Interactive widget
+
+The function below constructs noise-scaled circuits using {func}`.zne.construct_circuits`, executes them with the chosen noise model, and plots the resulting expectation values along with the ZNE extrapolation.
+
+```{code-cell}
+from mitiq.zne.scaling import fold_global
+from mitiq.zne.inference import RichardsonFactory
+
+scale_factors = [1.0, 3.0, 5.0]
+factory = RichardsonFactory(scale_factors=scale_factors)
+
+def plot_expectation(noise_rate, noise_type):
+    scaled = zne.construct_circuits(circuit, scale_factors, fold_global)
+    exp_vals = [
+        expectation_with_noise(sc, noise_rate, noise_type) for sc in scaled
+    ]
+    mitigated = factory.extrapolate(scale_factors, exp_vals)
+
+    fig, ax = plt.subplots()
+    ax.plot(scale_factors, exp_vals, "o-", label="scaled values")
+    ax.axhline(true_expectation, color="green", ls="--", label="ideal")
+    ax.axhline(mitigated, color="red", ls=":", label="zne")
+    ax.set_xlabel("scale factor")
+    ax.set_ylabel("⟨Z⟩")
+    ax.set_ylim(-1.1, 1.1)
+    ax.set_title(f"{noise_type} noise rate = {noise_rate:.2f}")
+    ax.legend()
+    plt.show()
+```
+
+```{code-cell}
+rate_slider = widgets.FloatSlider(value=0.01, min=0.0, max=0.3, step=0.01, description="noise rate")
+noise_choice = widgets.ToggleButtons(options=["depolarizing", "dephasing"], description="noise type")
+widgets.interactive_output(plot_expectation, {"noise_rate": rate_slider, "noise_type": noise_choice})
+display(noise_choice, rate_slider)
+```
+
+Move the slider to explore how ZNE recovers the correct expectation value as the noise increases.

--- a/docs/source/examples/interactive-zne-slider.md
+++ b/docs/source/examples/interactive-zne-slider.md
@@ -92,10 +92,16 @@ def plot_expectation(noise_rate, noise_type):
 ```
 
 ```{code-cell}
-rate_slider = widgets.FloatSlider(value=0.01, min=0.0, max=0.3, step=0.01, description="noise rate")
-noise_choice = widgets.ToggleButtons(options=["depolarizing", "dephasing"], description="noise type")
-widgets.interactive_output(plot_expectation, {"noise_rate": rate_slider, "noise_type": noise_choice})
-display(noise_choice, rate_slider)
+rate_slider = widgets.FloatSlider(
+    value=0.01, min=0.0, max=0.3, step=0.01, description="noise rate"
+)
+noise_choice = widgets.ToggleButtons(
+    options=["depolarizing", "dephasing"], description="noise type"
+)
+out = widgets.interactive_output(
+    plot_expectation, {"noise_rate": rate_slider, "noise_type": noise_choice}
+)
+display(noise_choice, rate_slider, out)
 ```
 
 Move the slider to explore how ZNE recovers the correct expectation value as the noise increases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ docs = [
     "pyqrack==1.32.27",
     "ucc==0.4.4; python_version == '3.12'",
     "pytket-cirq==0.39.0",
+    "ipywidgets>=8.1.7",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1154,6 +1154,23 @@ wheels = [
 ]
 
 [[package]]
+name = "ipywidgets"
+version = "8.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "comm" },
+    { name = "ipython", version = "8.36.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jupyterlab-widgets" },
+    { name = "traitlets" },
+    { name = "widgetsnbextension" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/48/d3dbac45c2814cb73812f98dd6b38bbcc957a4e7bb31d6ea9c03bf94ed87/ipywidgets-8.1.7.tar.gz", hash = "sha256:15f1ac050b9ccbefd45dccfbb2ef6bed0029d8278682d569d71b8dd96bee0376", size = 116721, upload-time = "2025-05-05T12:42:03.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/6a/9166369a2f092bd286d24e6307de555d63616e8ddb373ebad2b5635ca4cd/ipywidgets-8.1.7-py3-none-any.whl", hash = "sha256:764f2602d25471c213919b8a1997df04bef869251db4ca8efba1b76b1bd9f7bb", size = 139806, upload-time = "2025-05-05T12:41:56.833Z" },
+]
+
+[[package]]
 name = "jedi"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1278,6 +1295,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
+]
+
+[[package]]
+name = "jupyterlab-widgets"
+version = "3.0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/7d/160595ca88ee87ac6ba95d82177d29ec60aaa63821d3077babb22ce031a5/jupyterlab_widgets-3.0.15.tar.gz", hash = "sha256:2920888a0c2922351a9202817957a68c07d99673504d6cd37345299e971bb08b", size = 213149, upload-time = "2025-05-05T12:32:31.004Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/6a/ca128561b22b60bd5a0c4ea26649e68c8556b82bc70a0c396eebc977fe86/jupyterlab_widgets-3.0.15-py3-none-any.whl", hash = "sha256:d59023d7d7ef71400d51e6fee9a88867f6e65e10a4201605d2d7f3e8f012a31c", size = 216571, upload-time = "2025-05-05T12:32:29.534Z" },
 ]
 
 [[package]]
@@ -1572,6 +1598,7 @@ dev = [
 ]
 docs = [
     { name = "bqskit" },
+    { name = "ipywidgets" },
     { name = "jupytext" },
     { name = "myst-nb" },
     { name = "myst-parser" },
@@ -1628,6 +1655,7 @@ dev = [
 ]
 docs = [
     { name = "bqskit", specifier = "==1.1.1" },
+    { name = "ipywidgets", specifier = ">=8.1.7" },
     { name = "jupytext", specifier = "==1.16.1" },
     { name = "myst-nb", specifier = "==1.1.1" },
     { name = "myst-parser", specifier = "==4.0.0" },
@@ -3957,6 +3985,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "widgetsnbextension"
+version = "4.0.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/53/2e0253c5efd69c9656b1843892052a31c36d37ad42812b5da45c62191f7e/widgetsnbextension-4.0.14.tar.gz", hash = "sha256:a3629b04e3edb893212df862038c7232f62973373869db5084aed739b437b5af", size = 1097428, upload-time = "2025-04-10T13:01:25.628Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl", hash = "sha256:4875a9eaf72fbf5079dc372a51a9f268fc38d46f767cbf85c43a36da5cb9b575", size = 2196503, upload-time = "2025-04-10T13:01:23.086Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- create `interactive-zne-slider.md` notebook demonstrating ZNE with an ipywidget slider
- add notebook to examples gallery
- remove unused interactive notebook thumbnail

## Testing
- `make check-format`
- `make check-types`


------
https://chatgpt.com/codex/tasks/task_e_685700764d50832c8fd52583652c3c1b