### PR TITLE
Add logging option when inserting DDD sequences

### DIFF
--- a/mitiq/ddd/__init__.py
+++ b/mitiq/ddd/__init__.py
@@ -12,6 +12,7 @@ from mitiq.ddd import insertion
 from mitiq.ddd.insertion import (
     get_slack_matrix_from_circuit_mask,
     insert_ddd_sequences,
+    DDDInfo,
 )
 
 from mitiq.ddd.ddd import execute_with_ddd, mitigate_executor, ddd_decorator, construct_circuits, combine_results

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -6,6 +6,7 @@
 """Tools to determine slack windows in circuits and to insert DDD sequences."""
 
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import numpy as np
 import numpy.typing as npt
@@ -13,6 +14,21 @@ from cirq import Circuit, I, LineQubit, synchronize_terminal_measurements
 
 from mitiq import QPROGRAM
 from mitiq.interface import accept_qprogram_and_validate
+from mitiq.interface.conversions import convert_to_mitiq, convert_from_mitiq
+
+
+@dataclass
+class DDDInfo:
+    """Information about DDD sequence insertion.
+    
+    Attributes:
+        num_idle_windows: Number of idle windows found in the circuit.
+        num_sequences_inserted: Number of DDD sequences actually inserted.
+        idle_window_lengths: List of lengths of each idle window.
+    """
+    num_idle_windows: int
+    num_sequences_inserted: int
+    idle_window_lengths: list[int]
 
 
 def _get_circuit_mask(circuit: Circuit) -> npt.NDArray[np.int64]:
@@ -86,10 +102,78 @@ def get_slack_matrix_from_circuit_mask(
     return slack_matrix
 
 
+def _insert_ddd_sequences_with_info(
+    circuit: Circuit,
+    rule: Callable[[int], Circuit],
+) -> tuple[Circuit, DDDInfo]:
+    """Internal function that returns circuit with DDD sequences and info.
+    
+    Args:
+        circuit: The Cirq circuit to be modified with DDD sequences.
+        rule: The rule determining what DDD sequences should be applied.
+
+    Returns:
+        A tuple (circuit_with_ddd, ddd_info).
+    """
+    circuit = synchronize_terminal_measurements(circuit)
+    if not circuit.are_all_measurements_terminal():
+        raise ValueError(
+            "This circuit contains midcircuit measurements which "
+            "are not currently supported by DDD."
+        )
+
+    slack_matrix = get_slack_matrix_from_circuit_mask(
+        _get_circuit_mask(circuit)
+    )
+    # Copy to avoid mutating the input circuit
+    circuit_with_ddd = circuit.copy()
+    qubits = sorted(circuit.all_qubits())
+    
+    # Track insertion statistics
+    num_idle_windows = 0
+    num_sequences_inserted = 0
+    idle_window_lengths: list[int] = []
+    
+    for moment_idx in range(len(circuit)):
+        slack_column = slack_matrix[:, moment_idx]
+        for row_index, slack_length in enumerate(slack_column):
+            if slack_length > 1:
+                num_idle_windows += 1
+                idle_window_lengths.append(slack_length)
+                ddd_sequence = rule(slack_length).transform_qubits(
+                    {LineQubit(0): qubits[row_index]}
+                )
+                sequence_inserted = False
+                for idx, op in enumerate(ddd_sequence.all_operations()):
+                    moment = circuit_with_ddd[moment_idx + idx]
+                    op_to_replace = moment.operation_at(*op.qubits)
+
+                    if op_to_replace and op_to_replace.gate == I:
+                        moment = moment.without_operations_touching(op.qubits)
+
+                    circuit_with_ddd[moment_idx + idx] = moment.with_operation(
+                        op
+                    )
+                    sequence_inserted = True
+                if sequence_inserted:
+                    num_sequences_inserted += 1
+    
+    ddd_info = DDDInfo(
+        num_idle_windows=num_idle_windows,
+        num_sequences_inserted=num_sequences_inserted,
+        idle_window_lengths=idle_window_lengths,
+    )
+    
+    return circuit_with_ddd, ddd_info
+
+
 def insert_ddd_sequences(
     circuit: QPROGRAM,
     rule: Callable[[int], Circuit],
-) -> QPROGRAM:
+    *,
+    return_info: bool = False,
+    verbose: bool = False,
+) -> QPROGRAM | tuple[QPROGRAM, DDDInfo]:
     """Returns the circuit with DDD sequences applied according to the input
     rule.
 
@@ -98,14 +182,35 @@ def insert_ddd_sequences(
         rule: The rule determining what DDD sequences should be applied.
             A set of built-in DDD rules can be imported from
             ``mitiq.ddd.rules``.
+        return_info: If True, return a tuple ``(circuit, ddd_info)`` where
+            ``ddd_info`` is a ``DDDInfo`` object containing details about
+            the insertion (number of idle windows, sequences inserted, etc.).
+        verbose: If True, print information about the DDD insertion.
 
     Returns:
-        The circuit with DDD sequences added.
+        The circuit with DDD sequences added, or a tuple ``(circuit, ddd_info)``
+        if ``return_info=True``.
     """
