### PR TITLE
Add error mitigation benchmark scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,14 @@ qiskit = [
     "qiskit-ibm-runtime~=0.41.1",
     "ply==3.11",
 ]
+benchmarks = [
+    "mthree>=3.0.0",
+    "ply==3.11",
+    "pytket-quantinuum>=0.59.1",
+    "qermit>=0.7.1",
+    "qiskit>=2.0.0,<3.0.0",
+    "qiskit-aer~=0.17.0",
+]
 
 [dependency-groups]
 dev = [

--- a/scripts/benchmark_error_mitigation_common.py
+++ b/scripts/benchmark_error_mitigation_common.py
@@ -1,0 +1,332 @@
+# Copyright (C) Unitary Foundation
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Shared utilities for standalone error-mitigation benchmark scripts."""
+
+import argparse
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+import cirq
+import networkx as nx
+import numpy as np
+from tabulate import tabulate
+
+from mitiq import MeasurementResult, Observable, PauliString
+from mitiq.benchmarks import (
+    generate_ghz_circuit,
+    generate_mirror_circuit,
+    generate_quantum_volume_circuit,
+)
+from mitiq.interface.mitiq_cirq import compute_density_matrix
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    """Container for one benchmark row."""
+
+    method: str
+    ideal: float
+    noisy: float
+    mitigated: float | None
+    improvement: float | None
+    runtime: float
+    executions: int
+    notes: str = ""
+
+
+class CountingFloatExecutor:
+    """Wraps an expectation-value executor and counts calls."""
+
+    def __init__(self, executor: Callable[[cirq.Circuit], float]) -> None:
+        self._executor = executor
+        self.calls = 0
+
+    def __call__(self, circuit: cirq.Circuit) -> float:
+        self.calls += 1
+        return self._executor(circuit)
+
+
+class CountingMeasurementExecutor:
+    """Wraps a measurement executor and counts calls."""
+
+    def __init__(
+        self, executor: Callable[[cirq.Circuit], MeasurementResult]
+    ) -> None:
+        self._executor = executor
+        self.calls = 0
+
+    def __call__(self, circuit: cirq.Circuit) -> MeasurementResult:
+        self.calls += 1
+        return self._executor(circuit)
+
+
+def add_benchmark_arguments(parser: argparse.ArgumentParser) -> None:
+    """Adds common benchmark CLI arguments."""
+
+    parser.add_argument(
+        "--circuit",
+        choices=("ghz", "qv", "mirror"),
+        default="ghz",
+        help="Benchmark circuit family.",
+    )
+    parser.add_argument("--n-qubits", type=int, default=4)
+    parser.add_argument("--depth", type=int, default=4)
+    parser.add_argument("--noise-level", type=float, default=0.01)
+    parser.add_argument("--shots", type=int, default=8192)
+    parser.add_argument("--seed", type=int, default=1234)
+
+
+def build_benchmark_circuit(
+    circuit_name: str,
+    n_qubits: int,
+    depth: int,
+    seed: int,
+) -> cirq.Circuit:
+    """Returns a Mitiq benchmark circuit as a Cirq circuit."""
+
+    if circuit_name == "ghz":
+        return strip_global_phase(
+            generate_ghz_circuit(n_qubits, return_type="cirq")
+        )
+
+    if circuit_name == "qv":
+        circuit, _ = generate_quantum_volume_circuit(
+            n_qubits,
+            depth,
+            decompose=True,
+            seed=seed,
+            return_type="cirq",
+        )
+        return strip_global_phase(circuit)
+
+    graph = nx.path_graph(n_qubits)
+    circuit, _ = generate_mirror_circuit(
+        depth,
+        two_qubit_gate_prob=0.5,
+        connectivity_graph=graph,
+        seed=seed,
+        return_type="cirq",
+    )
+    return strip_global_phase(circuit)
+
+
+def strip_global_phase(circuit: cirq.Circuit) -> cirq.Circuit:
+    """Removes global phases, which do not affect benchmark expectations."""
+
+    return cirq.Circuit(
+        op
+        for op in circuit.all_operations()
+        if not isinstance(op.gate, cirq.GlobalPhaseGate)
+    )
+
+
+def benchmark_observable(circuit: cirq.Circuit) -> Observable:
+    """Returns a simple Pauli-Z observable for the circuit qubits."""
+
+    n_qubits = len(sorted(circuit.all_qubits()))
+    return Observable(PauliString("Z" * n_qubits))
+
+
+def zz_expectation_from_density_matrix(
+    density_matrix: np.ndarray,
+    n_qubits: int,
+) -> float:
+    """Computes the expectation of Z on all qubits."""
+
+    expectation = 0.0
+    probabilities = np.real(np.diag(density_matrix))
+    for state, probability in enumerate(probabilities):
+        eigenvalue = 1
+        for qubit_index in range(n_qubits):
+            bit = (state >> (n_qubits - qubit_index - 1)) & 1
+            eigenvalue *= 1 if bit == 0 else -1
+        expectation += eigenvalue * probability
+    return float(expectation)
+
+
+def zz_expectation_from_measurements(measurements: MeasurementResult) -> float:
+    """Computes the expectation of Z on all measured qubits."""
+
+    bitstrings = np.asarray(measurements.result)
+    signs = 1 - 2 * bitstrings
+    return float(np.mean(np.prod(signs, axis=1)))
+
+
+def ideal_expectation(circuit: cirq.Circuit) -> float:
+    """Computes the noiseless ZZ expectation value."""
+
+    density_matrix = compute_density_matrix(circuit, noise_level=(0.0,))
+    return zz_expectation_from_density_matrix(
+        density_matrix, len(circuit.all_qubits())
+    )
+
+
+def improvement_factor(
+    ideal: float,
+    noisy: float,
+    mitigated: float,
+) -> float:
+    """Computes |noisy - ideal| / |mitigated - ideal|."""
+
+    mitigated_error = abs(mitigated - ideal)
+    if mitigated_error == 0:
+        return float("inf")
+    return abs(noisy - ideal) / mitigated_error
+
+
+def append_gate_noise(
+    circuit: cirq.Circuit,
+    noise_level: float,
+) -> cirq.Circuit:
+    """Returns a copy with depolarizing noise after non-measurement gates."""
+
+    noisy_circuit = cirq.Circuit()
+    for op in circuit.all_operations():
+        noisy_circuit.append(op)
+        if isinstance(op.gate, cirq.MeasurementGate):
+            continue
+        if len(op.qubits) == 1:
+            noisy_circuit.append(cirq.depolarize(noise_level).on(*op.qubits))
+        elif len(op.qubits) == 2:
+            noisy_circuit.append(
+                cirq.depolarize(noise_level, n_qubits=2).on(*op.qubits)
+            )
+    return noisy_circuit
+
+
+def noisy_density_executor(
+    noise_level: float,
+) -> Callable[[cirq.Circuit], float]:
+    """Builds an executor returning a noisy ZZ expectation value."""
+
+    def execute(circuit: cirq.Circuit) -> float:
+        noisy_circuit = append_gate_noise(circuit, noise_level)
+        density_matrix = compute_density_matrix(
+            noisy_circuit, noise_level=(0.0,)
+        )
+        return zz_expectation_from_density_matrix(
+            density_matrix, len(circuit.all_qubits())
+        )
+
+    return execute
+
+
+def add_terminal_measurements(circuit: cirq.Circuit) -> cirq.Circuit:
+    """Returns a copy with one terminal measurement over all qubits."""
+
+    measured = circuit.copy()
+    qubits = sorted(measured.all_qubits())
+    measured.append(cirq.measure(*qubits, key="m"))
+    return measured
+
+
+def noisy_readout_executor(
+    p0: float,
+    p1: float,
+    shots: int,
+    seed: int,
+) -> Callable[[cirq.Circuit], MeasurementResult]:
+    """Builds a readout-noise executor returning Mitiq measurements."""
+
+    rng = np.random.default_rng(seed)
+    simulator = cirq.Simulator(seed=seed)
+
+    def execute(circuit: cirq.Circuit) -> MeasurementResult:
+        measured = add_terminal_measurements(circuit)
+        qubits = sorted(circuit.all_qubits())
+        result = simulator.run(measured, repetitions=shots)
+        bitstrings = np.array(result.measurements["m"], copy=True)
+
+        zero_flips = (bitstrings == 0) & (rng.random(bitstrings.shape) < p0)
+        one_flips = (bitstrings == 1) & (rng.random(bitstrings.shape) < p1)
+        bitstrings[zero_flips] = 1
+        bitstrings[one_flips] = 0
+
+        return MeasurementResult(
+            result=bitstrings,
+            qubit_indices=tuple(int(q.x) for q in qubits),
+        )
+
+    return execute
+
+
+def counts_from_measurements(
+    measurements: MeasurementResult,
+) -> dict[str, int]:
+    """Converts Mitiq measurements into a counts dictionary."""
+
+    counts: dict[str, int] = {}
+    for row in measurements.result:
+        key = "".join(str(int(bit)) for bit in row)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def print_results(results: list[BenchmarkResult]) -> None:
+    """Pretty-prints benchmark rows."""
+
+    rows = []
+    for result in results:
+        mitigated = (
+            "n/a" if result.mitigated is None else f"{result.mitigated:.6f}"
+        )
+        improvement = "n/a"
+        if result.improvement is not None:
+            improvement = f"{result.improvement:.3f}"
+        rows.append(
+            [
+                result.method,
+                f"{result.ideal:.6f}",
+                f"{result.noisy:.6f}",
+                mitigated,
+                improvement,
+                f"{result.runtime:.3f}",
+                result.executions,
+                result.notes,
+            ]
+        )
+
+    print(
+        tabulate(
+            rows,
+            headers=[
+                "method",
+                "ideal",
+                "noisy",
+                "mitigated",
+                "improvement",
+                "runtime_s",
+                "executions",
+                "notes",
+            ],
+        )
+    )
+
+
+def timed_result(
+    method: str,
+    ideal: float,
+    noisy: float,
+    executor: CountingFloatExecutor | CountingMeasurementExecutor,
+    run: Callable[[], float],
+    notes: str = "",
+) -> BenchmarkResult:
+    """Runs a mitigation method and returns a benchmark row."""
+
+    started_at = time.perf_counter()
+    mitigated = float(np.real_if_close(run()))
+    runtime = time.perf_counter() - started_at
+    return BenchmarkResult(
+        method=method,
+        ideal=ideal,
+        noisy=noisy,
+        mitigated=mitigated,
+        improvement=improvement_factor(ideal, noisy, mitigated),
+        runtime=runtime,
+        executions=executor.calls,
+        notes=notes,
+    )

--- a/scripts/benchmark_meas_mitigation.py
+++ b/scripts/benchmark_meas_mitigation.py
@@ -1,0 +1,162 @@
+# Copyright (C) Unitary Foundation
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Benchmark measurement mitigation with Mitiq REM, Mitiq TREX, and M3.
+
+Example:
+    python scripts/benchmark_meas_mitigation.py --circuit ghz --n-qubits 4
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import numpy as np
+from benchmark_error_mitigation_common import (
+    BenchmarkResult,
+    CountingMeasurementExecutor,
+    add_benchmark_arguments,
+    benchmark_observable,
+    build_benchmark_circuit,
+    counts_from_measurements,
+    ideal_expectation,
+    improvement_factor,
+    noisy_readout_executor,
+    print_results,
+    timed_result,
+    zz_expectation_from_measurements,
+)
+
+from mitiq.experimental.trex import execute_with_trex
+from mitiq.rem import execute_with_rem
+from mitiq.rem.inverse_confusion_matrix import (
+    generate_inverse_confusion_matrix,
+)
+
+
+def run_mthree(
+    circuit,
+    ideal: float,
+    noisy: float,
+    p0: float,
+    p1: float,
+    shots: int,
+    seed: int,
+) -> BenchmarkResult:
+    """Runs matrix-free measurement mitigation with mthree."""
+
+    try:
+        import mthree
+    except ImportError:
+        return BenchmarkResult(
+            method="mthree",
+            ideal=ideal,
+            noisy=noisy,
+            mitigated=None,
+            improvement=None,
+            runtime=0.0,
+            executions=0,
+            notes="install mthree to enable",
+        )
+
+    executor = CountingMeasurementExecutor(
+        noisy_readout_executor(p0, p1, shots, seed)
+    )
+    started_at = time.perf_counter()
+    measurements = executor(circuit)
+    counts = counts_from_measurements(measurements)
+
+    mitigation = mthree.M3Mitigation()
+    calibration = [
+        np.array([[1 - p0, p1], [p0, 1 - p1]])
+        for _ in range(len(circuit.all_qubits()))
+    ]
+    mitigation.cals_from_matrices(calibration)
+    quasi = mitigation.apply_correction(
+        counts, list(range(len(circuit.all_qubits())))
+    )
+    mitigated = float(quasi.expval("Z" * len(circuit.all_qubits())))
+    runtime = time.perf_counter() - started_at
+
+    return BenchmarkResult(
+        method="mthree",
+        ideal=ideal,
+        noisy=noisy,
+        mitigated=mitigated,
+        improvement=improvement_factor(ideal, noisy, mitigated),
+        runtime=runtime,
+        executions=executor.calls,
+        notes="M3 correction on Z...Z",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    add_benchmark_arguments(parser)
+    args = parser.parse_args()
+
+    circuit = build_benchmark_circuit(
+        args.circuit, args.n_qubits, args.depth, args.seed
+    )
+    observable = benchmark_observable(circuit)
+    ideal = ideal_expectation(circuit)
+
+    p0 = args.noise_level
+    p1 = args.noise_level
+    base_executor = CountingMeasurementExecutor(
+        noisy_readout_executor(p0, p1, args.shots, args.seed)
+    )
+    noisy = zz_expectation_from_measurements(base_executor(circuit))
+
+    rem_executor = CountingMeasurementExecutor(
+        noisy_readout_executor(p0, p1, args.shots, args.seed)
+    )
+    inverse_confusion_matrix = generate_inverse_confusion_matrix(
+        args.n_qubits, p0=p0, p1=p1
+    )
+    results = [
+        timed_result(
+            "mitiq.rem",
+            ideal,
+            noisy,
+            rem_executor,
+            lambda: execute_with_rem(
+                circuit,
+                rem_executor,
+                observable,
+                inverse_confusion_matrix=inverse_confusion_matrix,
+            ),
+        )
+    ]
+
+    trex_executor = CountingMeasurementExecutor(
+        noisy_readout_executor(p0, p1, args.shots, args.seed)
+    )
+    results.append(
+        timed_result(
+            "mitiq.trex",
+            ideal,
+            noisy,
+            trex_executor,
+            lambda: execute_with_trex(
+                circuit,
+                trex_executor,
+                observable,
+                num_randomizations=32,
+                random_state=args.seed,
+            ),
+            notes="experimental",
+        )
+    )
+    results.append(
+        run_mthree(circuit, ideal, noisy, p0, p1, args.shots, args.seed)
+    )
+
+    print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_pec.py
+++ b/scripts/benchmark_pec.py
@@ -41,7 +41,7 @@ def pec_representations(circuit: cirq.Circuit, noise_level: float):
 
 
 def run_qermit_placeholder(ideal: float, noisy: float) -> BenchmarkResult:
-    """Records whether Qermit PEC is importable in this environment."""
+    """Records why Qermit learning-based PEC is not run locally."""
 
     try:
         from qermit.probabilistic_error_cancellation import (  # noqa: F401
@@ -67,7 +67,7 @@ def run_qermit_placeholder(ideal: float, noisy: float) -> BenchmarkResult:
         improvement=None,
         runtime=0.0,
         executions=0,
-        notes="requires paired device/simulator backends",
+        notes="learning PEC needs paired noisy/ideal backends",
     )
 
 

--- a/scripts/benchmark_pec.py
+++ b/scripts/benchmark_pec.py
@@ -1,0 +1,113 @@
+# Copyright (C) Unitary Foundation
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Benchmark probabilistic error cancellation on Mitiq benchmark circuits.
+
+Example:
+    python scripts/benchmark_pec.py --circuit ghz --n-qubits 2 --shots 200
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import cirq
+from benchmark_error_mitigation_common import (
+    BenchmarkResult,
+    CountingFloatExecutor,
+    add_benchmark_arguments,
+    build_benchmark_circuit,
+    ideal_expectation,
+    noisy_density_executor,
+    print_results,
+    timed_result,
+)
+
+from mitiq.pec import execute_with_pec
+from mitiq.pec.representations import (
+    represent_operations_in_circuit_with_local_depolarizing_noise,
+)
+
+
+def pec_representations(circuit: cirq.Circuit, noise_level: float):
+    """Constructs local depolarizing-noise representations for the circuit."""
+
+    return represent_operations_in_circuit_with_local_depolarizing_noise(
+        ideal_circuit=circuit,
+        noise_level=noise_level,
+    )
+
+
+def run_qermit_placeholder(ideal: float, noisy: float) -> BenchmarkResult:
+    """Records whether Qermit PEC is importable in this environment."""
+
+    try:
+        from qermit.probabilistic_error_cancellation import (  # noqa: F401
+            gen_PEC_learning_based_MitEx,
+        )
+    except ImportError:
+        return BenchmarkResult(
+            method="qermit.pec",
+            ideal=ideal,
+            noisy=noisy,
+            mitigated=None,
+            improvement=None,
+            runtime=0.0,
+            executions=0,
+            notes="install qermit to enable",
+        )
+
+    return BenchmarkResult(
+        method="qermit.pec",
+        ideal=ideal,
+        noisy=noisy,
+        mitigated=None,
+        improvement=None,
+        runtime=0.0,
+        executions=0,
+        notes="requires paired device/simulator backends",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    add_benchmark_arguments(parser)
+    args = parser.parse_args()
+
+    circuit = build_benchmark_circuit(
+        args.circuit, args.n_qubits, args.depth, args.seed
+    )
+    ideal = ideal_expectation(circuit)
+
+    base_executor = CountingFloatExecutor(
+        noisy_density_executor(args.noise_level)
+    )
+    noisy = base_executor(circuit)
+
+    executor = CountingFloatExecutor(noisy_density_executor(args.noise_level))
+    representations = pec_representations(circuit, args.noise_level)
+    results = [
+        timed_result(
+            "mitiq.pec",
+            ideal,
+            noisy,
+            executor,
+            lambda: execute_with_pec(
+                circuit,
+                executor,
+                representations=representations,
+                num_samples=args.shots,
+                random_state=args.seed,
+            ),
+            notes=f"{args.shots} samples",
+        ),
+        run_qermit_placeholder(ideal, noisy),
+    ]
+
+    print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_zne.py
+++ b/scripts/benchmark_zne.py
@@ -29,9 +29,36 @@ from benchmark_error_mitigation_common import (
     zz_expectation_from_density_matrix,
 )
 
+from mitiq.interface import convert_from_mitiq
 from mitiq.zne import execute_with_zne
 from mitiq.zne.inference import LinearFactory
 from mitiq.zne.scaling import fold_global
+
+
+def qiskit_noise_model_for_circuit(qiskit_circuit, noise_level: float):
+    """Builds a Qiskit Aer noise model matching gates in a circuit."""
+
+    from qiskit_aer.noise import NoiseModel, depolarizing_error
+
+    noise_model = NoiseModel()
+    seen_errors = set()
+    for instruction in qiskit_circuit.data:
+        qubits = tuple(
+            qiskit_circuit.find_bit(q).index for q in instruction.qubits
+        )
+        if len(qubits) not in (1, 2):
+            continue
+        gate_name = instruction.operation.name
+        error_key = (gate_name, qubits)
+        if error_key in seen_errors:
+            continue
+        seen_errors.add(error_key)
+        noise_model.add_quantum_error(
+            depolarizing_error(noise_level, len(qubits)),
+            gate_name,
+            qubits,
+        )
+    return noise_model
 
 
 def qiskit_aer_density_executor(
@@ -42,40 +69,18 @@ def qiskit_aer_density_executor(
 
     try:
         from qiskit_aer import AerSimulator
-        from qiskit_aer.noise import NoiseModel, depolarizing_error
-
-        from mitiq.interface import convert_from_mitiq
     except ImportError:
         return None
 
     def execute(circuit: cirq.Circuit) -> float:
         qiskit_circuit = convert_from_mitiq(circuit, "qiskit")
 
-        one_qubit_gate_names = set()
-        two_qubit_gate_names = set()
-        for instruction in qiskit_circuit.data:
-            num_qubits = instruction.operation.num_qubits
-            if num_qubits == 1:
-                one_qubit_gate_names.add(instruction.operation.name)
-            elif num_qubits == 2:
-                two_qubit_gate_names.add(instruction.operation.name)
-
         qiskit_circuit.save_density_matrix()
-        noise_model = NoiseModel()
-        if one_qubit_gate_names:
-            noise_model.add_all_qubit_quantum_error(
-                depolarizing_error(noise_level, 1),
-                sorted(one_qubit_gate_names),
-            )
-        if two_qubit_gate_names:
-            noise_model.add_all_qubit_quantum_error(
-                depolarizing_error(noise_level, 2),
-                sorted(two_qubit_gate_names),
-            )
-
         simulator = AerSimulator(
             method="density_matrix",
-            noise_model=noise_model,
+            noise_model=qiskit_noise_model_for_circuit(
+                qiskit_circuit, noise_level
+            ),
             seed_simulator=seed,
         )
         result = simulator.run(qiskit_circuit).result()
@@ -87,19 +92,19 @@ def qiskit_aer_density_executor(
     return CountingFloatExecutor(execute)
 
 
-def run_qiskit_aer_zne(
+def run_qiskit_aer_manual_zne(
     circuit: cirq.Circuit,
     ideal: float,
     noisy: float,
     noise_level: float,
     seed: int,
 ) -> BenchmarkResult:
-    """Runs a Qiskit Aer ZNE comparison over folded Mitiq circuits."""
+    """Runs a manual folded-circuit ZNE baseline with Qiskit Aer."""
 
     executor = qiskit_aer_density_executor(noise_level, seed)
     if executor is None:
         return BenchmarkResult(
-            method="qiskit-aer.zne",
+            method="qiskit-aer.manual-zne",
             ideal=ideal,
             noisy=noisy,
             mitigated=None,
@@ -119,14 +124,104 @@ def run_qiskit_aer_zne(
     mitigated = float(np.polyval(coefficients, 0.0))
     runtime = time.perf_counter() - started_at
     return BenchmarkResult(
-        method="qiskit-aer.zne",
+        method="qiskit-aer.manual-zne",
         ideal=ideal,
         noisy=qiskit_noisy,
         mitigated=mitigated,
         improvement=improvement_factor(ideal, qiskit_noisy, mitigated),
         runtime=runtime,
         executions=executor.calls,
-        notes="fold_global + linear fit",
+        notes="manual fold_global + linear fit",
+    )
+
+
+def run_qermit_zne(
+    circuit: cirq.Circuit,
+    ideal: float,
+    noisy: float,
+    noise_level: float,
+    shots: int,
+    seed: int,
+) -> BenchmarkResult:
+    """Runs Qermit zero-noise extrapolation with a noisy Aer backend."""
+
+    try:
+        from pytket.extensions.qiskit import AerBackend, qiskit_to_tk
+        from pytket.pauli import Pauli, QubitPauliString
+        from pytket.utils import QubitPauliOperator
+        from qermit import (
+            AnsatzCircuit,
+            ObservableExperiment,
+            ObservableTracker,
+        )
+        from qermit.zero_noise_extrapolation import (
+            Fit,
+            Folding,
+            gen_ZNE_MitEx,
+        )
+    except ImportError:
+        return BenchmarkResult(
+            method="qermit.zne",
+            ideal=ideal,
+            noisy=noisy,
+            mitigated=None,
+            improvement=None,
+            runtime=0.0,
+            executions=0,
+            notes="install qermit to enable",
+        )
+
+    scale_factors = [1, 3, 5]
+    try:
+        qiskit_circuit = convert_from_mitiq(circuit, "qiskit")
+        pytket_circuit = qiskit_to_tk(qiskit_circuit)
+        backend = AerBackend(
+            noise_model=qiskit_noise_model_for_circuit(
+                qiskit_circuit, noise_level
+            ),
+            n_qubits=len(pytket_circuit.qubits),
+        )
+        pauli_string = QubitPauliString(
+            pytket_circuit.qubits,
+            [Pauli.Z] * len(pytket_circuit.qubits),
+        )
+        observable = QubitPauliOperator({pauli_string: 1.0})
+        experiment = ObservableExperiment(
+            AnsatzCircuit(pytket_circuit, shots, {}),
+            ObservableTracker(observable),
+        )
+        mitex = gen_ZNE_MitEx(
+            backend,
+            scale_factors,
+            fit_type=Fit.linear,
+            folding_type=Folding.circuit,
+            seed=seed,
+        )
+        started_at = time.perf_counter()
+        qermit_result = mitex.run([experiment])[0]
+        runtime = time.perf_counter() - started_at
+        mitigated = float(np.real_if_close(qermit_result.get(pauli_string, 0)))
+    except Exception as error:
+        return BenchmarkResult(
+            method="qermit.zne",
+            ideal=ideal,
+            noisy=noisy,
+            mitigated=None,
+            improvement=None,
+            runtime=0.0,
+            executions=0,
+            notes=f"qermit run failed: {type(error).__name__}",
+        )
+
+    return BenchmarkResult(
+        method="qermit.zne",
+        ideal=ideal,
+        noisy=noisy,
+        mitigated=mitigated,
+        improvement=improvement_factor(ideal, noisy, mitigated),
+        runtime=runtime,
+        executions=len(scale_factors),
+        notes="circuit folding + linear fit",
     )
 
 
@@ -164,7 +259,14 @@ def main() -> None:
         )
     ]
     results.append(
-        run_qiskit_aer_zne(circuit, ideal, noisy, args.noise_level, args.seed)
+        run_qiskit_aer_manual_zne(
+            circuit, ideal, noisy, args.noise_level, args.seed
+        )
+    )
+    results.append(
+        run_qermit_zne(
+            circuit, ideal, noisy, args.noise_level, args.shots, args.seed
+        )
     )
 
     print_results(results)

--- a/scripts/benchmark_zne.py
+++ b/scripts/benchmark_zne.py
@@ -1,0 +1,174 @@
+# Copyright (C) Unitary Foundation
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Benchmark zero-noise extrapolation on Mitiq benchmark circuits.
+
+Example:
+    python scripts/benchmark_zne.py --circuit ghz --n-qubits 4
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import cirq
+import numpy as np
+from benchmark_error_mitigation_common import (
+    BenchmarkResult,
+    CountingFloatExecutor,
+    add_benchmark_arguments,
+    build_benchmark_circuit,
+    ideal_expectation,
+    improvement_factor,
+    noisy_density_executor,
+    print_results,
+    timed_result,
+    zz_expectation_from_density_matrix,
+)
+
+from mitiq.zne import execute_with_zne
+from mitiq.zne.inference import LinearFactory
+from mitiq.zne.scaling import fold_global
+
+
+def qiskit_aer_density_executor(
+    noise_level: float,
+    seed: int,
+) -> CountingFloatExecutor | None:
+    """Builds a Qiskit Aer density-matrix executor when dependencies exist."""
+
+    try:
+        from qiskit_aer import AerSimulator
+        from qiskit_aer.noise import NoiseModel, depolarizing_error
+
+        from mitiq.interface import convert_from_mitiq
+    except ImportError:
+        return None
+
+    def execute(circuit: cirq.Circuit) -> float:
+        qiskit_circuit = convert_from_mitiq(circuit, "qiskit")
+
+        one_qubit_gate_names = set()
+        two_qubit_gate_names = set()
+        for instruction in qiskit_circuit.data:
+            num_qubits = instruction.operation.num_qubits
+            if num_qubits == 1:
+                one_qubit_gate_names.add(instruction.operation.name)
+            elif num_qubits == 2:
+                two_qubit_gate_names.add(instruction.operation.name)
+
+        qiskit_circuit.save_density_matrix()
+        noise_model = NoiseModel()
+        if one_qubit_gate_names:
+            noise_model.add_all_qubit_quantum_error(
+                depolarizing_error(noise_level, 1),
+                sorted(one_qubit_gate_names),
+            )
+        if two_qubit_gate_names:
+            noise_model.add_all_qubit_quantum_error(
+                depolarizing_error(noise_level, 2),
+                sorted(two_qubit_gate_names),
+            )
+
+        simulator = AerSimulator(
+            method="density_matrix",
+            noise_model=noise_model,
+            seed_simulator=seed,
+        )
+        result = simulator.run(qiskit_circuit).result()
+        density_matrix = np.asarray(result.data(0)["density_matrix"])
+        return zz_expectation_from_density_matrix(
+            density_matrix, qiskit_circuit.num_qubits
+        )
+
+    return CountingFloatExecutor(execute)
+
+
+def run_qiskit_aer_zne(
+    circuit: cirq.Circuit,
+    ideal: float,
+    noisy: float,
+    noise_level: float,
+    seed: int,
+) -> BenchmarkResult:
+    """Runs a Qiskit Aer ZNE comparison over folded Mitiq circuits."""
+
+    executor = qiskit_aer_density_executor(noise_level, seed)
+    if executor is None:
+        return BenchmarkResult(
+            method="qiskit-aer.zne",
+            ideal=ideal,
+            noisy=noisy,
+            mitigated=None,
+            improvement=None,
+            runtime=0.0,
+            executions=0,
+            notes="install qiskit extra to enable",
+        )
+    scale_factors = [1.0, 3.0, 5.0]
+    started_at = time.perf_counter()
+    values = [
+        executor(fold_global(circuit, scale_factor))
+        for scale_factor in scale_factors
+    ]
+    qiskit_noisy = values[0]
+    coefficients = np.polyfit(scale_factors, values, deg=1)
+    mitigated = float(np.polyval(coefficients, 0.0))
+    runtime = time.perf_counter() - started_at
+    return BenchmarkResult(
+        method="qiskit-aer.zne",
+        ideal=ideal,
+        noisy=qiskit_noisy,
+        mitigated=mitigated,
+        improvement=improvement_factor(ideal, qiskit_noisy, mitigated),
+        runtime=runtime,
+        executions=executor.calls,
+        notes="fold_global + linear fit",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    add_benchmark_arguments(parser)
+    args = parser.parse_args()
+
+    circuit = build_benchmark_circuit(
+        args.circuit, args.n_qubits, args.depth, args.seed
+    )
+    ideal = ideal_expectation(circuit)
+
+    base_executor = CountingFloatExecutor(
+        noisy_density_executor(args.noise_level)
+    )
+    noisy = base_executor(circuit)
+
+    mitiq_executor = CountingFloatExecutor(
+        noisy_density_executor(args.noise_level)
+    )
+    results = [
+        timed_result(
+            "mitiq.zne",
+            ideal,
+            noisy,
+            mitiq_executor,
+            lambda: execute_with_zne(
+                circuit,
+                mitiq_executor,
+                factory=LinearFactory([1.0, 3.0, 5.0]),
+                scale_noise=fold_global,
+            ),
+            notes="fold_global + LinearFactory",
+        )
+    ]
+    results.append(
+        run_qiskit_aer_zne(circuit, ideal, noisy, args.noise_level, args.seed)
+    )
+
+    print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -983,6 +983,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -991,6 +992,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -1635,6 +1637,14 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+benchmarks = [
+    { name = "mthree" },
+    { name = "ply" },
+    { name = "pytket-quantinuum" },
+    { name = "qermit" },
+    { name = "qiskit" },
+    { name = "qiskit-aer" },
+]
 braket = [
     { name = "amazon-braket-sdk" },
     { name = "cirq-ionq" },
@@ -1701,21 +1711,27 @@ requires-dist = [
     { name = "cirq-ionq", marker = "extra == 'braket'", specifier = ">=1.6.0,<1.7.0" },
     { name = "llvmlite", marker = "extra == 'braket'", specifier = "==0.46.0" },
     { name = "matplotlib", specifier = ">=3.8" },
+    { name = "mthree", marker = "extra == 'benchmarks'", specifier = ">=3.0.0" },
     { name = "numba", marker = "extra == 'braket'", specifier = "==0.64.0" },
     { name = "numpy", specifier = ">=2.0.0,<2.3.0" },
     { name = "pennylane", marker = "extra == 'pennylane'", specifier = ">=0.44.1,<0.46.0" },
     { name = "pennylane-qiskit", marker = "extra == 'pennylane'", specifier = "~=0.43.0" },
+    { name = "ply", marker = "extra == 'benchmarks'", specifier = "==3.11" },
     { name = "ply", marker = "extra == 'qiskit'", specifier = "==3.11" },
     { name = "pyquil", marker = "extra == 'pyquil'", specifier = "~=4.17.0" },
+    { name = "pytket-quantinuum", marker = "extra == 'benchmarks'", specifier = ">=0.59.1" },
     { name = "qbraid", marker = "extra == 'pyquil'", specifier = ">=0.10,<0.13" },
+    { name = "qermit", marker = "extra == 'benchmarks'", specifier = ">=0.7.1" },
     { name = "qibo", marker = "extra == 'qibo'", specifier = ">=0.2.16,<0.4.0" },
+    { name = "qiskit", marker = "extra == 'benchmarks'", specifier = ">=2.0.0,<3.0.0" },
     { name = "qiskit", marker = "extra == 'qiskit'", specifier = ">=2.0.0,<3.0.0" },
+    { name = "qiskit-aer", marker = "extra == 'benchmarks'", specifier = "~=0.17.0" },
     { name = "qiskit-aer", marker = "extra == 'qiskit'", specifier = "~=0.17.0" },
     { name = "qiskit-ibm-runtime", marker = "extra == 'qiskit'", specifier = "~=0.41.1" },
     { name = "scipy", specifier = ">=1.10.1,<=1.17.1" },
     { name = "tabulate" },
 ]
-provides-extras = ["braket", "pennylane", "pyquil", "qibo", "qiskit"]
+provides-extras = ["braket", "pennylane", "pyquil", "qibo", "qiskit", "benchmarks"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1785,6 +1801,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
     { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
     { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
+]
+
+[[package]]
+name = "mthree"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cython" },
+    { name = "numpy" },
+    { name = "orjson" },
+    { name = "psutil" },
+    { name = "qiskit" },
+    { name = "runningman" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/ee/bef8b180cc3d00c8b9753095fda46bf9f25e54cd3fbf094e1e7fc96ced87/mthree-3.0.0.tar.gz", hash = "sha256:20f2362aec16f06786e659c85136130197965c109179b47ce3416347a65811c5", size = 1219979, upload-time = "2025-03-27T21:23:23.771Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/f7/27dd504dad516df899737f1c41d02dd161732ead09ce2b0147a57196171f/mthree-3.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:4bc5e46d41359a0f46007a3c0f3e2f5a9ba0ff9e0134730a441a83434d2c2d88", size = 1886592, upload-time = "2025-03-27T21:23:04.588Z" },
+    { url = "https://files.pythonhosted.org/packages/97/40/58e8c91a177740b22b0528a7dbd0e7d5f7165e00428f429ce0531b618606/mthree-3.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:0c22adbbde12129908f2c1b791636c253e5ce2c286cbd37ff6f4e1b6741d86a8", size = 1922670, upload-time = "2025-03-27T21:23:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/49/dacb56726e209146b80c4eee35a94eb1cc9d19c03e0d5c6b2abf7a3297da/mthree-3.0.0-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:e20540a9b5a35e9cc7e06444a97fa337d92f95bc6b164405c6d8564a2a79c3f8", size = 5731290, upload-time = "2025-03-27T21:54:27.713Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/6b/cab924fd235960542e045d79a8f5adc36ce1525d4e3a63775ebcef938e0c/mthree-3.0.0-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:dbe8a47e11f8454a05f454a88c5bbcc88ae9def035771f10a85bc17fd6e97487", size = 5887689, upload-time = "2025-03-27T21:23:07.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/9d/d39e50ec73a77dd99755e86b1147cbc4a41bef3bbdfccffdb918310b6d82/mthree-3.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:5aaee72d32a9f00b0f944ea4514891a0e63e3720ba3a220b60c82308a9c1e831", size = 1851076, upload-time = "2025-03-27T21:23:09.613Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3e/6d7ac665dbf2a9f7371a890a31b3c538fbafa54eb287aa28df926ff5d20d/mthree-3.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fb055bc19411ca942e621a09c12c8880cfc94f1f67eb3f619ff429b279328a55", size = 1894002, upload-time = "2025-03-27T21:23:11.314Z" },
+    { url = "https://files.pythonhosted.org/packages/68/35/ab2bc99fb295a35e4bfbbcdec84d6034f5eb4694c5ee90633be942501411/mthree-3.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7a72f63e8d90bfd24c3b192c8eac37237e7e708c48bca204f973b620df3f5461", size = 1933486, upload-time = "2025-03-27T21:23:13.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d1/813f1fdb13d85cc6d62227e6ff773a31bac6b9e0c3dd9bc2929c4de22cba/mthree-3.0.0-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:ebde074471bcc41b10a03fe3bd8084c91abadca640e1bb9fbd8611c610911517", size = 5677049, upload-time = "2025-03-27T21:54:29.696Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c3/69a9bf4d3a2d6a697699262db22fcedaa59c4d07b0954dea1cc0980df2f0/mthree-3.0.0-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:4a9e9511f4bccbad4764d0623dd16fbb2fe0796c58efcba2a2b839255528d332", size = 5857330, upload-time = "2025-03-27T21:23:14.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/1d/8a583a5f7cd248871346b40f0f53768a712dcd3f4111da1e6b18d7012950/mthree-3.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:386f66911b584204e75ed4f7e51b78de8ffc3c704c0d8e1b2aa1fbdbedf51861", size = 1854870, upload-time = "2025-03-27T21:23:16.069Z" },
 ]
 
 [[package]]
@@ -2091,6 +2134,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/4d/032f9bf1c5636fb499ba4dc9866f1956f15ecd6e9532ce084d02c124045c/oqpy-0.3.10.tar.gz", hash = "sha256:be2155f6035ee8df89e4053bef9035f91fe264ad897415ec7098e33a0cb827cb", size = 31773, upload-time = "2026-02-25T15:04:39.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/47/157996e81032852e68af47dde52a9df7568306df2420c4fa8ec0fbac41a5/oqpy-0.3.10-py3-none-any.whl", hash = "sha256:d158af2f546a86759845863c107d700b61d320fd7aaec99b67d70dff3ff84206", size = 35870, upload-time = "2026-02-25T15:04:38.143Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/51/3fb9e65ae76ee97bd611869a503fa3fc0a6e81dd8b737cf3003f682df7ff/orjson-3.11.9-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:f01c4818b3fc9b0da8e096722a84318071eaa118df35f6ed2344da0e73a5444f", size = 228522, upload-time = "2026-05-06T15:09:35.362Z" },
+    { url = "https://files.pythonhosted.org/packages/16/fa/9d54b07cb3f3b0bfd57841478e42d7a0ece4a9f49f9907eecf5a45461687/orjson-3.11.9-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:3ebca4179031ee716ed076ffadc29428e900512f6fccee8614c9983157fcf19c", size = 128463, upload-time = "2026-05-06T15:09:37.063Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b1/6ceafc2eefd0a553e3be77ce6c49d107e772485d9568629376171c50e634/orjson-3.11.9-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48ee05097750de0ff69ed5b7bbcf0732182fd57a24043dcc2a1da780a5ead3a5", size = 132306, upload-time = "2026-05-06T15:09:38.299Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/76/f11311285324a40aab1e3031385c50b635a7cd0734fdaf60c7e89a696f60/orjson-3.11.9-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6082706765a95a6680d812e1daf1c0cfe8adec7831b3ff3b625693f3b461b1c", size = 127988, upload-time = "2026-05-06T15:09:39.597Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/85/0ef63bcf1337f44031ce9b91b1919563f62a37527b3ea4368bb15a22e5d7/orjson-3.11.9-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:277fefe9d76ee17eb14debf399e3533d4d63b5f677a4d3719eb763536af1f4bd", size = 135188, upload-time = "2026-05-06T15:09:40.957Z" },
+    { url = "https://files.pythonhosted.org/packages/05/94/b0d27090ea8a2095db3c2bd1b1c96f96f19bbb494d7fef33130e846e613d/orjson-3.11.9-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:03db380e3780fa0015ed776a90f20e8e20bb11dde13b216ce19e5718e3dfba62", size = 145937, upload-time = "2026-05-06T15:09:42.249Z" },
+    { url = "https://files.pythonhosted.org/packages/09/eb/75d50c29c05b8054013e221e598820a365c8e64065312e75e202ed880709/orjson-3.11.9-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33d7d766701847dc6729846362dc27895d2f2d2251264f9d10e7cb9878194877", size = 132758, upload-time = "2026-05-06T15:09:43.945Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/360686f39348aa88827cb6fbf7dc606fd41c831a35235e1abf1db8e3a9e6/orjson-3.11.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:147302878da387104b66bb4a8b0227d1d487e976ce41a8501916161072ed87b1", size = 133971, upload-time = "2026-05-06T15:09:45.239Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/30/3178eb16f3221aeef068b6f1f1ebe05f656ea5c6dffe9f6c917329fe17a3/orjson-3.11.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3513550321f8c8c811a7c3297b8a630e82dc08e4c10216d07703c997776236cd", size = 141685, upload-time = "2026-05-06T15:09:46.858Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f1/ff2f19ed0225f9680fafa42febca3570dd59444ebf190980738d376214c2/orjson-3.11.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:c5d001196b89fa9cf0a4ab79766cd835b991a166e4b621ba95089edc50c429ff", size = 415167, upload-time = "2026-05-06T15:09:48.312Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/61/863bddf0da6e9e586765414debd54b4e58db05f560902b6d00658cb88636/orjson-3.11.9-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:16969c9d369c98eb084889c6e4d2d39b77c7eb38ceccf8da2a9fff62ae908980", size = 147913, upload-time = "2026-05-06T15:09:49.733Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8a/4081492586d75b073d60c5271a8d0f05a0955cabf1e34c8473f6fcd84235/orjson-3.11.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:63e0efbc991250c0b3143488fa57d95affcabbfc63c99c48d625dd37779aafe2", size = 136959, upload-time = "2026-05-06T15:09:51.311Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bd/70b6ab193594d7abb875320c0a7c8335e846f28968c432c31042409c3c8d/orjson-3.11.9-cp311-cp311-win32.whl", hash = "sha256:14ed654580c1ed2bc217352ec82f91b047aef82951aa71c7f64e0dcb03c0e180", size = 131533, upload-time = "2026-05-06T15:09:52.637Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/17/1a1a228183d62d1b77e2c30d210f47dd4768b310ebe1607c63e3c0e3a71e/orjson-3.11.9-cp311-cp311-win_amd64.whl", hash = "sha256:57ea77fb70a448ce87d18fca050193202a3da5e54598f6501ca5476fb66cfe02", size = 127106, upload-time = "2026-05-06T15:09:54.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/95/285de5fa296d09681ee9c546cd4a8aeb773b701cf343dc125994f4d52953/orjson-3.11.9-cp311-cp311-win_arm64.whl", hash = "sha256:19b72ed11572a2ee51a67a903afbe5af504f84ed6f529c0fe44b0ab3fb5cc697", size = 126848, upload-time = "2026-05-06T15:09:55.551Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6d/11867a3ffa3a3608d84a4de51ef4dd0896d6b5cc9132fbe1daf593e677bc/orjson-3.11.9-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9ef6fe90aadef185c7b128859f40beb24720b4ecea95379fc9000931179c3a49", size = 228515, upload-time = "2026-05-06T15:09:57.265Z" },
+    { url = "https://files.pythonhosted.org/packages/24/75/05912954c8b288f34fcf5cd4b9b071cb4f6e77b9961e175e56ebb258089f/orjson-3.11.9-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5c9b8f28e726e97d97696c826bc7bea5d71cecd63576dba92924a32c1961291", size = 128409, upload-time = "2026-05-06T15:09:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/1c3a47df3bc8191ea9ac51603bbb872a95167a364320c269f2557911f406/orjson-3.11.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a473dbb4162108b27901492546f83c76fdcea3d0eadff00ae7a07e18dcce09", size = 132106, upload-time = "2026-05-06T15:10:00.798Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/cf/b33b5f3e695ae7d63feef9d915c37cc3b8f465493dcd4f8e0b4c697a2366/orjson-3.11.9-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:011382e2a60fda9d46f1cdee31068cfc52ffe952b587d683ec0463002802a0f4", size = 127864, upload-time = "2026-05-06T15:10:02.15Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6a/6cf69385a58208024fcb8c014e2141b8ce838aba6492b589f8acfff97fab/orjson-3.11.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2d3dc759490128c5c1711a53eeaa8ee1d437fd0038ffd2b6008abf46db3f882", size = 135213, upload-time = "2026-05-06T15:10:03.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f8/0b1bd3e8f2efcdd376af5c8cfd79eaf13f018080c0089c80ebd724e3c7fb/orjson-3.11.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8ea516b3726d190e1b4297e6f4e7a8650347ae053868a18163b4dd3641d1fff", size = 145994, upload-time = "2026-05-06T15:10:05.083Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/59/dab79f61044c529d2c81aecdc589b1f833a1c8dec11ba3b1c2498a02ca7e/orjson-3.11.9-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:380cdce7ba24989af81d0a7013d0aaec5d0e2a21734c0e2681b1bc4f141957fe", size = 132744, upload-time = "2026-05-06T15:10:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4fa4f0af7fa18951f7ab3fc2148e223af211bf03f59e1c6034ec3f97f21d61", size = 134014, upload-time = "2026-05-06T15:10:08.213Z" },
+    { url = "https://files.pythonhosted.org/packages/50/c7/375e83a76851b73b2e39f3bcf0e5a19e2b89bad13e5bca97d0b293d27f24/orjson-3.11.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a8f5f8bc7ce7d59f08d9f99fa510c06496164a24cb5f3d34537dbd9ca30132e2", size = 141509, upload-time = "2026-05-06T15:10:09.595Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7c/49d5d82a3d3097f641f094f552131f1e2723b0b8cb0fa2874ab65ecfffa6/orjson-3.11.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4d7fde5501b944f83b3e665e1b31343ff6e154b15560a16b7130ea1e594a4206", size = 415127, upload-time = "2026-05-06T15:10:11.049Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/dc/7446c538590d55f455647e5f3c61fc33f7108714e7afcffa6a2a033f8350/orjson-3.11.9-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cde1a448023ba7d5bb4c01c5afb48894380b5e4956e0627266526587ef4e535f", size = 148025, upload-time = "2026-05-06T15:10:12.842Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e5/4d2d8af06f788329b4f78f8cc3679bb395392fcaa1e4d8d3c33e85308fa4/orjson-3.11.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e63adb0e1f1ed5d9e168f50a91ceb93ae6420731d222dc7da5c69409aa47aa", size = 136943, upload-time = "2026-05-06T15:10:14.405Z" },
+    { url = "https://files.pythonhosted.org/packages/06/69/850264ccf6d80f6b174620d30a87f65c9b1490aba33fe6b62798e618cad3/orjson-3.11.9-cp312-cp312-win32.whl", hash = "sha256:2d057a602cdd19a0ad680417527c45b6961a095081c0f46fe0e03e304aac6470", size = 131606, upload-time = "2026-05-06T15:10:15.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/973a43fc9c55e20f2051e9830997649f669be0cb3ca52192087c0143f118/orjson-3.11.9-cp312-cp312-win_amd64.whl", hash = "sha256:59e403b1cc5a676da8eaf31f6254801b7341b3e29efa85f92b48d272637e77be", size = 127101, upload-time = "2026-05-06T15:10:17.129Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/495470f0e4a18f73fa10b7f6b84b464ec4cc5291c4e0c7c2a6c400bef006/orjson-3.11.9-cp312-cp312-win_arm64.whl", hash = "sha256:9af678d6488357948f1f84c6cd1c1d397c014e1ae2f98ae082a44eb48f602624", size = 126736, upload-time = "2026-05-06T15:10:18.645Z" },
 ]
 
 [[package]]
@@ -2559,6 +2640,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyqir"
+version = "0.12.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/10/3b041f225dac208451f568188fd06524360ffc66ff855a1a205af0a895a0/pyqir-0.12.5-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9bc8232f028f40e026cb72c7f654cf63f4c464ff4695874b70a45e8c34969665", size = 2160708, upload-time = "2026-05-12T18:06:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/88/94/a120794a8048291203b28c96e1c212243c45d8d99e2dad9002d67c0559ce/pyqir-0.12.5-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7f568054dbb42b7fd33e0d5b58e7ac60ad6af496e9e1376fcb4a45290e9f510d", size = 2102202, upload-time = "2026-05-12T18:06:56.336Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b7/da263a4c694b062d94b899a7248dec2238f965dc4ee58c69c6ba1263297e/pyqir-0.12.5-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4304984337a26cb01f8f0b0b0b436737e90379fbd0adfb48f142cfd942234384", size = 2640753, upload-time = "2026-05-12T18:06:57.988Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9f/e78010a4158e65be86b0013bccd5b0709ae87d8af9da82685464fb8e784c/pyqir-0.12.5-cp39-abi3-manylinux_2_38_aarch64.whl", hash = "sha256:ced0baf85371393bae59c3c93a97d3de68217f43fde21b7be8c6ed31b1e00128", size = 2709456, upload-time = "2026-05-12T18:06:59.761Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b2/970e1621e372dffbb540cbb06518d0af4a16e63c074db61d60fb3d464ae2/pyqir-0.12.5-cp39-abi3-win_amd64.whl", hash = "sha256:c70381e8e1e2db8e2a9d5aec484f51328b66f7ac9cc72989ba05a61d7689f950", size = 1967113, upload-time = "2026-05-12T18:07:01.197Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6e/575bbfe2382e15c2c1e1a3062ba5f1f0b61d73da05b2ff1b130dbda1214b/pyqir-0.12.5-cp39-abi3-win_arm64.whl", hash = "sha256:1be238924839fa5edbae20fb5a039f0caabe349e96c20029e7decf180a7aa1ae", size = 1868996, upload-time = "2026-05-12T18:07:02.58Z" },
+]
+
+[[package]]
 name = "pyqrack"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2713,7 +2807,7 @@ wheels = [
 
 [[package]]
 name = "pytket"
-version = "2.15.0"
+version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "graphviz" },
@@ -2727,16 +2821,16 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/4b/044fd8912071040a9f98f2fd85a506093c8387e964238b381114b679f81d/pytket-2.15.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:c48e39632cb923df213e0c7b5d5890bb5b0595a753ba694c94a76c6b3975a88b", size = 5547759, upload-time = "2026-03-06T16:14:16.474Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/0e/7cf5cc85d8bca150f25c4ca682abc6325cadd98154e798b5157fb98cb9a9/pytket-2.15.0-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:28aa4e25248123e5d67b1415e3d9d8ec384283ea88d577839f6d7659f5232579", size = 6237033, upload-time = "2026-03-06T16:14:18.324Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/04/fd10c47e1b3c20382fbe7fc33f8d3cd20463bbb55e5785ee5ef510663928/pytket-2.15.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30c48893dee117d47771962833347225571fd87f3ef1807b5b3d18fcf06ef271", size = 7579634, upload-time = "2026-03-06T16:14:20.064Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/35/b0a5f93b6715d6acac4860f00298eb38aba3bcb8c018a776d33603d58122/pytket-2.15.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13ff34fdb516ebd3a203ff782b02680d9f3d5d5e04ee0c986aac3faab0f3bc98", size = 8316190, upload-time = "2026-03-06T16:14:22.164Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/c4/cc295210bd8d9270d70d038fe4a8752fc0c9c38c49e20ca443843b4e5e24/pytket-2.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:31893e38e1294fec67d81e9c4a85a137a5912136eaca0f6d61dd1ef358244214", size = 9788736, upload-time = "2026-03-06T16:14:24.421Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/bf/2e693cd9a80dd57f94cc10d5003622ce33dc824c88713c37760a9329a495/pytket-2.15.0-cp312-abi3-macosx_14_0_arm64.whl", hash = "sha256:035815cdf331e97c6c2cd56f60882b30f768721975d7c2f082f5d044237b503e", size = 5528681, upload-time = "2026-03-06T16:14:26.697Z" },
-    { url = "https://files.pythonhosted.org/packages/62/35/11e65debec9d99286cc8ac84aa3f0404710a84852f318468bfc59e0ca205/pytket-2.15.0-cp312-abi3-macosx_15_0_x86_64.whl", hash = "sha256:06672344186a51b97ff7b779e71585092e425475abbabf535a65c23786afb042", size = 6218603, upload-time = "2026-03-06T16:14:28.736Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/e6/ef8ff958f7d03f48f6e22d23bb6a2ea15ad7c89c9d3de42bcc88b568b23a/pytket-2.15.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb12d0598ba47ef18c25544fcb83a063e7e67c9cce36de127ead507014c657c3", size = 7529689, upload-time = "2026-03-06T16:14:30.599Z" },
-    { url = "https://files.pythonhosted.org/packages/56/20/8e1599d5a7c9ce28cf78371f6b9d364f4d1739b682279aba352b9b8f5c6b/pytket-2.15.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7947db076949df22f3941cc90290afc470a73ade5d4dc1e6509d5fc58965ad5", size = 8258227, upload-time = "2026-03-06T16:14:32.417Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/dd/68fdb8117de1d8684b3416a42611fb64e59f0d674500062e3fdc50dd78b7/pytket-2.15.0-cp312-abi3-win_amd64.whl", hash = "sha256:1afae2c1b08692c9ac04a4cc9421e3aa039cb7e468d4bd2011a802f67c88dfb1", size = 9761390, upload-time = "2026-03-06T16:14:34.463Z" },
+    { url = "https://files.pythonhosted.org/packages/47/cc/cfcc64549767dee84172ebb5904e1b69d6246099d6ae170b2c91e0e0002c/pytket-2.18.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:f700a97c4caf2ac98c47a2c8e37b71b28b9b35ca9218bbb0357bba499b23eeaa", size = 5550955, upload-time = "2026-05-15T08:57:47.038Z" },
+    { url = "https://files.pythonhosted.org/packages/27/78/69295578749e0724647d3ba927f4d5466c48dc89218019e3298acb36842d/pytket-2.18.0-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:9349e1f6faddbe315fe32dd42da8609899b923b607034ff97ae40cb7f5a3d40c", size = 6240572, upload-time = "2026-05-15T08:57:49.046Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e1/6d75b33869b710699e939ab0b5193477d5e0f2d825613b07febf3c16c020/pytket-2.18.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7b3af39d4f3ae3297de8d75773b940800820192e12392071dab7eb3b4c761857", size = 7584459, upload-time = "2026-05-15T08:57:50.761Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/9047f68f21a12f14ca0c1a4fde2e618935afc79f061e2288ded62c468dbb/pytket-2.18.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4817d27ff0ebb5481b64b86eb3ec759b619354c0dff5e4f1a4cfc6e4b888cf78", size = 8320126, upload-time = "2026-05-15T08:57:53.146Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7b/7dbbd09d136084cb07f4aff4fc8cae03791e16c026713e6a72b9b170c601/pytket-2.18.0-cp311-cp311-win_amd64.whl", hash = "sha256:60d95245695257642853ff9b0dec31fd520c9c07cdba4d4fb429a861914b97fe", size = 9791813, upload-time = "2026-05-15T08:57:55.069Z" },
+    { url = "https://files.pythonhosted.org/packages/15/39/28cd32ee7606b1b252b29464ba9afaa2c59cfa4a21fea715c9ed150dfe4e/pytket-2.18.0-cp312-abi3-macosx_14_0_arm64.whl", hash = "sha256:9673824105eb781ae05c4c80d3cd6786f4ab58c5a5def5b9ca7ae890dce9fd2d", size = 5531855, upload-time = "2026-05-15T08:57:57.559Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/33/03df743d1349f649a96e26eab7726288b03e9a84d2ecaf6eb9f6e25760e5/pytket-2.18.0-cp312-abi3-macosx_15_0_x86_64.whl", hash = "sha256:c819bae62bd96020053ad872a7e85150509781c2a83d7a66a69b9c6b5f6329cb", size = 6223192, upload-time = "2026-05-15T08:57:59.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e5/9886826e5ccb5639e493567073e04dc2911972dd8ea095367305f546df13/pytket-2.18.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c805946d49d93d13bb3b4fe21f69e89be38f9b1d5739aea8f64cd1e70c85da4d", size = 7534626, upload-time = "2026-05-15T08:58:01.743Z" },
+    { url = "https://files.pythonhosted.org/packages/01/00/b50f3b11b92d5c74713d37ddb57e310a0fcc63eb13549007167985801286/pytket-2.18.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ca100f33ca3b56f8fe9f1d72c904067789cfc58bc084439f9aa409ec6621fc3", size = 8262137, upload-time = "2026-05-15T08:58:03.839Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ce/87fe3c1d0cb981f076d0cccde68043734ec57587a3f8049a675aae0e29e8/pytket-2.18.0-cp312-abi3-win_amd64.whl", hash = "sha256:9557d36cfe4b4376c36c071b0ac792038314ebec396df8252143ac4a1972a7b3", size = 9764538, upload-time = "2026-05-15T08:58:05.654Z" },
 ]
 
 [[package]]
@@ -2750,6 +2844,47 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/13/fbf0640efd753e9627ec0e4c915cdd92203e3e1a18f543b00c9cb20f9ad7/pytket_cirq-0.43.0-py3-none-any.whl", hash = "sha256:b40f259bd7761908040e53dadad655543bb99dac41836ffeb96f32ac6a6f6b9a", size = 26659, upload-time = "2026-01-07T17:54:42.726Z" },
+]
+
+[[package]]
+name = "pytket-qir"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyqir" },
+    { name = "pytket" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/c7/8b97910c6f07d70829a15a536fb64347c34286769c9e699306daf7f99dce/pytket_qir-2.0.0-py3-none-any.whl", hash = "sha256:89192884bd4c297add3270e055fc883d4d5fd9e696cf941f0d7aa51435780dcb", size = 50189, upload-time = "2026-05-27T14:15:07.79Z" },
+]
+
+[[package]]
+name = "pytket-qiskit"
+version = "0.71.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pytket" },
+    { name = "qiskit" },
+    { name = "qiskit-aer" },
+    { name = "qiskit-ibm-runtime" },
+    { name = "symengine" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/31/7150385fe20c9d946d73a2251f50630ddf7e612e99f8427d06cb91932e20/pytket_qiskit-0.71.0-py3-none-any.whl", hash = "sha256:4e64f44fdc1cbd4c1f94d4f9de59c7b393ff1cda639c06de5cad01c770fc3000", size = 57187, upload-time = "2025-07-21T09:27:09.443Z" },
+]
+
+[[package]]
+name = "pytket-quantinuum"
+version = "0.59.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pytket" },
+    { name = "pytket-qir" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/07/00101d194faef1a4c790cb44aa05afeb6eff313dd490694f6ce632203ef4/pytket_quantinuum-0.59.1-py3-none-any.whl", hash = "sha256:df420233aeca1ad5c6513bdfb89ba691830dde9ad0651dca55d550ba28cbb311", size = 46526, upload-time = "2026-05-13T09:42:38.732Z" },
 ]
 
 [[package]]
@@ -2899,6 +3034,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/d7/051d37d2de0b618f87b27e16986ca3fe5208df08f3e5c48a1910dd109f42/qcs_sdk_python-0.21.22-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e0e55b477d5d053334aede3dd7f1613fb9c547d09d560ae7f43a67cdfe0d09a8", size = 6237527, upload-time = "2025-12-03T18:29:21.447Z" },
     { url = "https://files.pythonhosted.org/packages/e0/5d/a98b6cbf036f244c37af7f9ef8d7aff75c8343e503eecd9995742bad30ea/qcs_sdk_python-0.21.22-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d8c75597e8b3e87477f48a1554b3a34b8c289133853a2bec5db0c9561e96332c", size = 6645690, upload-time = "2025-12-03T18:29:23.197Z" },
     { url = "https://files.pythonhosted.org/packages/48/88/10139528f9d29886036051dbea4566d418dc1e5a8b11bc5b231b185a603c/qcs_sdk_python-0.21.22-cp312-cp312-win_amd64.whl", hash = "sha256:becdb70a11345a0e13b072b57f5de1630be4495c5972d11d5d5d037500180fdd", size = 6971402, upload-time = "2025-12-03T18:29:25.381Z" },
+]
+
+[[package]]
+name = "qermit"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "pytket-qiskit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/1e/df2e3f0a80cada699357c4b1c424fee0a0364aae48724ff51fb2bfe52f21/qermit-0.7.1.tar.gz", hash = "sha256:ddbb5dc9d4c009ba40ebbe9e44bef672f537463a72fe4634e085fa50a17a22ad", size = 94786, upload-time = "2025-03-26T16:20:12.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/c8/22685ad0b0676e4de1975ccbc2ff651e17b1d8fe59b60fe7fe084f13393b/qermit-0.7.1-py3-none-any.whl", hash = "sha256:0ffeeab2f7acd2e09284c5cfa857f03298efcac32dedbd9a3f1329a55e1955a3", size = 125216, upload-time = "2025-03-26T16:20:11.389Z" },
 ]
 
 [[package]]
@@ -3198,6 +3346,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
     { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
 ]
+
+[[package]]
+name = "runningman"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "qiskit-ibm-runtime" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/da/1844e876e56efcd015fe0d76a929a457722531ed77b4c133352bb748bd93/runningman-2.3.0.tar.gz", hash = "sha256:99f98ca2c854363083c5a39d2382667f6eed36a8e1db312d4ff0918f417290d7", size = 15247, upload-time = "2025-03-18T13:35:37.127Z" }
 
 [[package]]
 name = "rustworkx"
@@ -3589,6 +3746,32 @@ dependencies = [
     { name = "stim" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/86/872e2da05aab7026207acd5caf19b10419d76e0e9b738018b3c6c7c1fb96/stimcirq-1.16.0.tar.gz", hash = "sha256:50ef71b7ca653b7831b7c7d5af3b8812b47a06c4347d8e26a27809765e55f79b", size = 36408, upload-time = "2026-05-22T05:41:37.793Z" }
+
+[[package]]
+name = "symengine"
+version = "0.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/ae/051d3e2ffd128f4a8fa67d380bb7be45637d39e206b4c3737c087a3d4b71/symengine-0.14.1.tar.gz", hash = "sha256:4e9e4b4ec56371c2151803ae0403dab07dd1c74ce88e9abca433bebeb6e2f0f0", size = 938282, upload-time = "2025-04-21T04:03:04.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/eb/875243e2856ef203f102cfefe54b81f4a08daed2c7b2ad929e8b82282d93/symengine-0.14.1-cp311-abi3-macosx_10_13_x86_64.whl", hash = "sha256:182d7ca746622764e50af4f926eb9733bd4d1fddb9526faa67bc6ca88b333e23", size = 26038565, upload-time = "2025-09-14T15:23:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/13/85/58acf0f28ae556205044bce9228a4e0e3bb532e0d4a81f3af84e0c45d95b/symengine-0.14.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:6fbe25be42ba2040f09d464c06a7812f8e8d04c8087abbad914be561deac2141", size = 23108837, upload-time = "2025-09-14T15:23:17.395Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/00/0355f1a261d608b1eaa972071e73070bc415cd1932e90574354e98f46254/symengine-0.14.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:78ac61effb97f63eca70bb4ececb2cb329b09f1d587cfab51768bd3c04543010", size = 61943252, upload-time = "2025-09-14T15:23:21.076Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b4/41374adf5f7e60576862e4b4df1519225001fe2f230a3d15c67aa273ea48/symengine-0.14.1-cp311-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5ee52a0aaacafc032dbe5ca57c0b3d87a228e9ef6e88676a4ecc0111fb647b9e", size = 94027577, upload-time = "2025-09-14T15:23:26.165Z" },
+    { url = "https://files.pythonhosted.org/packages/52/af/0de548738de262f2288cdefc02df35aaa8c398369643619f59a9c2b5a0b0/symengine-0.14.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:577dd78b33f29e7713443588c576013ede4757cb8aedc36bcc405cf85844d7f9", size = 51085045, upload-time = "2025-09-14T15:23:30.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d3/fb148c2a2fdefa8f1630f3a0da0170d77ee8e1ac3baf7804504ddc9baacd/symengine-0.14.1-cp311-abi3-win_amd64.whl", hash = "sha256:c1142fd44cc952025185521c1f8a756af8625955f41ad7b947df2b81a14ce7f3", size = 18739305, upload-time = "2025-09-14T15:23:33.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f8/689900a258a68b121d7c61a6705b5332969dd95517f9be1d66a4937a17e1/symengine-0.14.1-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:43a394acef2355bbcbed089c8f83a7dbdac28f4f979e094b549f571fc411dea6", size = 25992552, upload-time = "2025-04-21T04:01:07.102Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/10/82291c78d6dbc17b2e4371559a3945920ecc536ec36b6c8dde28165064f9/symengine-0.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7eb37cd5a9eb0c1c5e35c515139fd1221d937b269aef3569b92c7bb4e251be4", size = 23052876, upload-time = "2025-04-21T04:01:09.679Z" },
+    { url = "https://files.pythonhosted.org/packages/30/1a/2199515b7d4f3aa74262e3eb31916a593c4daa7da53bb2c9cbd2cc13fad8/symengine-0.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7657663cfb0d87d66848f7cacda0b2447e127584bc9ec65120e75ce68b21b809", size = 60873086, upload-time = "2025-04-21T04:01:14.285Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ce/1e7d9abea217cee8a543ff1fb395b4462e9a4df8072e25b42984e8a6938e/symengine-0.14.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:94535da1085a4927364fbb4a8705f7f504897ac53da2cc6d6a8edc897e49c4da", size = 90878511, upload-time = "2025-04-21T04:01:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/23/4bcd98c8a79bc0d584786eb765f33dffca1136fe9b506c6e336d61fad844/symengine-0.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a32a29b9462446c9e7f3bf464c7faa847ac2a2d75f0f3fd2f7c0606f9b9384cb", size = 50397966, upload-time = "2025-04-21T04:01:27.732Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/c2/72612eae87f3d0ca58ae4e2207eaee9f8c1dfddc6862a1dc8e2257d67e14/symengine-0.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:f639a488886a066c4d8f19f2a4fd2213de2ea428153d8e1bf425c14f8bc74d57", size = 18803262, upload-time = "2025-04-21T04:01:31.136Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ab/3ef6b6385b277511a2e80f5425629af6566c491200ced6ba4a5b33db6b9c/symengine-0.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4c657fba40960dc143d90b20fe49ae769d5c82b323b9dd459f5e3dea4796df8f", size = 25962842, upload-time = "2025-04-21T04:01:34.359Z" },
+    { url = "https://files.pythonhosted.org/packages/58/8d/e47e7e9166b4d53cacb0ad722164a6a2bfbb459d62bee105a05998f7b2aa/symengine-0.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9789c62a8ade18f368241525e910dae745fdde1f3b8bb782e5ac8bbfad505e92", size = 23046175, upload-time = "2025-04-21T04:01:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/be/76/6c2227ca8076c238b65341beb3ce4a5bb29174afce3eb9f124b319242693/symengine-0.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcab68fe738a50df3a1b2415f75395c588aab237cb636818332e6cda7ddcf5fb", size = 60719492, upload-time = "2025-04-21T04:01:40.806Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d8/e2dad8babfbb6c8abdb2c443aefca0ae65078c2a0c1f791117a2e659b005/symengine-0.14.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f58a88571a5f7ceca499d7f7834c00d129a55d4c2104a463ba8e3ec24c252e89", size = 90545323, upload-time = "2025-04-21T04:01:46.143Z" },
+    { url = "https://files.pythonhosted.org/packages/64/4f/84948cd8384deb43465c14daea81e53159b1c22a2fd55c4f087c47f180df/symengine-0.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a55b8f78541d57a28beda6971bed0a7ddbd585148bb030221f7ca3a0c8e2517", size = 50278629, upload-time = "2025-04-21T04:01:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/7f/4d6b6998a69af3614cc4cb5953acc23b116b35e0596be4dd991397f0cdce/symengine-0.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:5091ce86728022d2c7e0e864ab23070494c1f24fb430ab3437d46806e854651e", size = 18754027, upload-time = "2025-04-21T04:01:55.355Z" },
+]
 
 [[package]]
 name = "sympy"


### PR DESCRIPTION
Closes #2876.

## What changed
- Adds standalone benchmark scripts for ZNE, measurement mitigation, and PEC on Mitiq benchmark circuits.
- Compares Mitiq ZNE with a Qiskit Aer density-matrix ZNE baseline, and Mitiq REM/TREX with mthree measurement mitigation.
- Adds a `benchmarks` optional dependency extra for external comparison tools.

## Notes
- Supported circuit families are GHZ, quantum volume, and mirror circuits.
- Qermit PEC is detected and reported as unavailable for this simple single-backend runner because its learning-based API expects paired device/simulator backends.

## Validation
- `uv run ruff check scripts/benchmark_error_mitigation_common.py scripts/benchmark_meas_mitigation.py scripts/benchmark_zne.py scripts/benchmark_pec.py`
- `uv run python scripts/benchmark_zne.py --circuit ghz --n-qubits 4 --noise-level 0.01`
- `uv run python scripts/benchmark_zne.py --circuit qv --n-qubits 3 --depth 2 --noise-level 0.01`
- `uv run python scripts/benchmark_meas_mitigation.py --circuit qv --n-qubits 3 --depth 2 --shots 256 --noise-level 0.03`
- `uv run python scripts/benchmark_pec.py --circuit qv --n-qubits 2 --depth 2 --shots 20 --noise-level 0.01`

AI assistance disclosure: I used Codex as a coding assistant, then inspected the generated changes and ran the validation commands above.