### PR TITLE
Replace deprecated np.polyfit with numpy.polynomial.polynomial.polyfit [fix #2322]

### DIFF
--- a/mitiq/zne/inference.py
+++ b/mitiq/zne/inference.py
@@ -145,8 +145,8 @@ def mitiq_polyfit(
     weights: npt.ArrayLike | None = None,
 ) -> tuple[list[float], npt.NDArray[np.float64] | None]:
     """Fits the ansatz to the (scale factor, expectation value) data using
-    ``numpy.polyfit``, returning the optimal parameters and covariance matrix
-    of the parameters.
+    ``numpy.polynomial.polynomial.polyfit``, returning the optimal parameters
+    and covariance matrix of the parameters.
 
     Args:
         scale_factors: The array of noise scale factors.
@@ -164,16 +164,28 @@ def mitiq_polyfit(
         ExtrapolationWarning: If the extrapolation fit is ill-conditioned.
     """
 
+    from numpy.polynomial import polynomial
+
     w = None if weights is None else np.asarray(weights, dtype=float)
 
     with warnings.catch_warnings(record=True) as warn_list:
-        try:
-            opt_params, params_cov = np.polyfit(
-                scale_factors, exp_values, deg, w=w, cov=True
-            )
-        except (ValueError, np.linalg.LinAlgError):
-            opt_params = np.polyfit(scale_factors, exp_values, deg, w=w)
-            params_cov = None
+        opt_params, [_res, rank, *_] = polynomial.polyfit(
+            scale_factors, exp_values, deg, w=w, full=True
+        )
+        residuals = cast(npt.NDArray[np.float64], _res)
+        if rank < deg + 1:
+            warnings.warn(_EXTR_WARN, ExtrapolationWarning)
+
+    params_cov = None
+    if len(residuals) > 0:
+        n = len(scale_factors)
+        fac = residuals[0] / (n - deg - 1)
+        V = np.vander(
+            np.asarray(scale_factors, dtype=float), N=deg + 1, increasing=True
+        )
+        if w is not None:
+            V = np.diag(w) @ V
+        params_cov = fac * np.linalg.inv(V.T @ V)
 
     for warn in warn_list:
         # replace RankWarning with ExtrapolationWarning
@@ -184,7 +196,9 @@ def mitiq_polyfit(
         warnings.warn_explicit(
             warn.message, warn.category, warn.filename, warn.lineno
         )
-    return list(opt_params), params_cov
+    return list(opt_params)[::-1], (
+        params_cov[::-1, ::-1] if params_cov is not None else None
+    )
 
 
 class Factory(ABC):


### PR DESCRIPTION
## Summary

Fixes #2322: Remove usage of `np.polyfit` (deprecated in NumPy 2.0)

### Changes

- Replaced `np.polyfit` with `np.polynomial.polynomial.polyfit` in the `mitiq_polyfit` function
- Compute covariance matrix from residuals and weighted Vandermonde matrix:
  - Build Vandermonde matrix with `increasing=True` (ascending order: [a0, a1, a2, ...])
  - For weighted fits: V = diag(w) @ V, covariance = fac * inv(V.T @ V)
  - For unweighted fits: V = V, same formula with w=None
- Coefficient order flipped from ascending to descending for backward compatibility
- Covariance matrix indices flipped to match descending coefficient order

### Mathematical Notes

The covariance matrix formula uses the weighted Vandermonde matrix:
```
V = diag(w) @ np.vander(scale_factors, deg+1, increasing=True)
cov = fac * inv(V.T @ V)
```

This correctly handles both weighted and unweighted cases by scaling the design matrix directly, rather than using the incorrect `X.T @ np.diag(w) @ X` formula from the previous PR #2989.

### Testing

- All 118 tests pass (1 xfailed as expected)
- Covariance matrix output verified against `np.polyfit` for both weighted and unweighted cases
- Specific test case `test_params_cov_and_zne_std` passes with expected covariance `[[3.0, -1.0], [-1.0, 1.0]]`