### PR TITLE
fix module import issues

### DIFF
--- a/mitiq/__init__.py
+++ b/mitiq/__init__.py
@@ -15,6 +15,7 @@ from mitiq.typing import (
 # Utils
 from mitiq.interface import compare_cost
 from mitiq.utils import qem_methods
+from mitiq import benchmarks
 
 # Executors and observables.
 from mitiq.executor import Executor
@@ -23,6 +24,9 @@ from mitiq.observable import PauliString, Observable
 # About and version.
 from mitiq._about import about
 from mitiq._version import __version__
+
+# QEM techniques.
+from mitiq import cdr, ddd, lre, pea, pec, pt, qse, raw, rem, shadows, vd, zne
 
 # Calibration
 from mitiq.calibration import (

--- a/mitiq/interface/__init__.py
+++ b/mitiq/interface/__init__.py
@@ -3,6 +3,10 @@
 # This source code is licensed under the GPL license (v3) found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib
+import sys
+from types import ModuleType
+
 from mitiq.interface.conversions import (
     accept_any_qprogram_as_input,
     atomic_converter,
@@ -17,3 +21,23 @@ from mitiq.interface.conversions import (
 )
 
 from .utils import compare_cost
+
+
+_SUBMODULES = {
+    "mitiq_braket",
+    "mitiq_cirq",
+    "mitiq_openqasm",
+    "mitiq_pennylane",
+    "mitiq_pyquil",
+    "mitiq_qibo",
+    "mitiq_qiskit",
+}
+
+
+def __getattr__(name: str) -> ModuleType:
+    if name in _SUBMODULES:
+        module = importlib.import_module(f"mitiq.interface.{name}")
+        sys.modules[f"{__name__}.{name}"] = module
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/mitiq/interface/__init__.py
+++ b/mitiq/interface/__init__.py
@@ -34,6 +34,12 @@ _SUBMODULES = {
 }
 
 
+# Lazy-loading via PEP 562 package-level __getattr__.
+#
+# Interface submodules (e.g. mitiq_qiskit, mitiq_pennylane) depend on
+# optional third-party packages that users may not have installed. Importing
+# them eagerly at package load time would force every user to have every
+# optional dependency installed, even if they only ever use one frontend.
 def __getattr__(name: str) -> ModuleType:
     if name in _SUBMODULES:
         module = importlib.import_module(f"mitiq.interface.{name}")


### PR DESCRIPTION
## Description

fixes https://github.com/unitaryfoundation/mitiq/issues/2471 by ensuring modules are included in the proper `__init__.py` files. Solution for `interface` module is slightly more complicated since each submodule has dependencies that the user might not have. Hence you only import the module when the user asks for it. Inspired by this PEP https://peps.python.org/pep-0562/ (and claude).

**Note**: I am responsible for making this bug more prolific 🤦🏻 https://github.com/unitaryfoundation/mitiq/pull/2206