### PR TITLE
Added support for PRx and MS.

### DIFF
--- a/mitiq/interface/mitiq_braket/conversions.py
+++ b/mitiq/interface/mitiq_braket/conversions.py
@@ -187,6 +187,14 @@ def _translate_one_qubit_braket_instruction_to_cirq_operation(
         return [cirq_ops.rz(gate.angle).on(*qubits)]
     elif isinstance(gate, braket_gates.PhaseShift):
         return [cirq_ops.Z.on(*qubits) ** (gate.angle / np.pi)]
+    elif isinstance(gate, braket_gates.PRx):
+        return [
+            cirq_ops.PhasedXPowGate(
+                phase_exponent=gate.angle_2 / np.pi,
+                exponent=gate.angle_1 / np.pi,
+                global_shift=-0.5,
+            ).on(*qubits)
+        ]
     elif isinstance(gate, braket_gates.GPi):
         return [
             cirq_ionq_ops.GPIGate(phi=gate.angle / (2 * np.pi)).on(*qubits)
@@ -281,13 +289,12 @@ def _translate_two_qubit_braket_instruction_to_cirq_operation(
         ]
     elif isinstance(gate, braket_gates.XY):
         return [cirq_ops.ISwapPowGate(exponent=gate.angle / np.pi).on(*qubits)]
-
-    # Two-qubit two-parameters parameterized gates.
     elif isinstance(gate, braket_gates.MS):
         return [
             cirq_ionq_ops.MSGate(
                 phi0=gate.angle_1 / (2 * np.pi),
                 phi1=gate.angle_2 / (2 * np.pi),
+                theta=gate.angle_3 / (2 * np.pi),
             ).on(*qubits)
         ]
 


### PR DESCRIPTION
## Description

- Added PRx from braket.
- Changed MS from two parameters to three parameters.
- Updated testers.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
- [x] Added myself / the copyright holder to the AUTHORS file
