### PR TITLE
Add tests for observable and pauli error paths (#2365)

### DIFF
--- a/mitiq/observable/tests/test_observable.py
+++ b/mitiq/observable/tests/test_observable.py
@@ -352,3 +352,32 @@ def test_pauli_string_deduplication_removal_of_0_coefficients():
     obs = Observable(*pauli_strings)
     assert obs.nterms == 1
     assert obs == Observable(XI.with_coeff(XI.coeff * 2))
+
+
+def test_observable_paulis_property():
+    pauli1 = PauliString(spec="XI")
+    pauli2 = PauliString(spec="ZZ")
+    obs = Observable(pauli1, pauli2)
+    assert obs.paulis == [pauli1, pauli2]
+
+
+def test_observable_mul_returns_notimplemented():
+    obs = Observable(PauliString(spec="XI"))
+    assert obs.__mul__("not a valid operand") is NotImplemented
+
+
+def test_observable_rmul_returns_notimplemented():
+    obs = Observable(PauliString(spec="XI"))
+    assert obs.__rmul__("not a valid operand") is NotImplemented
+
+
+def test_observable_mul_unsupported_type_raises_type_error():
+    obs = Observable(PauliString(spec="XI"))
+    with pytest.raises(TypeError):
+        obs * "not a valid operand"
+
+
+def test_observable_rmul_unsupported_type_raises_type_error():
+    obs = Observable(PauliString(spec="XI"))
+    with pytest.raises(TypeError):
+        "not a valid operand" * obs

--- a/mitiq/observable/tests/test_pauli.py
+++ b/mitiq/observable/tests/test_pauli.py
@@ -382,3 +382,18 @@ def test_spec():
 
 def test_with_coeff():
     assert PauliString(spec="X").with_coeff(2).coeff == 2
+
+
+def test_pauli_init_invalid_spec_raises():
+    with pytest.raises(ValueError, match="invalid characters in spec"):
+        PauliString(spec="A")
+
+
+def test_pauli_init_support_length_mismatch_raises():
+    with pytest.raises(ValueError, match="must be equal"):
+        PauliString(spec="XX", support=[0])
+
+
+def test_pauli_repr():
+    pauli = PauliString(spec="XYZ")
+    assert repr(pauli) == repr(pauli._pauli)


### PR DESCRIPTION
Addresses some of the unchecked items in #2365 for the `mitiq/observable` module.

Adds unit tests for paths that were previously untested:

- `PauliString`: invalid characters in `spec` and a `support`/`spec` length mismatch both raise `ValueError`, plus `__repr__`.
- `Observable`: the `paulis` accessor, and that multiplying by an unsupported operand type returns `NotImplemented` (and raises `TypeError` through the operator).

One related line in `PauliString.can_be_measured_with` — the `if cirq.I in (...): continue` branch — looks unreachable to me, since `cirq.PauliString` drops identity factors so every qubit in the overlap set maps to a non-identity Pauli. Happy to mark it `# pragma: no cover` if you'd prefer that over leaving it uncovered.

Tests pass locally and `ruff check`/`ruff format` are clean.
