### PR TITLE
fix cost when ideal executor is being used

### DIFF
--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -225,7 +225,8 @@ class Calibrator:
         frontend: The executor frontend as a string. For a list of supported
             frontends see ``mitiq.SUPPORTED_PROGRAM_TYPES.keys()``,
         ideal_executor: An optional simulated executor returning the ideal
-            :class:`.MeasurementResult` without noise.
+            :class:`.MeasurementResult` without noise. Required when using
+            custom benchmark circuits without a pre-set ideal distribution.
     """
 
     def __init__(
@@ -331,7 +332,11 @@ class Calibrator:
         )
 
         noisy = num_circuits * (num_options + 1)
-        ideal = 0  # TODO: ideal executor is currently unused
+        ideal = (
+            sum(1 for p in self.problems if p.type == "custom")
+            if self.ideal_executor is not None
+            else 0
+        )
         return {
             "noisy_executions": noisy,
             "ideal_executions": ideal,

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -522,3 +522,6 @@ def test_calibrator_custom_ideal_distribution():
     )
     problem = cal.problems[0]
     assert problem.ideal_distribution == {"1": 1.0}
+    assert cal.get_cost() == {"noisy_executions": 3, "ideal_executions": 1}
+
+

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -523,5 +523,3 @@ def test_calibrator_custom_ideal_distribution():
     problem = cal.problems[0]
     assert problem.ideal_distribution == {"1": 1.0}
     assert cal.get_cost() == {"noisy_executions": 3, "ideal_executions": 1}
-
-


### PR DESCRIPTION
## Description

The calibrator uses the ideal executor when a custom circuit is being used, but the cost computation did not account for it.

fixes https://github.com/unitaryfoundation/mitiq/issues/1716