### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: Check out Mitiq
         uses: actions/checkout@v6
+      - name: Extract release notes of latest version
+        run: |
+          awk '/^## Version /{if(found) exit; found=1} found{print}' CHANGELOG.md > release_notes.md
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -22,6 +25,6 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          body_path: ./CHANGELOG.md
+          body_path: ./release_notes.md
           draft: true
           prerelease: false


### PR DESCRIPTION
## Description

When we create releases on github we paste in the entire changelog. The changelog as of 0.49.0 is now more than 125,000 characters which is the limit for the action. This PR pulls out only the latest version release notes to use to create the release.