### PR TITLE
add AI contribution policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,3 +171,5 @@ Our policy on labelling is intended to facilitate reviews, and not to track whic
 Contributors should note tool usage in their pull request description, commit message, or wherever authorship is normally indicated for the work.
 For instance, use a commit message trailer like `Assisted-by: `.
 This transparency helps the community develop best practices and understand the role of these new tools.
+
+Maintainers have the right to close contributor PRs and after warnings, ban contributors who do not abide by this policy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,3 +155,19 @@ Milestones are tracked using the [GitHub milestone feature](https://github.com/u
 All releases for Mitiq are tagged on the `main` branch with tags for the version number of the release.
 Find all the previous releases [here](https://github.com/unitaryfoundation/mitiq/releases).
 
+## AI use policy and guidelines
+
+Mitiq's policy is that contributors can use whatever tools they would like to craft their contributions, but **there must be a human in the loop**.
+Contributors must read and review all LLM-generated code or text before they ask other project members to review it.
+The contributor is always the author and is fully accountable for their contributions.
+Contributors should be sufficiently confident that the contribution is high enough quality that asking for a review is a good use of scarce maintainer time, and they should be able to answer questions about their work during review.
+
+Contributors can use any tools that aid in understanding the mitiq codebase and writing code, including AI tools.
+However, as noted above, contributors always need to understand and explain the changes they're proposing to make, whether or not they used an LLM as part of your process to produce them.
+The answer to "Why is X an improvement?" should never be "I'm not sure. The AI did it."
+
+Contributors are expected to **be transparent and label contributions that contain substantial amounts of tool-generated content**.
+Our policy on labelling is intended to facilitate reviews, and not to track which parts of mitiq are generated.
+Contributors should note tool usage in their pull request description, commit message, or wherever authorship is normally indicated for the work.
+For instance, use a commit message trailer like `Assisted-by: `.
+This transparency helps the community develop best practices and understand the role of these new tools.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ We welcome contributions to Mitiq including bug fixes, feature requests, etc.
 To get started, check out our [contribution guidelines](https://mitiq.readthedocs.io/en/stable/toc_contributing.html) and/or [documentation guidelines](https://mitiq.readthedocs.io/en/stable/contributing_docs.html).
 
 Contributions of all kinds are welcome!
+We accept AI-assissted contributions, and we ask contributors to be transparent about how they are using AI tooling to help reviewers best review contributions.
+See the [contributing documentation](https://mitiq.readthedocs.io/en/stable/contributing.html) for more details on the policy.
 
 ## Contributors ✨
 


### PR DESCRIPTION
## Description

Does what it says on the 🥫. Language taken from [zulips](https://github.com/zulip/zulip/blob/main/CONTRIBUTING.md?plain=1#ai-use-policy-and-guidelines) and [LLVMs](https://llvm.org/docs//AIToolPolicy.html) AI guides/policies..