### PR TITLE
Support direct PEA representations

### DIFF
--- a/mitiq/experimental/pea/pea.py
+++ b/mitiq/experimental/pea/pea.py
@@ -21,16 +21,101 @@ from mitiq.pec.pec import (
     LargeSampleWarning,
     sample_circuit,
 )
+from mitiq.pec.types import OperationRepresentation
+
+
+def _canonical_scaled_representations(
+    representations: Sequence[OperationRepresentation],
+    scale_factor: float,
+) -> list[OperationRepresentation]:
+    r"""Returns canonically scaled representations for PEA.
+
+    A quasi-probability representation can be split into positive and negative
+    parts as ``G = gamma_plus * Phi_plus - gamma_minus * Phi_minus``. PEA's
+    canonical noise scaling uses
+    ``G(lambda) = (gamma_plus - lambda * gamma_minus) * Phi_plus
+    - (1 - lambda) * gamma_minus * Phi_minus``.
+    """
+    scaled_representations = []
+    for representation in representations:
+        gamma_plus = sum(c for c in representation.coeffs if c > 0)
+        gamma_minus = sum(-c for c in representation.coeffs if c < 0)
+
+        if np.isclose(gamma_plus, 0.0):
+            raise ValueError(
+                "Cannot canonically scale a representation without positive "
+                "coefficients."
+            )
+
+        if np.isclose(gamma_minus, 0.0):
+            scaled_coeffs = list(representation.coeffs)
+        else:
+            positive_scale = (
+                gamma_plus - scale_factor * gamma_minus
+            ) / gamma_plus
+            negative_scale = 1.0 - scale_factor
+            scaled_coeffs = [
+                float(c * positive_scale if c > 0 else c * negative_scale)
+                for c in representation.coeffs
+            ]
+
+        scaled_representations.append(
+            OperationRepresentation(
+                getattr(representation, "_native_ideal", representation.ideal),
+                representation.noisy_operations,
+                scaled_coeffs,
+                representation.is_qubit_dependent,
+            )
+        )
+
+    return scaled_representations
+
+
+def _resolve_representations(
+    circuit: Circuit,
+    scale_factor: float,
+    noise_model: str | None,
+    epsilon: float | None,
+    representations: Sequence[OperationRepresentation] | None,
+) -> Sequence[OperationRepresentation]:
+    if representations is not None and noise_model is not None:
+        raise ValueError(
+            "Exactly one of 'representations' or 'noise_model' should be "
+            "provided."
+        )
+    if representations is None and noise_model is None:
+        raise ValueError(
+            "Either 'representations' or 'noise_model' must be provided."
+        )
+    if representations is not None:
+        return _canonical_scaled_representations(representations, scale_factor)
+
+    if epsilon is None:
+        raise ValueError(
+            "'epsilon' must be provided when using the legacy 'noise_model' "
+            "argument."
+        )
+    assert noise_model is not None
+    warnings.warn(
+        "The 'noise_model' argument is deprecated. Pass "
+        "'representations' directly instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    return scale_circuit_amplifications(
+        circuit, scale_factor, noise_model, epsilon
+    )
 
 
 def construct_circuits(
     circuit: Circuit,
     scale_factors: list[float],
-    noise_model: str,
-    epsilon: float,
+    noise_model: str | None = None,
+    epsilon: float | None = None,
     random_state: int | np.random.RandomState | None = None,
     precision: float = 0.1,
     num_samples: int | None = None,
+    representations: Sequence[OperationRepresentation] | None = None,
 ) -> tuple[list[list[QPROGRAM]], list[list[int]], list[float]]:
     """Samples lists of implementable circuits from the noise-amplified
     representation of the input ideal circuit at each input noise scale
@@ -45,10 +130,12 @@ def construct_circuits(
             sequence is sampled.
         scale_factors: A list of (positive) numbers by which the baseline
             noise level is to be amplified.
-        noise_model: A string describing the noise model to be used for the
+        representations: Quasi-probability representations of the circuit
+            operations to be canonically noise-scaled for PEA.
+        noise_model: A legacy string describing the noise model to be used for
             noise-scaled representations, e.g. "local_depolarizing" or
-            "global_depolarizing".
-        epsilon: Baseline noise level.
+            "global_depolarizing". Deprecated in favor of ``representations``.
+        epsilon: Baseline noise level. Required only with ``noise_model``.
         random_state: The random state or seed for reproducibility.
         precision: The desired precision for the sampling process.
             Default is 0.1.
@@ -72,7 +159,9 @@ def construct_circuits(
     # Get the 1-norm of the circuit quasi-probability representation
     _, _, norm = sample_circuit(
         circuit,
-        scale_circuit_amplifications(circuit, 1.0, noise_model, epsilon),
+        _resolve_representations(
+            circuit, 1.0, noise_model, epsilon, representations
+        ),
         num_samples=1,
     )
 
@@ -89,7 +178,9 @@ def construct_circuits(
     for s in scale_factors:
         sampled_circuits, signs, norm = sample_circuit(
             circuit,
-            scale_circuit_amplifications(circuit, s, noise_model, epsilon),
+            _resolve_representations(
+                circuit, s, noise_model, epsilon, representations
+            ),
             num_samples=num_samples,
             random_state=random_state,
         )
@@ -148,15 +239,17 @@ def execute_with_pea(
     circuit: Circuit,
     executor: Executor | Callable[[QPROGRAM], QuantumResult],
     scale_factors: list[float],
-    noise_model: str,
-    epsilon: float,
-    extrapolation_method: Callable[[Sequence[float], Sequence[float]], float],
+    noise_model: str | None = None,
+    epsilon: float | None = None,
+    extrapolation_method: Callable[[Sequence[float], Sequence[float]], float]
+    | None = None,
     observable: Observable | None = None,
     random_state: int | np.random.RandomState | None = None,
     precision: float = 0.1,
     num_samples: int | None = None,
     full_output: bool = False,
     force_run_all: bool = False,
+    representations: Sequence[OperationRepresentation] | None = None,
 ) -> float | tuple[float, dict[str, Any]]:
     r"""Estimates the error-mitigated expectation value associated to the
     input circuit, via the application of probabilistic error amplification
