### PR TITLE
chore: updating docs to correctly reflect num_chunks argument in lre.

### DIFF
--- a/mitiq/lre/inference/multivariate_richardson.py
+++ b/mitiq/lre/inference/multivariate_richardson.py
@@ -73,7 +73,7 @@ def sample_matrix(
         fold_multiplier: Scaling gap required by unitary folding.
         num_chunks: The number of equally-sized circuit chunks. Noise
             scaling is applied to each chunk independently. Ranges from 1
-            (all gates in one chunk, similar to global folding in ZNE) to the
+            (all gates in one chunk, similar to ZNE) to the
             number of circuit layers (default, each layer is a separate chunk).
 
     Returns:

--- a/mitiq/lre/inference/multivariate_richardson.py
+++ b/mitiq/lre/inference/multivariate_richardson.py
@@ -71,9 +71,10 @@ def sample_matrix(
         input_circuit: Quantum circuit to be scaled.
         degree: Degree of the multivariate polynomial.
         fold_multiplier: Scaling gap required by unitary folding.
-        num_chunks: Number of desired approximately equal chunks. When the
-            number of chunks is the same as the layers in the input circuit,
-            the input circuit is unchanged.
+        num_chunks: The number of equally-sized circuit chunks. Noise
+            scaling is applied to each chunk independently. Ranges from 1
+            (all gates in one chunk, similar to ZNE) to the number of circuit
+            layers (default, each layer is a separate chunk).
 
     Returns:
         Matrix of the evaluated monomial basis terms from the scale factor
@@ -148,9 +149,10 @@ def multivariate_richardson_coefficients(
         input_circuit: Circuit to be scaled.
         degree: Degree of the multivariate polynomial.
         fold_multiplier: Scaling gap required by unitary folding.
-        num_chunks: Number of desired approximately equal chunks. When the
-            number of chunks is the same as the layers in the input circuit,
-            the input circuit is unchanged.
+        num_chunks: The number of equally-sized circuit chunks. Noise
+            scaling is applied to each chunk independently. Ranges from 1
+            (all gates in one chunk, similar to ZNE) to the number of circuit
+            layers (default, each layer is a separate chunk).
 
     Returns:
         List of the evaluated monomial basis terms using the scale factor

--- a/mitiq/lre/inference/multivariate_richardson.py
+++ b/mitiq/lre/inference/multivariate_richardson.py
@@ -73,8 +73,8 @@ def sample_matrix(
         fold_multiplier: Scaling gap required by unitary folding.
         num_chunks: The number of equally-sized circuit chunks. Noise
             scaling is applied to each chunk independently. Ranges from 1
-            (all gates in one chunk, similar to ZNE) to the number of circuit
-            layers (default, each layer is a separate chunk).
+            (all gates in one chunk, similar to global folding in ZNE) to the
+            number of circuit layers (default, each layer is a separate chunk).
 
     Returns:
         Matrix of the evaluated monomial basis terms from the scale factor

--- a/mitiq/lre/lre.py
+++ b/mitiq/lre/lre.py
@@ -40,10 +40,10 @@ def construct_circuits(
             is used to generate the scale factor vectors.
         folding_method: Unitary folding method. Default is
             :func:`mitiq.zne.scaling.folding.fold_gates_at_random`.
-        num_chunks: Number of desired approximately equal chunks. When the
-            number of chunks is the same as the layers in the input circuit,
-            the input circuit is unchanged.
-
+        num_chunks: The number of equally-sized circuit chunks. Noise
+            scaling is applied to each chunk independently. Ranges from 1
+            (all gates in one chunk, similar to ZNE) to the number of circuit
+            layers (default, each layer is a separate chunk).
 
     Returns:
         The scaled circuits using the
@@ -73,9 +73,10 @@ def combine_results(
         degree: Degree of the multivariate polynomial.
         fold_multiplier: Scaling gap value required for unitary folding which
             is used to generate the scale factor vectors.
-        num_chunks: Number of desired approximately equal chunks. When the
-            number of chunks is the same as the layers in the input circuit,
-            the input circuit is unchanged.
+        num_chunks: The number of equally-sized circuit chunks. Noise
+            scaling is applied to each chunk independently. Ranges from 1
+            (all gates in one chunk, similar to ZNE) to the number of circuit
+            layers (default, each layer is a separate chunk).
 
     Returns:
         The expectation value estimated with LRE.
@@ -123,10 +124,10 @@ def execute_with_lre(
             ``executor`` is used to compute the expectation of the observable.
         folding_method: Unitary folding method. Default is
             :func:`mitiq.zne.scaling.folding.fold_gates_at_random`.
-        num_chunks: Number of desired approximately equal chunks. When the
-            number of chunks is the same as the layers in the input circuit,
-            the input circuit is unchanged.
-
+        num_chunks: The number of equally-sized circuit chunks. Noise
+            scaling is applied to each chunk independently. Ranges from 1
+            (all gates in one chunk, similar to ZNE) to the number of circuit
+            layers (default, each layer is a separate chunk).
 
     Returns:
         Error-mitigated expectation value
@@ -181,10 +182,10 @@ def mitigate_executor(
             ``executor`` is used to compute the expectation of the observable.
         folding_method: Unitary folding method. Default is
             :func:`mitiq.zne.scaling.folding.fold_gates_at_random`.
-        num_chunks: Number of desired approximately equal chunks. When the
-            number of chunks is the same as the layers in the input circuit,
-            the input circuit is unchanged.
-
+        num_chunks: The number of equally-sized circuit chunks. Noise
+            scaling is applied to each chunk independently. Ranges from 1
+            (all gates in one chunk, similar to ZNE) to the number of circuit
+            layers (default, each layer is a separate chunk).
 
     Returns:
         Error-mitigated version of the circuit executor.
@@ -249,11 +250,10 @@ def lre_decorator(
             ``executor`` is used to compute the expectation of the observable.
         folding_method: Unitary folding method. Default is
             :func:`mitiq.zne.scaling.folding.fold_gates_at_random`.
-        num_chunks: Number of desired approximately equal chunks. When the
-            number of chunks is the same as the layers in the input circuit,
-            the input circuit is unchanged.
-
-
+        num_chunks: The number of equally-sized circuit chunks. Noise
+            scaling is applied to each chunk independently. Ranges from 1
+            (all gates in one chunk, similar to ZNE) to the number of circuit
+            layers (default, each layer is a separate chunk).
 
     Returns:
         Error-mitigated decorator.

--- a/mitiq/lre/multivariate_scaling/layerwise_folding.py
+++ b/mitiq/lre/multivariate_scaling/layerwise_folding.py
@@ -52,24 +52,24 @@ def _get_chunks(
     Adapted from:
     https://stackoverflow.com/questions/2130016/splitting-a-list-into-n-parts-of-approximately-equal-length
 
-        Args:
-            input_circuit: Circuit of interest.
-            num_chunks: The number of equally-sized circuit chunks. Noise
-                scaling is applied to each chunk independently. Ranges from 1
-                (all gates in one chunk, similar to ZNE) to the number of
-                circuit layers (default, each layer is a separate chunk).
-        Returns:
-            split_circuit: Circuit of interest split into approximately equal
-                chunks.
+    Args:
+        input_circuit: Circuit of interest.
+        num_chunks: The number of equally-sized circuit chunks. Noise
+            scaling is applied to each chunk independently. Ranges from 1
+            (all gates in one chunk, similar to ZNE) to the number of
+            circuit layers (default, each layer is a separate chunk).
 
-        Raises:
-            ValueError:
-                When the number of chunks for the input circuit is larger than
-                    the number of layers in the input circuit.
+    Returns:
+        split_circuit: Circuit of interest split into approximately equal
+            chunks.
 
-            ValueError:
-                When the number of chunks is less than 1.
+    Raises:
+        ValueError:
+            When the number of chunks for the input circuit is larger than
+            the number of layers in the input circuit.
 
+        ValueError:
+            When the number of chunks is less than 1.
     """
     num_layers = _get_num_layers_without_measurements(input_circuit)
     if num_chunks is None:
@@ -103,19 +103,19 @@ def get_scale_factor_vectors(
     """Returns the patterned scale factor vectors required for multivariate
     extrapolation.
 
-        Args:
-            input_circuit: Quantum circuit to be scaled.
-            degree: Degree of the multivariate polynomial.
-            fold_multiplier: Scaling gap required by unitary folding.
-            num_chunks: The number of equally-sized circuit chunks. Noise
-                scaling is applied to each chunk independently. Ranges from 1
-                (all gates in one chunk, similar to ZNE) to the number of
-                circuit layers (default, each layer is a separate chunk).
+    Args:
+        input_circuit: Quantum circuit to be scaled.
+        degree: Degree of the multivariate polynomial.
+        fold_multiplier: Scaling gap required by unitary folding.
+        num_chunks: The number of equally-sized circuit chunks. Noise
+            scaling is applied to each chunk independently. Ranges from 1
+            (all gates in one chunk, similar to ZNE) to the number of
+            circuit layers (default, each layer is a separate chunk).
 
-        Returns:
-            scale_factor_vectors: A vector of scale factors where each
-                component in the vector corresponds to the layer in the input
-                circuit.
+    Returns:
+        scale_factor_vectors: A vector of scale factors where each
+            component in the vector corresponds to the layer in the input
+            circuit.
     """
 
     circuit_chunks = _get_chunks(input_circuit, num_chunks)

--- a/mitiq/lre/multivariate_scaling/layerwise_folding.py
+++ b/mitiq/lre/multivariate_scaling/layerwise_folding.py
@@ -54,11 +54,10 @@ def _get_chunks(
 
         Args:
             input_circuit: Circuit of interest.
-            num_chunks: Number of desired approximately equal chunks,
-                * when num_chunks == num_layers, the original circuit is
-                    returned.
-                * when num_chunks == 1, the entire circuit is chunked into 1
-                    layer.
+            num_chunks: The number of equally-sized circuit chunks. Noise
+                scaling is applied to each chunk independently. Ranges from 1
+                (all gates in one chunk, similar to ZNE) to the number of
+                circuit layers (default, each layer is a separate chunk).
         Returns:
             split_circuit: Circuit of interest split into approximately equal
                 chunks.
@@ -108,7 +107,10 @@ def get_scale_factor_vectors(
             input_circuit: Quantum circuit to be scaled.
             degree: Degree of the multivariate polynomial.
             fold_multiplier: Scaling gap required by unitary folding.
-            num_chunks: Number of desired approximately equal chunks.
+            num_chunks: The number of equally-sized circuit chunks. Noise
+                scaling is applied to each chunk independently. Ranges from 1
+                (all gates in one chunk, similar to ZNE) to the number of
+                circuit layers (default, each layer is a separate chunk).
 
         Returns:
             scale_factor_vectors: A vector of scale factors where each
@@ -167,9 +169,10 @@ def _multivariate_layer_scaling(
         input_circuit: Circuit to be scaled.
         degree: Degree of the multivariate polynomial.
         fold_multiplier: Scaling gap required by unitary folding.
-        num_chunks: Number of desired approximately equal chunks. When the
-            number of chunks is the same as the layers in the input circuit,
-            the input circuit is unchanged.
+        num_chunks: The number of equally-sized circuit chunks. Noise
+            scaling is applied to each chunk independently. Ranges from 1
+            (all gates in one chunk, similar to ZNE) to the number of circuit
+            layers (default, each layer is a separate chunk).
         folding_method: Unitary folding method. Default is
             :func:`fold_gates_at_random`.
 

--- a/uv.lock
+++ b/uv.lock
@@ -1679,7 +1679,7 @@ requires-dist = [
     { name = "pyquil", marker = "extra == 'pyquil'", specifier = "~=4.17.0" },
     { name = "qbraid", marker = "extra == 'pyquil'", specifier = "~=0.10.0" },
     { name = "qibo", marker = "extra == 'qibo'", specifier = "~=0.2.16" },
-    { name = "qiskit", marker = "extra == 'qiskit'", specifier = ">=2.0,<2.3" },
+    { name = "qiskit", marker = "extra == 'qiskit'", specifier = ">=2.0.0,<3.0.0" },
     { name = "qiskit-aer", marker = "extra == 'qiskit'", specifier = "~=0.17.0" },
     { name = "qiskit-ibm-runtime", marker = "extra == 'qiskit'", specifier = "~=0.41.1" },
     { name = "scipy", specifier = ">=1.10.1,<=1.17.0" },


### PR DESCRIPTION
Closes: #2914 

Updated documentation more clearly explains what `num_chunks` represents (equally-sized circuit chunks) and also how noise-scaling applies to chunks (independently per chunk)
 
Additionally, the docs now explicitly mention the valid range (1 to number of layers) as well as the default behavior (each layer is its own chunk). The factually incorrect statement that the circuit is "unchanged" has been removed. 