+    # Convert to Mitiq internal representation
+    mitiq_circuit, input_circuit_type = convert_to_mitiq(circuit)
+    
+    # Insert DDD sequences
+    circuit_with_ddd, ddd_info = _insert_ddd_sequences_with_info(
+        mitiq_circuit, rule
+    )
+    
+    if verbose:
+        print(f"DDD: found {ddd_info.num_idle_windows} idle windows; inserted {ddd_info.num_sequences_inserted} sequences")
+    
+    # Convert back to original type
+    result_circuit = convert_from_mitiq(circuit_with_ddd, input_circuit_type)
+    
+    if return_info:
+        return result_circuit, ddd_info
+    return result_circuit
 
-    return _insert_ddd_sequences(circuit, rule)
 
-
+# Keep the old decorated version for backward compatibility
 @accept_qprogram_and_validate
 def _insert_ddd_sequences(
     circuit: Circuit,
@@ -123,34 +228,5 @@ def _insert_ddd_sequences(
     Returns:
         The circuit with DDD sequences added.
     """
-    circuit = synchronize_terminal_measurements(circuit)
-    if not circuit.are_all_measurements_terminal():
-        raise ValueError(
-            "This circuit contains midcircuit measurements which "
-            "are not currently supported by DDD."
-        )
-
-    slack_matrix = get_slack_matrix_from_circuit_mask(
-        _get_circuit_mask(circuit)
-    )
-    # Copy to avoid mutating the input circuit
-    circuit_with_ddd = circuit.copy()
-    qubits = sorted(circuit.all_qubits())
-    for moment_idx in range(len(circuit)):
-        slack_column = slack_matrix[:, moment_idx]
-        for row_index, slack_length in enumerate(slack_column):
-            if slack_length > 1:
-                ddd_sequence = rule(slack_length).transform_qubits(
-                    {LineQubit(0): qubits[row_index]}
-                )
-                for idx, op in enumerate(ddd_sequence.all_operations()):
-                    moment = circuit_with_ddd[moment_idx + idx]
-                    op_to_replace = moment.operation_at(*op.qubits)
-
-                    if op_to_replace and op_to_replace.gate == I:
-                        moment = moment.without_operations_touching(op.qubits)
-
-                    circuit_with_ddd[moment_idx + idx] = moment.with_operation(
-                        op
-                    )
+    circuit_with_ddd, _ = _insert_ddd_sequences_with_info(circuit, rule)
     return circuit_with_ddd


### PR DESCRIPTION
Fixes #2882

## Summary
This PR adds optional logging and structured return info when applying DDD (Digital Dynamical Decoupling), addressing the issue where users couldn't tell if DDD actually did anything.

## Changes

### New `DDDInfo` dataclass
```python
@dataclass
class DDDInfo:
    num_idle_windows: int        # Number of idle windows found
    num_sequences_inserted: int  # Number of sequences inserted
    idle_window_lengths: list[int]  # List of lengths of each idle window
```

### New `return_info=True` option
Returns structured information about what DDD did:
```python
from mitiq.ddd import insert_ddd_sequences, DDDInfo
from mitiq.ddd.rules import xx

circuit, info = insert_ddd_sequences(circuit, xx, return_info=True)
print(info.num_idle_windows)       # e.g., 5
print(info.num_sequences_inserted) # e.g., 5
print(info.idle_window_lengths)    # e.g., [3, 4, 2, 5, 3]
```

### New `verbose=True` option
Prints a human-readable summary:
```python
insert_ddd_sequences(circuit, xx, verbose=True)
# prints: "DDD: found 5 idle windows; inserted 5 sequences"
```

## Why this matters
Users were confused when DDD silently did nothing (e.g., no idle windows available). This provides clear feedback about what happened.

## Testing
All existing functionality remains backward compatible - the new options are opt-in via keyword arguments.