@@ -180,10 +273,12 @@ def execute_with_pea(
             unmitigated ``QuantumResult`` (e.g. an expectation value).
         scale_factors: A list of (positive) numbers by which the baseline
             noise level is to be amplified.
-        noise_model: A string describing the noise model to be used for the
+        representations: Quasi-probability representations of the circuit
+            operations to be canonically noise-scaled for PEA.
+        noise_model: A legacy string describing the noise model to be used for
             noise-scaled representations, e.g. "local_depolarizing" or
-            "global_depolarizing".
-        epsilon: Baseline noise level.
+            "global_depolarizing". Deprecated in favor of ``representations``.
+        epsilon: Baseline noise level. Required only with ``noise_model``.
         extrapolation_method: The method of extrapolation to use when fitting
             the measured results. A list of built-in functions can be found
             in ``mitiq.zne.inference``.
@@ -208,14 +303,18 @@ def execute_with_pea(
         ``full_output`` is ``False``, only ``pea_value`` is
         returned.
     """
+    if extrapolation_method is None:
+        raise ValueError("'extrapolation_method' must be provided.")
+
     scaled_circuits, scaled_signs, scaled_norms = construct_circuits(
         circuit,
         scale_factors,
-        noise_model,
-        epsilon,
-        random_state,
-        precision,
-        num_samples,
+        noise_model=noise_model,
+        epsilon=epsilon,
+        random_state=random_state,
+        precision=precision,
+        num_samples=num_samples,
+        representations=representations,
     )
     # Execute all sampled circuits
     if not isinstance(executor, Executor):

--- a/mitiq/experimental/pea/pea.py
+++ b/mitiq/experimental/pea/pea.py
@@ -48,6 +48,11 @@ def _canonical_scaled_representations(
             )
 
         if np.isclose(gamma_minus, 0.0):
+            if not np.isclose(scale_factor, 1.0):
+                raise ValueError(
+                    "Cannot canonically scale an all-positive "
+                    "representation away from scale factor 1."
+                )
             scaled_coeffs = list(representation.coeffs)
         else:
             positive_scale = (
@@ -156,17 +161,27 @@ def construct_circuits(
             f" but precision is {precision}."
         )
 
-    # Get the 1-norm of the circuit quasi-probability representation
-    _, _, norm = sample_circuit(
-        circuit,
+    scaled_representations = [
         _resolve_representations(
-            circuit, 1.0, noise_model, epsilon, representations
-        ),
-        num_samples=1,
-    )
+            circuit, s, noise_model, epsilon, representations
+        )
+        for s in scale_factors
+    ]
 
     # Deduce the number of samples (if not given by the user)
     if num_samples is None:
+        _, _, norm = sample_circuit(
+            circuit,
+            _resolve_representations(
+                circuit, 1.0, noise_model, epsilon, representations
+            ),
+            num_samples=1,
+        )
+        for scaled_representation in scaled_representations:
+            _, _, scaled_norm = sample_circuit(
+                circuit, scaled_representation, num_samples=1
+            )
+            norm = max(norm, scaled_norm)
         num_samples = int((norm / precision) ** 2)
 
     if num_samples > 10**5:
@@ -175,12 +190,10 @@ def construct_circuits(
     scaled_sampled_circuits = []
     scaled_signs = []
     scaled_norms = []
-    for s in scale_factors:
+    for scaled_representation in scaled_representations:
         sampled_circuits, signs, norm = sample_circuit(
             circuit,
-            _resolve_representations(
-                circuit, s, noise_model, epsilon, representations
-            ),
+            scaled_representation,
             num_samples=num_samples,
             random_state=random_state,
         )

--- a/mitiq/experimental/pea/tests/test_pea.py
+++ b/mitiq/experimental/pea/tests/test_pea.py
@@ -354,14 +354,18 @@ def test_pea_data_with_full_output():
         full_output=True,
     )
     # Get num samples from precision
-    _, _, norm = sample_circuit(
-        twoq_circ,
-        amplify_noisy_ops_in_circuit_with_local_depolarizing_noise(
-            twoq_circ, epsilon
-        ),
-        num_samples=1,
-    )
-    num_samples = int((norm / precision) ** 2)
+    scale_factors = [1, 1.2, 1.6]
+    norms = []
+    for scale_factor in scale_factors:
+        _, _, norm = sample_circuit(
+            twoq_circ,
+            scale_circuit_amplifications(
+                twoq_circ, scale_factor, "local_depolarizing", epsilon
+            ),
+            num_samples=1,
+        )
+        norms.append(norm)
+    num_samples = int((max(norms) / precision) ** 2)
 
     # Manually get raw expectation values
     scaled_exp_values = [

--- a/mitiq/experimental/pea/tests/test_pea.py
+++ b/mitiq/experimental/pea/tests/test_pea.py
@@ -159,6 +159,58 @@ def test_direct_representations_match_legacy_at_base_scale():
     assert direct == legacy
 
 
+def test_direct_representations_reject_all_positive_non_base_scale():
+    representations = scale_circuit_amplifications(
+        oneq_circ,
+        scale_factor=1,
+        noise_model="local_depolarizing",
+        epsilon=BASE_NOISE,
+    )
+
+    with pytest.raises(ValueError, match="all-positive"):
+        construct_circuits(
+            oneq_circ,
+            scale_factors=[1, 2],
+            representations=representations,
+            num_samples=10,
+        )
+
+
+def test_direct_representations_precision_uses_largest_scaled_norm():
+    representations = (
+        represent_operations_in_circuit_with_local_depolarizing_noise(
+            oneq_circ,
+            noise_level=BASE_NOISE,
+        )
+    )
+    scale_factors = [0, 1]
+    precision = 0.2
+
+    _, _, scaled_norms = construct_circuits(
+        oneq_circ,
+        scale_factors=scale_factors,
+        representations=representations,
+        num_samples=1,
+        random_state=1,
+    )
+    scaled_circuits, _, _ = construct_circuits(
+        oneq_circ,
+        scale_factors=scale_factors,
+        representations=representations,
+        precision=precision,
+        random_state=1,
+    )
+
+    expected_num_samples = int((max(scaled_norms) / precision) ** 2)
+    base_num_samples = int((scaled_norms[1] / precision) ** 2)
+
+    assert expected_num_samples > base_num_samples
+    assert [len(circuits) for circuits in scaled_circuits] == [
+        expected_num_samples,
+        expected_num_samples,
+    ]
+
+
 @pytest.mark.parametrize("precision", [0.2, 0.1])
 def test_precision_option_used_in_num_samples(precision):
     """Tests that the 'precision' argument is used to deduce num_samples."""

--- a/mitiq/experimental/pea/tests/test_pea.py
+++ b/mitiq/experimental/pea/tests/test_pea.py
@@ -5,6 +5,8 @@
 
 """Unit tests for PEA."""
 
+import warnings
+
 import cirq
 import numpy as np
 import pytest
@@ -17,12 +19,18 @@ from mitiq.experimental.pea import (
 from mitiq.experimental.pea.amplifications.amplify_depolarizing import (
     amplify_noisy_ops_in_circuit_with_local_depolarizing_noise,
 )
+from mitiq.experimental.pea.scale_amplifications import (
+    scale_circuit_amplifications,
+)
 from mitiq.interface import convert_from_mitiq, convert_to_mitiq
 from mitiq.interface.mitiq_cirq import compute_density_matrix
 from mitiq.pec import (
     OperationRepresentation,
 )
 from mitiq.pec.pec import LargeSampleWarning, sample_circuit
+from mitiq.pec.representations.depolarizing import (
+    represent_operations_in_circuit_with_local_depolarizing_noise,
+)
 from mitiq.typing import QPROGRAM, SUPPORTED_PROGRAM_TYPES
 from mitiq.zne.inference import LinearFactory
 
@@ -57,6 +65,98 @@ BASE_NOISE = 0.02
 q0, q1 = cirq.LineQubit.range(2)
 oneq_circ = cirq.Circuit(cirq.Z.on(q0), cirq.Z.on(q0))
 twoq_circ = cirq.Circuit(cirq.Y.on(q1), cirq.CNOT.on(q0, q1), cirq.Y.on(q1))
+
+
+def test_construct_circuits_accepts_direct_representations():
+    representations = (
+        represent_operations_in_circuit_with_local_depolarizing_noise(
+            oneq_circ,
+            noise_level=BASE_NOISE,
+        )
+    )
+
+    scaled_circuits, scaled_signs, scaled_norms = construct_circuits(
+        oneq_circ,
+        scale_factors=[0, 1],
+        representations=representations,
+        num_samples=10,
+        random_state=1,
+    )
+
+    assert [len(circuits) for circuits in scaled_circuits] == [10, 10]
+    assert len(scaled_signs) == 2
+    assert scaled_norms[0] > scaled_norms[1]
+    assert np.isclose(scaled_norms[1], 1.0)
+    assert all(sign == 1 for sign in scaled_signs[1])
+
+
+def test_construct_circuits_rejects_ambiguous_representation_source():
+    representations = get_pauli_and_cnot_representations(BASE_NOISE)
+
+    with pytest.raises(ValueError, match="Exactly one"):
+        construct_circuits(
+            oneq_circ,
+            scale_factors=[1],
+            noise_model="local_depolarizing",
+            epsilon=BASE_NOISE,
+            representations=representations,
+        )
+
+    with pytest.raises(ValueError, match="Either 'representations'"):
+        construct_circuits(oneq_circ, scale_factors=[1])
+
+    with pytest.raises(ValueError, match="'epsilon' must be provided"):
+        construct_circuits(
+            oneq_circ,
+            scale_factors=[1],
+            noise_model="local_depolarizing",
+        )
+
+
+def test_noise_model_path_is_deprecated_but_backward_compatible():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        legacy = construct_circuits(
+            oneq_circ,
+            scale_factors=[1],
+            noise_model="local_depolarizing",
+            epsilon=BASE_NOISE,
+            num_samples=10,
+            random_state=1,
+        )
+
+    assert any(
+        "'noise_model' argument is deprecated" in str(warning.message)
+        for warning in caught
+    )
+    assert len(legacy[0][0]) == 10
+
+
+def test_direct_representations_match_legacy_at_base_scale():
+    representations = scale_circuit_amplifications(
+        oneq_circ,
+        scale_factor=1,
+        noise_model="local_depolarizing",
+        epsilon=BASE_NOISE,
+    )
+
+    direct = construct_circuits(
+        oneq_circ,
+        scale_factors=[1],
+        representations=representations,
+        num_samples=10,
+        random_state=1,
+    )
+    legacy = construct_circuits(
+        oneq_circ,
+        scale_factors=[1],
+        noise_model="local_depolarizing",
+        epsilon=BASE_NOISE,
+        num_samples=10,
+        random_state=1,
+    )
+
+    assert direct == legacy
 
 
 @pytest.mark.parametrize("precision", [0.2, 0.1])


### PR DESCRIPTION
## Description

Fixes #2936.

This updates experimental PEA so `construct_circuits` can take direct `OperationRepresentation` objects instead of forcing the legacy `noise_model` string path.

Changes:

- adds canonical scaling for direct quasi-probability representations
- rejects ambiguous calls where both `representations` and `noise_model` are passed
- keeps `noise_model` backward compatible and emits a deprecation warning
- threads the new representation path through `execute_with_pea`
- adds unit tests for direct representations, validation errors, legacy compatibility, and the base-scale legacy match

Validation run locally:

```bash
uv run --group dev pytest mitiq/experimental/pea/tests/test_pea.py -k 'not braket'
uv run --group dev pytest mitiq/experimental/pea/tests/test_scale_amplifications.py
uv run --extra braket --extra qiskit --group dev pytest mitiq/experimental/pea/tests/test_pea.py
uv run --group dev ruff check mitiq/experimental/pea/pea.py mitiq/experimental/pea/tests/test_pea.py
uv run --group dev ruff format --check mitiq/experimental/pea/pea.py mitiq/experimental/pea/tests/test_pea.py
python3 -m compileall -q mitiq/experimental/pea/pea.py mitiq/experimental/pea/tests/test_pea.py
git diff --check
```

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
