### PR TITLE
Exclude non-manifest files from Dependabot scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,16 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot
 
 version: 2
 updates:
-  - package-ecosystem: "uv" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "daily"
     allow:
       - dependency-type: "all"
+    exclude-paths:
+      - "VERSION.txt"
+      - "INTEGRATIONS.txt"
     ignore:
       # Ignore patch releases in "supported frontend/backend" packages.
       - dependency-name: "cirq"
@@ -44,12 +44,10 @@ updates:
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "pyqrack"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-    # Allow up to 10 open pull requests for pip dependencies
     open-pull-requests-limit: 10
     labels:
       - "infrastructure"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
## Description

While reviewing Dependabot logs, I noticed it was attempting to check for updates to a nonexistent package:

```
2025-11-06T19:18:16.2988710Z updater | 2025/11/06 19:18:16 INFO <job_1145424397> Checking if 0-48-0  needs updating
2025-11-06T19:18:16.3422103Z updater | 2025/11/06 19:18:16 INFO <job_1145424397> Fetching release information from json registry at https://pypi.org/pypi/ for 0-48-0
2025-11-06T19:18:16.4303576Z   proxy | 2025/11/06 19:18:16 [338] GET https://pypi.org/pypi/0-48-0/json
2025-11-06T19:18:16.5237728Z   proxy | 2025/11/06 19:18:16 [338] 404 https://pypi.org/pypi/0-48-0/json
```

It thinks `0-48-0` is a dependency, which is our current version which is only stored in `VERSION.txt`. Sure enough when checking dependabot config (which you can check [here](https://github.com/unitaryfoundation/mitiq/network/updates/24663136/jobs)) it's scanning `pyproject.toml`, `uv.lock`, `INTEGRATIONS.txt` and `VERSION.txt`. Neither of these last two files are places dependabot should be looking.