### PR TITLE
Add test for OperationRepresentation.sample invalid random_state (#2365)

### DIFF
--- a/mitiq/pec/types/tests/test_types.py
+++ b/mitiq/pec/types/tests/test_types.py
@@ -595,3 +595,13 @@ def test_different_length_error():
             noisy_operations=[NoisyOperation(xcirq), NoisyOperation(zcirq)],
             coeffs=[0.5, 0.5, 0.4],
         )
+
+
+def test_sample_bad_random_state_type_raises():
+    q = cirq.LineQubit(0)
+    ideal = cirq.Circuit(cirq.X(q))
+    noisy_x = NoisyOperation(cirq.Circuit(cirq.X(q)), np.identity(4))
+    noisy_z = NoisyOperation(cirq.Circuit(cirq.Z(q)), np.identity(4))
+    rep = OperationRepresentation(ideal, [noisy_x, noisy_z], [0.5, 0.5])
+    with pytest.raises(TypeError, match="random_state"):
+        rep.sample(random_state="not-a-valid-type")


### PR DESCRIPTION
Adds a unit test for the `pec/types/types.py` item in #2365: `OperationRepresentation.sample` raises `TypeError` when `random_state` is neither an `int` nor a `np.random.RandomState`.

Small, focused test for existing error handling; tested locally and ruff is clean. (Continues the #2365 coverage work from #3021 / #3022.)
