### PR TITLE
Address CI errors with Windows + tcl/tkinter and Ubuntu + Code Coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Submit coverage report to Codecov
         # Only submit to Codecov once.
-        if: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Currently seeing random errors with the CI Windows builds. Potential solutions were found online. Including [adding an environmental variable for matplotlib](https://github.com/microsoft/azure-pipelines-tasks/issues/16426#issuecomment-1289893365) and [moving the install of Python from its own action in the build workflow to being installed using `uv`](https://github.com/tonkintaylor/rastr/pull/193). 

```
=========================== short test summary info ===========================
FAILED mitiq/zne/tests/test_inference.py::test_plot_data_exp_factory[PolyExpFactory] - _tkinter.TclError: Can't find a usable init.tcl in the following directories: 
    {C:\hostedtoolcache\windows\Python\3.11.9\x64\tcl\tcl8.6}

C:/hostedtoolcache/windows/Python/3.11.9/x64/tcl/tcl8.6/init.tcl: couldn't read file "C:/hostedtoolcache/windows/Python/3.11.9/x64/tcl/tcl8.6/init.tcl": No error
couldn't read file "C:/hostedtoolcache/windows/Python/3.11.9/x64/tcl/tcl8.6/init.tcl": No error
    while executing
"source C:/hostedtoolcache/windows/Python/3.11.9/x64/tcl/tcl8.6/init.tcl"
    ("uplevel" body line 1)
    invoked from within
"uplevel #0 [list source $tclfile]"


This probably means that Tcl wasn't installed properly.
```