### PR TITLE
Add tests for folding error paths (#2365)

### DIFF
--- a/mitiq/zne/scaling/tests/test_folding.py
+++ b/mitiq/zne/scaling/tests/test_folding.py
@@ -1395,3 +1395,15 @@ def test_scaling_with_pyquil_retains_declarations(fold_method):
 
     scaled = fold_method(program, 1)
     assert scaled.declarations == program.declarations
+
+
+def test_fold_all_negative_num_folds_raises():
+    circuit = Circuit([ops.H.on(LineQubit(0))])
+    with pytest.raises(ValueError, match="must be positive"):
+        _fold_all(circuit, num_folds=-1)
+
+
+def test_fold_global_scale_factor_less_than_one_raises():
+    circuit = Circuit([ops.H.on(LineQubit(0)), ops.X.on(LineQubit(0))])
+    with pytest.raises(ValueError, match="scale factor must be a real number"):
+        fold_global(circuit, scale_factor=0.5)


### PR DESCRIPTION
Adds unit tests for the `folding.py` error paths from the checklist in #2365:

- `_fold_all` raises `ValueError` when `num_folds` is negative
- `fold_global` raises `ValueError` when `scale_factor < 1`

Both are small, focused tests for existing error handling. Tested locally and ruff is clean. (Complements #3021, which covered the `observable.py` / `pauli.py` items.)
