### PR TITLE
Add error mitigation benchmark scripts (unitaryHACK bounty #2876)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,13 @@ qiskit = [
     "qiskit-ibm-runtime~=0.41.1",
     "ply==3.11",
 ]
+benchmarking = [
+    "mthree",
+    "qermit",
+    "qiskit>=2.0.0,<3.0.0",
+    "qiskit-aer~=0.17.0",
+    "qiskit-ibm-runtime~=0.41.1",
+]
 
 [dependency-groups]
 dev = [
@@ -96,9 +103,6 @@ Homepage = "https://unitary.foundation"
 Documentation = "https://mitiq.readthedocs.io/en/stable/"
 Repository = "https://github.com/unitaryfoundation/mitiq/"
 Issues = "https://github.com/unitaryfoundation/mitiq/issues/"
-
-[tool.black]
-line-length = 79
 
 [tool.ruff]
 exclude = ["__init__.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ Documentation = "https://mitiq.readthedocs.io/en/stable/"
 Repository = "https://github.com/unitaryfoundation/mitiq/"
 Issues = "https://github.com/unitaryfoundation/mitiq/issues/"
 
+[tool.black]
+line-length = 79
+
 [tool.ruff]
 exclude = ["__init__.py"]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,153 +1,49 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "mitiq"
-version = "1.0.0"
-readme = "README.md"
-description = "Mitiq is an open source toolkit for implementing error mitigation techniques on most current intermediate-scale quantum computers." 
-authors = [ 
-    { name = "Unitary Foundation", email = "info@unitary.foundation" },
-]
+name = "mitiqbounty"
+version = "0.1.0"
+description = "Reproducible benchmarks comparing quantum error mitigation libraries"
 requires-python = ">=3.11,<3.13"
-license = { text = "GPL v3.0" }
-classifiers = [
-    "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "Operating System :: MacOS",
-    "Operating System :: POSIX :: Linux",
-    "Operating System :: Microsoft :: Windows",
-    "Topic :: Software Development :: Compilers",
-    "Topic :: Scientific/Engineering :: Quantum Computing",
-    "Typing :: Typed",
-]
 dependencies = [
-    "numpy>=2.0.0,<2.3.0",
-    "scipy>=1.10.1,<=1.17.1",
-    "cirq-core>=1.6.0,<1.7.0",
-    "tabulate",
-    "matplotlib>=3.8",
+    # core quantum error mitigation
+    "mitiq>=1.0.0",
+    # cirq is pulled in by mitiq but pin for clarity
+    "cirq-core>=1.4",
+    # graph library for mirror circuits
+    "networkx>=3.0",
 ]
 
 [project.optional-dependencies]
-braket = [
-    "amazon-braket-sdk>=1.97,<1.118",
-    "cirq-ionq>=1.6.0,<1.7.0",
-    "llvmlite==0.46.0",
-    "numba==0.64.0",
+# measurement error mitigation benchmark
+meas = [
+    "mthree>=3.0.0",
+    "qiskit-aer>=0.14",
 ]
-pennylane = [
-    "pennylane-qiskit~=0.43.0",
-    "pennylane>=0.44.1,<0.46.0",
+# ZNE benchmark (qermit + manual Qiskit ZNE via AerSimulator)
+zne = [
+    "qermit>=0.9.0",
+    "pytket-qiskit>=0.60",
+    "qiskit-aer>=0.14",
 ]
-pyquil = [
-    "pyquil~=4.17.0",
-    "qbraid>=0.10,<0.13",
+# PEC benchmark (qermit + optional cloud Qiskit PEC via qiskit-ibm-runtime)
+pec = [
+    "qermit>=0.9.0",
+    "pytket-qiskit>=0.60",
+    "qiskit-aer>=0.14",
+    "qiskit-ibm-runtime>=0.20",  # optional: needed for Qiskit PEC (cloud only)
 ]
-qibo = [
-    "qibo>=0.2.16,<0.4.0",
-]
-qiskit = [
-    "qiskit>=2.0.0,<3.0.0",
-    "qiskit-aer~=0.17.0",
-    "qiskit-ibm-runtime~=0.41.1",
-    "ply==3.11",
-]
-
-[dependency-groups]
+# all benchmark dependencies
 dev = [
-    "pytest==9.0.3",
-    "pytest-xdist[psutil]==3.0.2",
-    "pytest-cov==7.0.0",
-    "ruff==0.15.6",
-    "mypy==1.0.0",
-    "types-tabulate",
-]
-docs = [
-    "Sphinx==8.1.3",
-    "sphinxcontrib-bibtex==2.6.5",
-    "sphinx-copybutton==0.5.2",
-    "sphinx-autodoc-typehints==3.0.1",
-    "sphinx-design==0.6.1",
-    "sphinx-tags==0.4",
-    "myst-nb==1.3.0",
-    "myst-parser==5.0.0",
-    "pydata-sphinx-theme==0.16.1",
-    "jupytext==1.18.1",
-    "sphinx-gallery==0.19.0",
-    "nbsphinx==0.9.7",
-    "pandas==2.3.3",
-    "pyscf==2.12.0; sys_platform != 'win32'",
-    "openfermion==1.7.1; sys_platform != 'win32'",
-    "openfermionpyscf==0.5; sys_platform != 'win32'",
-    "bqskit==1.2.1",
-    "seaborn==0.13.2",
-    "stim==1.16.0",
-    "stimcirq==1.16.0",
-    "pyqrack==2.0.2",
-    "ucc==0.4.12; python_version == '3.12'",
-    "pytket-cirq==0.43.0",
-]
-
-[project.urls]
-Homepage = "https://unitary.foundation"
-Documentation = "https://mitiq.readthedocs.io/en/stable/"
-Repository = "https://github.com/unitaryfoundation/mitiq/"
-Issues = "https://github.com/unitaryfoundation/mitiq/issues/"
-
-[tool.ruff]
-exclude = ["__init__.py"]
-line-length = 79
-target-version = 'py312'
-
-[tool.ruff.lint]
-select = [
-    # pycodestyle
-    "E",
-    # pyflakes
-    "F",
-    # isort
-    "I",
-]
-
-[tool.pytest]
-addopts = ["--color=yes"]
-filterwarnings = [
-    # TODO: these are probably too restrictive
-    'ignore::UserWarning',
-    'ignore::DeprecationWarning',
-    # Experimental modules emit FutureWarning by design; suppress in test suite
-    # since the warning behavior is covered by mitiq/tests/test_experimental.py
-    'ignore:mitiq\.\w+ is experimental:FutureWarning',
-]
-
-[tool.mypy]
-exclude = 'mitiq.*.tests*'
-ignore_missing_imports = true
-
-# Enable a subset of strict options
-check_untyped_defs = true
-disallow_any_generics = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_defs = true
-no_implicit_optional = true
-warn_redundant_casts = true
-warn_unused_configs = true
-
-[tool.coverage.run]
-omit = [
-    "*/tests/*",
-    "mitiq/_about.py",
-]
-
-[tool.coverage.report]
-exclude_lines = [
-    "pragma: no cover",
-    "raise NotImplementedError",
+    "mthree>=3.0.0",
+    "qermit>=0.9.0",
+    "pytket-qiskit>=0.60",
+    "qiskit-aer>=0.14",
+    "qiskit-ibm-runtime>=0.20",
 ]
 
 [tool.setuptools.packages.find]
 where = ["."]
+include = ["scripts*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,49 +1,153 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "mitiqbounty"
-version = "0.1.0"
-description = "Reproducible benchmarks comparing quantum error mitigation libraries"
+name = "mitiq"
+version = "1.0.0"
+readme = "README.md"
+description = "Mitiq is an open source toolkit for implementing error mitigation techniques on most current intermediate-scale quantum computers." 
+authors = [ 
+    { name = "Unitary Foundation", email = "info@unitary.foundation" },
+]
 requires-python = ">=3.11,<3.13"
+license = { text = "GPL v3.0" }
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
+    "Topic :: Software Development :: Compilers",
+    "Topic :: Scientific/Engineering :: Quantum Computing",
+    "Typing :: Typed",
+]
 dependencies = [
-    # core quantum error mitigation
-    "mitiq>=1.0.0",
-    # cirq is pulled in by mitiq but pin for clarity
-    "cirq-core>=1.4",
-    # graph library for mirror circuits
-    "networkx>=3.0",
+    "numpy>=2.0.0,<2.3.0",
+    "scipy>=1.10.1,<=1.17.1",
+    "cirq-core>=1.6.0,<1.7.0",
+    "tabulate",
+    "matplotlib>=3.8",
 ]
 
 [project.optional-dependencies]
-# measurement error mitigation benchmark
-meas = [
-    "mthree>=3.0.0",
-    "qiskit-aer>=0.14",
+braket = [
+    "amazon-braket-sdk>=1.97,<1.118",
+    "cirq-ionq>=1.6.0,<1.7.0",
+    "llvmlite==0.46.0",
+    "numba==0.64.0",
 ]
-# ZNE benchmark (qermit + manual Qiskit ZNE via AerSimulator)
-zne = [
-    "qermit>=0.9.0",
-    "pytket-qiskit>=0.60",
-    "qiskit-aer>=0.14",
+pennylane = [
+    "pennylane-qiskit~=0.43.0",
+    "pennylane>=0.44.1,<0.46.0",
 ]
-# PEC benchmark (qermit + optional cloud Qiskit PEC via qiskit-ibm-runtime)
-pec = [
-    "qermit>=0.9.0",
-    "pytket-qiskit>=0.60",
-    "qiskit-aer>=0.14",
-    "qiskit-ibm-runtime>=0.20",  # optional: needed for Qiskit PEC (cloud only)
+pyquil = [
+    "pyquil~=4.17.0",
+    "qbraid>=0.10,<0.13",
 ]
-# all benchmark dependencies
+qibo = [
+    "qibo>=0.2.16,<0.4.0",
+]
+qiskit = [
+    "qiskit>=2.0.0,<3.0.0",
+    "qiskit-aer~=0.17.0",
+    "qiskit-ibm-runtime~=0.41.1",
+    "ply==3.11",
+]
+
+[dependency-groups]
 dev = [
-    "mthree>=3.0.0",
-    "qermit>=0.9.0",
-    "pytket-qiskit>=0.60",
-    "qiskit-aer>=0.14",
-    "qiskit-ibm-runtime>=0.20",
+    "pytest==9.0.3",
+    "pytest-xdist[psutil]==3.0.2",
+    "pytest-cov==7.0.0",
+    "ruff==0.15.6",
+    "mypy==1.0.0",
+    "types-tabulate",
+]
+docs = [
+    "Sphinx==8.1.3",
+    "sphinxcontrib-bibtex==2.6.5",
+    "sphinx-copybutton==0.5.2",
+    "sphinx-autodoc-typehints==3.0.1",
+    "sphinx-design==0.6.1",
+    "sphinx-tags==0.4",
+    "myst-nb==1.3.0",
+    "myst-parser==5.0.0",
+    "pydata-sphinx-theme==0.16.1",
+    "jupytext==1.18.1",
+    "sphinx-gallery==0.19.0",
+    "nbsphinx==0.9.7",
+    "pandas==2.3.3",
+    "pyscf==2.12.0; sys_platform != 'win32'",
+    "openfermion==1.7.1; sys_platform != 'win32'",
+    "openfermionpyscf==0.5; sys_platform != 'win32'",
+    "bqskit==1.2.1",
+    "seaborn==0.13.2",
+    "stim==1.16.0",
+    "stimcirq==1.16.0",
+    "pyqrack==2.0.2",
+    "ucc==0.4.12; python_version == '3.12'",
+    "pytket-cirq==0.43.0",
+]
+
+[project.urls]
+Homepage = "https://unitary.foundation"
+Documentation = "https://mitiq.readthedocs.io/en/stable/"
+Repository = "https://github.com/unitaryfoundation/mitiq/"
+Issues = "https://github.com/unitaryfoundation/mitiq/issues/"
+
+[tool.ruff]
+exclude = ["__init__.py"]
+line-length = 79
+target-version = 'py312'
+
+[tool.ruff.lint]
+select = [
+    # pycodestyle
+    "E",
+    # pyflakes
+    "F",
+    # isort
+    "I",
+]
+
+[tool.pytest]
+addopts = ["--color=yes"]
+filterwarnings = [
+    # TODO: these are probably too restrictive
+    'ignore::UserWarning',
+    'ignore::DeprecationWarning',
+    # Experimental modules emit FutureWarning by design; suppress in test suite
+    # since the warning behavior is covered by mitiq/tests/test_experimental.py
+    'ignore:mitiq\.\w+ is experimental:FutureWarning',
+]
+
+[tool.mypy]
+exclude = 'mitiq.*.tests*'
+ignore_missing_imports = true
+
+# Enable a subset of strict options
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_configs = true
+
+[tool.coverage.run]
+omit = [
+    "*/tests/*",
+    "mitiq/_about.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
 ]
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["scripts*"]

--- a/scripts/benchmark_meas_mitigation.py
+++ b/scripts/benchmark_meas_mitigation.py
@@ -21,7 +21,7 @@ Arguments
 
 Dependencies
 ------------
-    pip install "mitiq>=1.0.0" mthree qiskit-aer
+    pip install -r scripts/requirements-benchmark.txt
 
 Output
 ------

--- a/scripts/benchmark_meas_mitigation.py
+++ b/scripts/benchmark_meas_mitigation.py
@@ -7,14 +7,15 @@ circuit with synthetic readout (bitflip) noise.
 Usage
 -----
     python scripts/benchmark_meas_mitigation.py
-    python scripts/benchmark_meas_mitigation.py --n-qubits 4 --noise-level 0.05 --shots 8192
+    python scripts/benchmark_meas_mitigation.py \
+        --n-qubits 4 --noise-level 0.05 --shots 8192
 
 Arguments
 ---------
     --circuit      Circuit type: ghz (only supported option)   (default: ghz)
     --n-qubits     Number of qubits                            (default: 4)
     --noise-level  Per-qubit readout bitflip probability        (default: 0.05)
-    --shots        Shots per circuit execution                   (default: 8192)
+    --shots        Shots per circuit execution        (default: 8192)
     --seed         Random seed                                   (default: 42)
     --tool         Run a specific tool only: rem | trex | mthree | all
                                                                 (default: all)
@@ -36,7 +37,8 @@ Notes
 -----
     The observable is Z⊗n (tensor product of Pauli Z on all qubits).
     For a GHZ state with even n, the ideal expectation value is +1.0.
-    Noise model: independent bitflip on each qubit with probability noise_level.
+    Noise model: independent per-qubit bitflip with probability
+    noise_level.
     mitiq.rem uses a pre-computed inverse confusion matrix.
     mitiq.experimental.trex uses twirled readout error mitigation.
     mthree uses matrix-free measurement error mitigation (M3).
@@ -45,14 +47,13 @@ Notes
 from __future__ import annotations
 
 import argparse
-import sys
 import time
 from typing import Callable, Tuple
 
 import numpy as np
 
+# ── helpers ──────────────────────────────────────────────────────────────────
 
-# ── helpers ────────────────────────────────────────────────────────────────────
 
 class _Counter:
     """Callable wrapper that counts invocations.
@@ -75,10 +76,14 @@ class _Counter:
 
 def _zn_eigenvalue(n: int) -> np.ndarray:
     """Return eigenvalues of Z⊗n: (-1)^popcount(i) for i in [0, 2^n)."""
-    return np.array([(-1) ** bin(i).count("1") for i in range(2 ** n)], dtype=float)
+    return np.array(
+        [(-1) ** bin(i).count("1") for i in range(2**n)],
+        dtype=float,
+    )
 
 
-# ── circuit generation ─────────────────────────────────────────────────────────
+# ── circuit generation ───────────────────────────────────────────────────────
+
 
 def _get_cirq_ghz(n_qubits: int):
     """Return a cirq GHZ circuit (no measurements)."""
@@ -92,7 +97,8 @@ def _ideal_expval(circuit, n_qubits: int) -> float:
     import cirq
 
     clean = cirq.Circuit(
-        op for op in circuit.all_operations()
+        op
+        for op in circuit.all_operations()
         if not isinstance(op.gate, cirq.MeasurementGate)
     )
     sv = cirq.Simulator().simulate(clean).final_state_vector.flatten()
@@ -101,7 +107,7 @@ def _ideal_expval(circuit, n_qubits: int) -> float:
 
 
 def _count_gates(circuit) -> Tuple[int, int]:
-    """Return (n_1q_gates, n_2q_gates) for a cirq circuit, ignoring measurements."""
+    """Return (n_1q_gates, n_2q_gates), ignoring measurements."""
     import cirq
 
     n1 = n2 = 0
@@ -118,6 +124,7 @@ def _count_gates(circuit) -> Tuple[int, int]:
 
 # ── noisy executor (readout bitflip) ─────────────────────────────────────────
 
+
 def _make_readout_executor(n_qubits: int, noise_level: float, shots: int) -> Callable:
     """
     Return an executor that runs the circuit ideally then applies independent
@@ -133,7 +140,8 @@ def _make_readout_executor(n_qubits: int, noise_level: float, shots: int) -> Cal
 
     def executor(circuit: cirq.Circuit) -> MeasurementResult:
         clean = cirq.Circuit(
-            op for op in circuit.all_operations()
+            op
+            for op in circuit.all_operations()
             if not isinstance(op.gate, cirq.MeasurementGate)
         )
         clean = clean + cirq.measure(*qubits, key="m")
@@ -145,14 +153,17 @@ def _make_readout_executor(n_qubits: int, noise_level: float, shots: int) -> Cal
         return MeasurementResult(bits)
 
     # mitiq inspects __annotations__ to determine the executor return type
-    executor.__annotations__ = {"circuit": cirq.Circuit, "return": MeasurementResult}
+    executor.__annotations__ = {
+        "circuit": cirq.Circuit,
+        "return": MeasurementResult,
+    }
     return executor
 
 
-def _noisy_expval_from_bitflip(circuit, n_qubits: int, noise_level: float, shots: int) -> float:
+def _noisy_expval_from_bitflip(
+    circuit, n_qubits: int, noise_level: float, shots: int
+) -> float:
     """Compute noisy ⟨Z⊗n⟩ under readout bitflip noise (shot-based)."""
-    import cirq
-    from mitiq import MeasurementResult
 
     executor = _make_readout_executor(n_qubits, noise_level, shots)
     mr = executor(circuit)
@@ -162,7 +173,8 @@ def _noisy_expval_from_bitflip(circuit, n_qubits: int, noise_level: float, shots
     return float(np.mean(ev[indices]))
 
 
-# ── mitiq.rem ─────────────────────────────────────────────────────────────────
+# ── mitiq.rem ────────────────────────────────────────────────────────────────
+
 
 def benchmark_mitiq_rem(
     circuit,
@@ -186,16 +198,21 @@ def benchmark_mitiq_rem(
     mit_counter = _Counter(mit_executor)
 
     t0 = time.perf_counter()
-    mitigated = float(execute_with_rem(
-        circuit, mit_counter, obs,
-        inverse_confusion_matrix=icm,
-    ).real)
+    mitigated = float(
+        execute_with_rem(
+            circuit,
+            mit_counter,
+            obs,
+            inverse_confusion_matrix=icm,
+        ).real
+    )
     elapsed = time.perf_counter() - t0
 
     return noisy_val, mitigated, elapsed, mit_counter.n
 
 
-# ── mitiq.experimental.trex ───────────────────────────────────────────────────
+# ── mitiq.experimental.trex ──────────────────────────────────────────────────
+
 
 def benchmark_mitiq_trex(
     circuit,
@@ -209,8 +226,6 @@ def benchmark_mitiq_trex(
     from mitiq.experimental.trex import execute_with_trex
 
     obs = Observable(PauliString(spec="Z" * n_qubits))
-    executor = _make_readout_executor(n_qubits, noise_level, shots)
-
     noisy_counter = _Counter(_make_readout_executor(n_qubits, noise_level, shots))
     noisy_val = float(obs.expectation(circuit, noisy_counter).real)
 
@@ -218,17 +233,22 @@ def benchmark_mitiq_trex(
     trex_counter = _Counter(trex_executor)
 
     t0 = time.perf_counter()
-    mitigated = float(execute_with_trex(
-        circuit, trex_counter, obs,
-        num_randomizations=32,
-        random_state=seed,
-    ))
+    mitigated = float(
+        execute_with_trex(
+            circuit,
+            trex_counter,
+            obs,
+            num_randomizations=32,
+            random_state=seed,
+        )
+    )
     elapsed = time.perf_counter() - t0
 
     return noisy_val, mitigated, elapsed, trex_counter.n
 
 
-# ── mthree ────────────────────────────────────────────────────────────────────
+# ── mthree ───────────────────────────────────────────────────────────────────
+
 
 def benchmark_mthree(
     circuit,
@@ -236,7 +256,7 @@ def benchmark_mthree(
     noise_level: float,
     shots: int,
 ) -> Tuple[float, float, float, int]:
-    """Benchmark mthree M3Mitigation on a Qiskit AerSimulator with readout noise."""
+    """Benchmark mthree M3Mitigation on AerSimulator with readout noise."""
     import mthree
     from qiskit import QuantumCircuit, transpile
     from qiskit_aer import AerSimulator
@@ -250,22 +270,14 @@ def benchmark_mthree(
     qc.measure_all()
 
     # Readout-only noise model
-    ro_error = ReadoutError([[1 - noise_level, noise_level], [noise_level, 1 - noise_level]])
+    ro_error = ReadoutError(
+        [[1 - noise_level, noise_level], [noise_level, 1 - noise_level]]
+    )
     nm = NoiseModel()
     nm.add_all_qubit_readout_error(ro_error)
     sim = AerSimulator(noise_model=nm)
 
     t_qc = transpile(qc, sim, optimization_level=0)
-
-    # Noiseless baseline (no noise model)
-    sim_ideal = AerSimulator()
-    ideal_qc = QuantumCircuit(n_qubits)
-    ideal_qc.h(0)
-    for i in range(n_qubits - 1):
-        ideal_qc.cx(i, i + 1)
-    ideal_qc.measure_all()
-    ideal_counts = sim_ideal.run(transpile(ideal_qc, sim_ideal), shots=shots).result().get_counts()
-    ideal_val = _expval_from_counts(ideal_counts, n_qubits)
 
     # Noisy counts
     noisy_counts = sim.run(t_qc, shots=shots).result().get_counts()
@@ -276,7 +288,8 @@ def benchmark_mthree(
     mit.cals_from_system(range(n_qubits), shots=shots)
     n_circuits = 1  # noisy run
     # calibration circuits also count
-    n_cal = n_qubits  # mthree calibrates each qubit with 2 circuits; count conservatively
+    # mthree calibrates each qubit; count conservatively
+    n_cal = n_qubits
 
     t0 = time.perf_counter()
     quasis = mit.apply_correction(noisy_counts, range(n_qubits))
@@ -284,7 +297,7 @@ def benchmark_mthree(
 
     diagonal = {
         format(i, f"0{n_qubits}b"): (-1) ** bin(i).count("1")
-        for i in range(2 ** n_qubits)
+        for i in range(2**n_qubits)
     }
     mitigated = float(quasis.expval(diagonal))
 
@@ -301,7 +314,7 @@ def _expval_from_counts(counts: dict, n: int) -> float:
     return ev
 
 
-# ── table output ──────────────────────────────────────────────────────────────
+# ── table output ─────────────────────────────────────────────────────────────
 
 _COL = (20, 8, 8, 10, 8, 9, 7, 5, 5)
 _HDR = (
@@ -320,8 +333,16 @@ def _improv(noisy: float, mitigated: float, ideal: float) -> str:
     return f"{abs(noisy - ideal) / denom:.2f}×"
 
 
-def _row(name: str, ideal: float, noisy: float, mitigated: float,
-         elapsed: float, n_circs: int, n1: int, n2: int) -> None:
+def _row(
+    name: str,
+    ideal: float,
+    noisy: float,
+    mitigated: float,
+    elapsed: float,
+    n_circs: int,
+    n1: int,
+    n2: int,
+) -> None:
     factor = _improv(noisy, mitigated, ideal)
     print(
         f"{name:<{_COL[0]}} {ideal:>{_COL[1]}.4f} {noisy:>{_COL[2]}.4f} "
@@ -331,26 +352,39 @@ def _row(name: str, ideal: float, noisy: float, mitigated: float,
     )
 
 
-# ── main ──────────────────────────────────────────────────────────────────────
+# ── main ─────────────────────────────────────────────────────────────────────
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("--circuit", choices=["ghz"], default="ghz",
-                        help="Circuit type (default: ghz)")
-    parser.add_argument("--n-qubits", type=int, default=4,
-                        help="Number of qubits (default: 4)")
-    parser.add_argument("--noise-level", type=float, default=0.05,
-                        help="Per-qubit readout bitflip probability (default: 0.05)")
-    parser.add_argument("--shots", type=int, default=8192,
-                        help="Shots per circuit (default: 8192)")
+    parser.add_argument(
+        "--circuit", choices=["ghz"], default="ghz", help="Circuit type (default: ghz)"
+    )
+    parser.add_argument(
+        "--n-qubits", type=int, default=4, help="Number of qubits (default: 4)"
+    )
+    parser.add_argument(
+        "--noise-level",
+        type=float,
+        default=0.05,
+        help="Per-qubit readout bitflip probability (default: 0.05)",
+    )
+    parser.add_argument(
+        "--shots", type=int, default=8192, help="Shots per circuit (default: 8192)"
+    )
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--tool", choices=["all", "rem", "trex", "mthree"], default="all")
+    parser.add_argument(
+        "--tool",
+        choices=["all", "rem", "trex", "mthree"],
+        default="all",
+    )
     args = parser.parse_args()
 
     import warnings
+
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
     warnings.filterwarnings("ignore", message=".*global phase.*")
@@ -369,7 +403,10 @@ def main() -> None:
     ideal = _ideal_expval(circuit, args.n_qubits)
     n1, n2 = _count_gates(circuit)
 
-    print(f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}   1Q gates: {n1}   2Q gates: {n2}\n")
+    print(
+        f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}"
+        f"   1Q gates: {n1}   2Q gates: {n2}\n"
+    )
     print(_HDR)
     print(_SEP)
 
@@ -395,9 +432,19 @@ def main() -> None:
             if key == "trex":
                 kwargs["seed"] = args.seed
             noisy, mitigated, elapsed, n_circs = fn(**kwargs)
-            _row(display_name, ideal, noisy, mitigated, elapsed, n_circs, n1, n2)
+            _row(
+                display_name,
+                ideal,
+                noisy,
+                mitigated,
+                elapsed,
+                n_circs,
+                n1,
+                n2,
+            )
         except ImportError as exc:
-            print(f"{'  ' + display_name:<{_COL[0]}} SKIP (missing dep): {exc}")
+            label = "  " + display_name
+            print(f"{label:<{_COL[0]}} SKIP (missing dep): {exc}")
         except Exception as exc:
             print(f"{'  ' + display_name:<{_COL[0]}} ERROR: {exc}")
 

--- a/scripts/benchmark_meas_mitigation.py
+++ b/scripts/benchmark_meas_mitigation.py
@@ -1,24 +1,24 @@
 """
 Measurement Error Mitigation Benchmark
 =======================================
-Compare ``mitiq.rem``, ``mitiq.experimental.trex``, and ``mthree`` on a GHZ
-circuit with synthetic readout (bitflip) noise.
+Compare ``mitiq.rem``, ``mitiq.experimental.trex``, and ``mthree`` on GHZ,
+QV, and mirror circuits with synthetic readout (bitflip) noise.
 
 Usage
 -----
-    python scripts/benchmark_meas_mitigation.py
-    python scripts/benchmark_meas_mitigation.py \
-        --n-qubits 4 --noise-level 0.05 --shots 8192
+    python scripts/benchmark_meas_mitigation.py               # ghz, qv, mirror
+    python scripts/benchmark_meas_mitigation.py --circuit ghz # one circuit
 
 Arguments
 ---------
-    --circuit      Circuit type: ghz (only supported option)   (default: ghz)
-    --n-qubits     Number of qubits                            (default: 4)
+    --circuit      Circuit type: ghz | qv | mirror | all        (default: all)
+    --n-qubits     Number of qubits                             (default: 4)
+    --depth        Circuit depth for qv / mirror                 (default: 4)
     --noise-level  Per-qubit readout bitflip probability        (default: 0.05)
-    --shots        Shots per circuit execution        (default: 8192)
+    --shots        Shots per circuit execution                  (default: 8192)
     --seed         Random seed                                   (default: 42)
     --tool         Run a specific tool only: rem | trex | mthree | all
-                                                                (default: all)
+                                                                 (default: all)
 
 Dependencies
 ------------
@@ -51,45 +51,44 @@ import time
 from typing import Callable, Tuple
 
 import numpy as np
-
-# ── helpers ──────────────────────────────────────────────────────────────────
-
-
-class _Counter:
-    """Callable wrapper that counts invocations.
-
-    Copies ``__annotations__`` from the wrapped callable so that mitiq's
-    executor type-hint inspection still works correctly.
-    """
-
-    def __init__(self, fn: Callable) -> None:
-        self._fn = fn
-        self.n = 0
-        # propagate type hints so mitiq can detect the return type
-        ann = getattr(fn, "__annotations__", {})
-        self.__call__.__func__.__annotations__ = ann  # type: ignore[attr-defined]
-
-    def __call__(self, *args, **kwargs):
-        self.n += 1
-        return self._fn(*args, **kwargs)
-
-
-def _zn_eigenvalue(n: int) -> np.ndarray:
-    """Return eigenvalues of Z⊗n: (-1)^popcount(i) for i in [0, 2^n)."""
-    return np.array(
-        [(-1) ** bin(i).count("1") for i in range(2**n)],
-        dtype=float,
-    )
-
+from benchmark_utils import (
+    _COL,
+    _HDR,
+    _SEP,
+    _count_gates,
+    _Counter,
+    _row,
+    _zn_eigenvalue,
+)
 
 # ── circuit generation ───────────────────────────────────────────────────────
 
 
-def _get_cirq_ghz(n_qubits: int):
-    """Return a cirq GHZ circuit (no measurements)."""
+def get_benchmark_circuit(
+    circuit_type: str, n_qubits: int, depth: int, seed: int
+):
+    """Return a cirq circuit for the chosen type (no measurements)."""
     from mitiq import benchmarks
 
-    return benchmarks.generate_ghz_circuit(n_qubits)
+    if circuit_type == "ghz":
+        return benchmarks.generate_ghz_circuit(n_qubits)
+    elif circuit_type == "qv":
+        circuit, _ = benchmarks.generate_quantum_volume_circuit(
+            n_qubits, depth, decompose=True, seed=seed
+        )
+        return circuit
+    elif circuit_type == "mirror":
+        import networkx as nx
+
+        circuit, _ = benchmarks.generate_mirror_circuit(
+            nlayers=depth,
+            two_qubit_gate_prob=0.5,
+            connectivity_graph=nx.path_graph(n_qubits),
+            seed=seed,
+        )
+        return circuit
+    else:
+        raise ValueError(f"Unknown circuit type: {circuit_type!r}")
 
 
 def _ideal_expval(circuit, n_qubits: int) -> float:
@@ -104,22 +103,6 @@ def _ideal_expval(circuit, n_qubits: int) -> float:
     sv = cirq.Simulator().simulate(clean).final_state_vector.flatten()
     ev = _zn_eigenvalue(n_qubits)
     return float(np.real(np.dot(ev, np.abs(sv) ** 2)))
-
-
-def _count_gates(circuit) -> Tuple[int, int]:
-    """Return (n_1q_gates, n_2q_gates), ignoring measurements."""
-    import cirq
-
-    n1 = n2 = 0
-    for op in circuit.all_operations():
-        if isinstance(op.gate, cirq.MeasurementGate):
-            continue
-        nq = len(op.qubits)
-        if nq == 1:
-            n1 += 1
-        elif nq == 2:
-            n2 += 1
-    return n1, n2
 
 
 # ── noisy executor (readout bitflip) ─────────────────────────────────────────
@@ -186,7 +169,7 @@ def benchmark_mitiq_rem(
     shots: int,
 ) -> Tuple[float, float, float, int]:
     """Benchmark mitiq.rem (inverse confusion matrix)."""
-    from mitiq import Observable, PauliString
+    from mitiq import Observable, PauliString  # isort: skip
     from mitiq.rem import execute_with_rem, generate_inverse_confusion_matrix
 
     obs = Observable(PauliString(spec="Z" * n_qubits))
@@ -227,7 +210,7 @@ def benchmark_mitiq_trex(
     seed: int = 42,
 ) -> Tuple[float, float, float, int]:
     """Benchmark mitiq.experimental.trex (twirled readout error mitigation)."""
-    from mitiq import Observable, PauliString
+    from mitiq import Observable, PauliString  # isort: skip
     from mitiq.experimental.trex import execute_with_trex
 
     obs = Observable(PauliString(spec="Z" * n_qubits))
@@ -264,16 +247,20 @@ def benchmark_mthree(
     shots: int,
 ) -> Tuple[float, float, float, int]:
     """Benchmark mthree M3Mitigation on AerSimulator with readout noise."""
+    import cirq
     import mthree
     from qiskit import QuantumCircuit, transpile
     from qiskit_aer import AerSimulator
     from qiskit_aer.noise import NoiseModel, ReadoutError
 
-    # Build GHZ circuit in Qiskit
-    qc = QuantumCircuit(n_qubits)
-    qc.h(0)
-    for i in range(n_qubits - 1):
-        qc.cx(i, i + 1)
+    # Convert mitiq benchmarks circuit to Qiskit via QASM
+    clean = cirq.Circuit(
+        op
+        for op in circuit.all_operations()
+        if not isinstance(op.gate, cirq.MeasurementGate)
+    )
+    qasm_str = clean.to_qasm()
+    qc = QuantumCircuit.from_qasm_str(qasm_str)
     qc.measure_all()
 
     # Readout-only noise model
@@ -321,104 +308,21 @@ def _expval_from_counts(counts: dict, n: int) -> float:
     return ev
 
 
-# ── table output ─────────────────────────────────────────────────────────────
-
-_COL = (20, 8, 8, 10, 8, 9, 7, 5, 5)
-_HDR = (
-    f"{'Tool':<{_COL[0]}} {'Ideal':>{_COL[1]}} {'Noisy':>{_COL[2]}} "
-    f"{'Mitigated':>{_COL[3]}} {'Improv':>{_COL[4]}} "
-    f"{'Time(s)':>{_COL[5]}} {'Circs':>{_COL[6]}} "
-    f"{'1Q':>{_COL[7]}} {'2Q':>{_COL[8]}}"
-)
-_SEP = "-" * len(_HDR)
+# ── per-circuit runner ───────────────────────────────────────────────────────
 
 
-def _improv(noisy: float, mitigated: float, ideal: float) -> str:
-    denom = abs(mitigated - ideal)
-    if denom < 1e-10:
-        return "∞"
-    return f"{abs(noisy - ideal) / denom:.2f}×"
-
-
-def _row(
-    name: str,
-    ideal: float,
-    noisy: float,
-    mitigated: float,
-    elapsed: float,
-    n_circs: int,
-    n1: int,
-    n2: int,
-) -> None:
-    factor = _improv(noisy, mitigated, ideal)
-    print(
-        f"{name:<{_COL[0]}} {ideal:>{_COL[1]}.4f} {noisy:>{_COL[2]}.4f} "
-        f"{mitigated:>{_COL[3]}.4f} {factor:>{_COL[4]}} "
-        f"{elapsed:>{_COL[5]}.2f} {n_circs:>{_COL[6]}} "
-        f"{n1:>{_COL[7]}} {n2:>{_COL[8]}}"
+def _run_circuit(circuit_type: str, args) -> None:
+    """Run measurement-error benchmark for one circuit type."""
+    circuit = get_benchmark_circuit(
+        circuit_type, args.n_qubits, args.depth, args.seed
     )
-
-
-# ── main ─────────────────────────────────────────────────────────────────────
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    parser.add_argument(
-        "--circuit",
-        choices=["ghz"],
-        default="ghz",
-        help="Circuit type (default: ghz)",
-    )
-    parser.add_argument(
-        "--n-qubits", type=int, default=4, help="Number of qubits (default: 4)"
-    )
-    parser.add_argument(
-        "--noise-level",
-        type=float,
-        default=0.05,
-        help="Per-qubit readout bitflip probability (default: 0.05)",
-    )
-    parser.add_argument(
-        "--shots",
-        type=int,
-        default=8192,
-        help="Shots per circuit (default: 8192)",
-    )
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument(
-        "--tool",
-        choices=["all", "rem", "trex", "mthree"],
-        default="all",
-    )
-    args = parser.parse_args()
-
-    import warnings
-
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
-    warnings.filterwarnings("ignore", message=".*global phase.*")
-    warnings.filterwarnings("ignore", message=".*IBMFractional.*")
-
-    np.random.seed(args.seed)
-
-    print(
-        f"\nMeasurement Error Mitigation Benchmark\n"
-        f"circuit={args.circuit}  n_qubits={args.n_qubits}  "
-        f"noise_level={args.noise_level}  shots={args.shots}"
-    )
-    print("=" * len(_HDR))
-
-    circuit = _get_cirq_ghz(args.n_qubits)
     ideal = _ideal_expval(circuit, args.n_qubits)
     n1, n2 = _count_gates(circuit)
 
+    print(f"\ncircuit: {circuit_type}")
     print(
         f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}"
-        f"   1Q gates: {n1}   2Q gates: {n2}\n"
+        f"   1Q gates: {n1}   2Q gates: {n2}"
     )
     print(_HDR)
     print(_SEP)
@@ -462,6 +366,74 @@ def main() -> None:
             print(f"{'  ' + display_name:<{_COL[0]}} ERROR: {exc}")
 
     print(_SEP)
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--circuit",
+        choices=["ghz", "qv", "mirror", "all"],
+        default="all",
+        help="Circuit type, or 'all' to run ghz/qv/mirror (default: all)",
+    )
+    parser.add_argument(
+        "--n-qubits", type=int, default=4, help="Number of qubits (default: 4)"
+    )
+    parser.add_argument(
+        "--depth",
+        type=int,
+        default=4,
+        help="Circuit depth for qv/mirror (default: 4)",
+    )
+    parser.add_argument(
+        "--noise-level",
+        type=float,
+        default=0.05,
+        help="Per-qubit readout bitflip probability (default: 0.05)",
+    )
+    parser.add_argument(
+        "--shots",
+        type=int,
+        default=8192,
+        help="Shots per circuit (default: 8192)",
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--tool",
+        choices=["all", "rem", "trex", "mthree"],
+        default="all",
+    )
+    args = parser.parse_args()
+
+    import warnings
+
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
+    warnings.filterwarnings("ignore", message=".*global phase.*")
+    warnings.filterwarnings("ignore", message=".*IBMFractional.*")
+
+    np.random.seed(args.seed)
+
+    circuit_types = (
+        ["ghz", "qv", "mirror"] if args.circuit == "all" else [args.circuit]
+    )
+
+    print(
+        f"\nMeasurement Error Mitigation Benchmark\n"
+        f"circuit={args.circuit}  n_qubits={args.n_qubits}  "
+        f"noise_level={args.noise_level}  shots={args.shots}"
+    )
+    print("=" * len(_HDR))
+
+    for ct in circuit_types:
+        _run_circuit(ct, args)
+
     print(
         "\nImprov = |noisy − ideal| / |mitigated − ideal|  "
         "(>1 means mitigation helped, <1 means it hurt)"

--- a/scripts/benchmark_meas_mitigation.py
+++ b/scripts/benchmark_meas_mitigation.py
@@ -1,0 +1,412 @@
+"""
+Measurement Error Mitigation Benchmark
+=======================================
+Compare ``mitiq.rem``, ``mitiq.experimental.trex``, and ``mthree`` on a GHZ
+circuit with synthetic readout (bitflip) noise.
+
+Usage
+-----
+    python scripts/benchmark_meas_mitigation.py
+    python scripts/benchmark_meas_mitigation.py --n-qubits 4 --noise-level 0.05 --shots 8192
+
+Arguments
+---------
+    --circuit      Circuit type: ghz (only supported option)   (default: ghz)
+    --n-qubits     Number of qubits                            (default: 4)
+    --noise-level  Per-qubit readout bitflip probability        (default: 0.05)
+    --shots        Shots per circuit execution                   (default: 8192)
+    --seed         Random seed                                   (default: 42)
+    --tool         Run a specific tool only: rem | trex | mthree | all
+                                                                (default: all)
+
+Dependencies
+------------
+    pip install "mitiq>=1.0.0" mthree qiskit-aer
+
+Output
+------
+    Prints a table with:
+      - Ideal, noisy, and mitigated expectation values (Z⊗n)
+      - Error mitigation improvement factor
+      - Wall-clock runtime
+      - Circuit execution count
+      - Single- and two-qubit gate counts of the benchmark circuit
+
+Notes
+-----
+    The observable is Z⊗n (tensor product of Pauli Z on all qubits).
+    For a GHZ state with even n, the ideal expectation value is +1.0.
+    Noise model: independent bitflip on each qubit with probability noise_level.
+    mitiq.rem uses a pre-computed inverse confusion matrix.
+    mitiq.experimental.trex uses twirled readout error mitigation.
+    mthree uses matrix-free measurement error mitigation (M3).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from typing import Callable, Tuple
+
+import numpy as np
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+class _Counter:
+    """Callable wrapper that counts invocations.
+
+    Copies ``__annotations__`` from the wrapped callable so that mitiq's
+    executor type-hint inspection still works correctly.
+    """
+
+    def __init__(self, fn: Callable) -> None:
+        self._fn = fn
+        self.n = 0
+        # propagate type hints so mitiq can detect the return type
+        ann = getattr(fn, "__annotations__", {})
+        self.__call__.__func__.__annotations__ = ann  # type: ignore[attr-defined]
+
+    def __call__(self, *args, **kwargs):
+        self.n += 1
+        return self._fn(*args, **kwargs)
+
+
+def _zn_eigenvalue(n: int) -> np.ndarray:
+    """Return eigenvalues of Z⊗n: (-1)^popcount(i) for i in [0, 2^n)."""
+    return np.array([(-1) ** bin(i).count("1") for i in range(2 ** n)], dtype=float)
+
+
+# ── circuit generation ─────────────────────────────────────────────────────────
+
+def _get_cirq_ghz(n_qubits: int):
+    """Return a cirq GHZ circuit (no measurements)."""
+    from mitiq import benchmarks
+
+    return benchmarks.generate_ghz_circuit(n_qubits)
+
+
+def _ideal_expval(circuit, n_qubits: int) -> float:
+    """Compute ideal ⟨Z⊗n⟩ via noiseless cirq statevector simulation."""
+    import cirq
+
+    clean = cirq.Circuit(
+        op for op in circuit.all_operations()
+        if not isinstance(op.gate, cirq.MeasurementGate)
+    )
+    sv = cirq.Simulator().simulate(clean).final_state_vector.flatten()
+    ev = _zn_eigenvalue(n_qubits)
+    return float(np.real(np.dot(ev, np.abs(sv) ** 2)))
+
+
+def _count_gates(circuit) -> Tuple[int, int]:
+    """Return (n_1q_gates, n_2q_gates) for a cirq circuit, ignoring measurements."""
+    import cirq
+
+    n1 = n2 = 0
+    for op in circuit.all_operations():
+        if isinstance(op.gate, cirq.MeasurementGate):
+            continue
+        nq = len(op.qubits)
+        if nq == 1:
+            n1 += 1
+        elif nq == 2:
+            n2 += 1
+    return n1, n2
+
+
+# ── noisy executor (readout bitflip) ─────────────────────────────────────────
+
+def _make_readout_executor(n_qubits: int, noise_level: float, shots: int) -> Callable:
+    """
+    Return an executor that runs the circuit ideally then applies independent
+    per-qubit bitflip noise at probability ``noise_level``.
+    Returns a ``MeasurementResult`` (raw bitstrings).
+    """
+    import cirq
+    from mitiq import MeasurementResult
+
+    qubits = cirq.LineQubit.range(n_qubits)
+    sim = cirq.Simulator()
+    rng = np.random.default_rng(0)
+
+    def executor(circuit: cirq.Circuit) -> MeasurementResult:
+        clean = cirq.Circuit(
+            op for op in circuit.all_operations()
+            if not isinstance(op.gate, cirq.MeasurementGate)
+        )
+        clean = clean + cirq.measure(*qubits, key="m")
+        result = sim.run(clean, repetitions=shots)
+        bits = result.measurements["m"].copy().astype(np.int8)
+        # apply independent bitflip noise
+        mask = rng.random(bits.shape) < noise_level
+        bits ^= mask.astype(np.int8)
+        return MeasurementResult(bits)
+
+    # mitiq inspects __annotations__ to determine the executor return type
+    executor.__annotations__ = {"circuit": cirq.Circuit, "return": MeasurementResult}
+    return executor
+
+
+def _noisy_expval_from_bitflip(circuit, n_qubits: int, noise_level: float, shots: int) -> float:
+    """Compute noisy ⟨Z⊗n⟩ under readout bitflip noise (shot-based)."""
+    import cirq
+    from mitiq import MeasurementResult
+
+    executor = _make_readout_executor(n_qubits, noise_level, shots)
+    mr = executor(circuit)
+    ev = _zn_eigenvalue(n_qubits)
+    bitstrings = mr.asarray  # shape (shots, n_qubits)
+    indices = bitstrings.dot(2 ** np.arange(n_qubits - 1, -1, -1))
+    return float(np.mean(ev[indices]))
+
+
+# ── mitiq.rem ─────────────────────────────────────────────────────────────────
+
+def benchmark_mitiq_rem(
+    circuit,
+    n_qubits: int,
+    noise_level: float,
+    shots: int,
+) -> Tuple[float, float, float, int]:
+    """Benchmark mitiq.rem (inverse confusion matrix)."""
+    from mitiq import Observable, PauliString
+    from mitiq.rem import execute_with_rem, generate_inverse_confusion_matrix
+
+    obs = Observable(PauliString(spec="Z" * n_qubits))
+    executor = _make_readout_executor(n_qubits, noise_level, shots)
+
+    # noisy baseline (no mitigation)
+    noisy_counter = _Counter(executor)
+    noisy_val = float(obs.expectation(circuit, noisy_counter).real)
+
+    icm = generate_inverse_confusion_matrix(n_qubits, p0=noise_level, p1=noise_level)
+    mit_executor = _make_readout_executor(n_qubits, noise_level, shots)
+    mit_counter = _Counter(mit_executor)
+
+    t0 = time.perf_counter()
+    mitigated = float(execute_with_rem(
+        circuit, mit_counter, obs,
+        inverse_confusion_matrix=icm,
+    ).real)
+    elapsed = time.perf_counter() - t0
+
+    return noisy_val, mitigated, elapsed, mit_counter.n
+
+
+# ── mitiq.experimental.trex ───────────────────────────────────────────────────
+
+def benchmark_mitiq_trex(
+    circuit,
+    n_qubits: int,
+    noise_level: float,
+    shots: int,
+    seed: int = 42,
+) -> Tuple[float, float, float, int]:
+    """Benchmark mitiq.experimental.trex (twirled readout error mitigation)."""
+    from mitiq import Observable, PauliString
+    from mitiq.experimental.trex import execute_with_trex
+
+    obs = Observable(PauliString(spec="Z" * n_qubits))
+    executor = _make_readout_executor(n_qubits, noise_level, shots)
+
+    noisy_counter = _Counter(_make_readout_executor(n_qubits, noise_level, shots))
+    noisy_val = float(obs.expectation(circuit, noisy_counter).real)
+
+    trex_executor = _make_readout_executor(n_qubits, noise_level, shots)
+    trex_counter = _Counter(trex_executor)
+
+    t0 = time.perf_counter()
+    mitigated = float(execute_with_trex(
+        circuit, trex_counter, obs,
+        num_randomizations=32,
+        random_state=seed,
+    ))
+    elapsed = time.perf_counter() - t0
+
+    return noisy_val, mitigated, elapsed, trex_counter.n
+
+
+# ── mthree ────────────────────────────────────────────────────────────────────
+
+def benchmark_mthree(
+    circuit,
+    n_qubits: int,
+    noise_level: float,
+    shots: int,
+) -> Tuple[float, float, float, int]:
+    """Benchmark mthree M3Mitigation on a Qiskit AerSimulator with readout noise."""
+    import mthree
+    from qiskit import QuantumCircuit, transpile
+    from qiskit_aer import AerSimulator
+    from qiskit_aer.noise import NoiseModel, ReadoutError
+
+    # Build GHZ circuit in Qiskit
+    qc = QuantumCircuit(n_qubits)
+    qc.h(0)
+    for i in range(n_qubits - 1):
+        qc.cx(i, i + 1)
+    qc.measure_all()
+
+    # Readout-only noise model
+    ro_error = ReadoutError([[1 - noise_level, noise_level], [noise_level, 1 - noise_level]])
+    nm = NoiseModel()
+    nm.add_all_qubit_readout_error(ro_error)
+    sim = AerSimulator(noise_model=nm)
+
+    t_qc = transpile(qc, sim, optimization_level=0)
+
+    # Noiseless baseline (no noise model)
+    sim_ideal = AerSimulator()
+    ideal_qc = QuantumCircuit(n_qubits)
+    ideal_qc.h(0)
+    for i in range(n_qubits - 1):
+        ideal_qc.cx(i, i + 1)
+    ideal_qc.measure_all()
+    ideal_counts = sim_ideal.run(transpile(ideal_qc, sim_ideal), shots=shots).result().get_counts()
+    ideal_val = _expval_from_counts(ideal_counts, n_qubits)
+
+    # Noisy counts
+    noisy_counts = sim.run(t_qc, shots=shots).result().get_counts()
+    noisy_val = _expval_from_counts(noisy_counts, n_qubits)
+
+    # mthree calibration + correction
+    mit = mthree.M3Mitigation(sim)
+    mit.cals_from_system(range(n_qubits), shots=shots)
+    n_circuits = 1  # noisy run
+    # calibration circuits also count
+    n_cal = n_qubits  # mthree calibrates each qubit with 2 circuits; count conservatively
+
+    t0 = time.perf_counter()
+    quasis = mit.apply_correction(noisy_counts, range(n_qubits))
+    elapsed = time.perf_counter() - t0
+
+    diagonal = {
+        format(i, f"0{n_qubits}b"): (-1) ** bin(i).count("1")
+        for i in range(2 ** n_qubits)
+    }
+    mitigated = float(quasis.expval(diagonal))
+
+    return noisy_val, mitigated, elapsed, n_circuits + n_cal
+
+
+def _expval_from_counts(counts: dict, n: int) -> float:
+    """Compute ⟨Z⊗n⟩ from a Qiskit counts dictionary."""
+    total = sum(counts.values())
+    ev = 0.0
+    for bs, cnt in counts.items():
+        parity = sum(int(b) for b in bs.replace(" ", "")) % 2
+        ev += (-1) ** parity * cnt / total
+    return ev
+
+
+# ── table output ──────────────────────────────────────────────────────────────
+
+_COL = (20, 8, 8, 10, 8, 9, 7, 5, 5)
+_HDR = (
+    f"{'Tool':<{_COL[0]}} {'Ideal':>{_COL[1]}} {'Noisy':>{_COL[2]}} "
+    f"{'Mitigated':>{_COL[3]}} {'Improv':>{_COL[4]}} "
+    f"{'Time(s)':>{_COL[5]}} {'Circs':>{_COL[6]}} "
+    f"{'1Q':>{_COL[7]}} {'2Q':>{_COL[8]}}"
+)
+_SEP = "-" * len(_HDR)
+
+
+def _improv(noisy: float, mitigated: float, ideal: float) -> str:
+    denom = abs(mitigated - ideal)
+    if denom < 1e-10:
+        return "∞"
+    return f"{abs(noisy - ideal) / denom:.2f}×"
+
+
+def _row(name: str, ideal: float, noisy: float, mitigated: float,
+         elapsed: float, n_circs: int, n1: int, n2: int) -> None:
+    factor = _improv(noisy, mitigated, ideal)
+    print(
+        f"{name:<{_COL[0]}} {ideal:>{_COL[1]}.4f} {noisy:>{_COL[2]}.4f} "
+        f"{mitigated:>{_COL[3]}.4f} {factor:>{_COL[4]}} "
+        f"{elapsed:>{_COL[5]}.2f} {n_circs:>{_COL[6]}} "
+        f"{n1:>{_COL[7]}} {n2:>{_COL[8]}}"
+    )
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--circuit", choices=["ghz"], default="ghz",
+                        help="Circuit type (default: ghz)")
+    parser.add_argument("--n-qubits", type=int, default=4,
+                        help="Number of qubits (default: 4)")
+    parser.add_argument("--noise-level", type=float, default=0.05,
+                        help="Per-qubit readout bitflip probability (default: 0.05)")
+    parser.add_argument("--shots", type=int, default=8192,
+                        help="Shots per circuit (default: 8192)")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--tool", choices=["all", "rem", "trex", "mthree"], default="all")
+    args = parser.parse_args()
+
+    import warnings
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
+    warnings.filterwarnings("ignore", message=".*global phase.*")
+    warnings.filterwarnings("ignore", message=".*IBMFractional.*")
+
+    np.random.seed(args.seed)
+
+    print(
+        f"\nMeasurement Error Mitigation Benchmark\n"
+        f"circuit={args.circuit}  n_qubits={args.n_qubits}  "
+        f"noise_level={args.noise_level}  shots={args.shots}"
+    )
+    print("=" * len(_HDR))
+
+    circuit = _get_cirq_ghz(args.n_qubits)
+    ideal = _ideal_expval(circuit, args.n_qubits)
+    n1, n2 = _count_gates(circuit)
+
+    print(f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}   1Q gates: {n1}   2Q gates: {n2}\n")
+    print(_HDR)
+    print(_SEP)
+
+    benchmarks_map = {
+        "rem": ("mitiq.rem", benchmark_mitiq_rem),
+        "trex": ("mitiq.experimental.trex", benchmark_mitiq_trex),
+        "mthree": ("mthree", benchmark_mthree),
+    }
+    tools_to_run = (
+        list(benchmarks_map.items())
+        if args.tool == "all"
+        else [(args.tool, benchmarks_map[args.tool])]
+    )
+
+    for key, (display_name, fn) in tools_to_run:
+        try:
+            kwargs: dict = dict(
+                circuit=circuit,
+                n_qubits=args.n_qubits,
+                noise_level=args.noise_level,
+                shots=args.shots,
+            )
+            if key == "trex":
+                kwargs["seed"] = args.seed
+            noisy, mitigated, elapsed, n_circs = fn(**kwargs)
+            _row(display_name, ideal, noisy, mitigated, elapsed, n_circs, n1, n2)
+        except ImportError as exc:
+            print(f"{'  ' + display_name:<{_COL[0]}} SKIP (missing dep): {exc}")
+        except Exception as exc:
+            print(f"{'  ' + display_name:<{_COL[0]}} ERROR: {exc}")
+
+    print(_SEP)
+    print(
+        "\nImprov = |noisy − ideal| / |mitigated − ideal|  "
+        "(>1 means mitigation helped, <1 means it hurt)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_meas_mitigation.py
+++ b/scripts/benchmark_meas_mitigation.py
@@ -125,13 +125,16 @@ def _count_gates(circuit) -> Tuple[int, int]:
 # ── noisy executor (readout bitflip) ─────────────────────────────────────────
 
 
-def _make_readout_executor(n_qubits: int, noise_level: float, shots: int) -> Callable:
+def _make_readout_executor(
+    n_qubits: int, noise_level: float, shots: int
+) -> Callable:
     """
     Return an executor that runs the circuit ideally then applies independent
     per-qubit bitflip noise at probability ``noise_level``.
     Returns a ``MeasurementResult`` (raw bitstrings).
     """
     import cirq
+
     from mitiq import MeasurementResult
 
     qubits = cirq.LineQubit.range(n_qubits)
@@ -193,7 +196,9 @@ def benchmark_mitiq_rem(
     noisy_counter = _Counter(executor)
     noisy_val = float(obs.expectation(circuit, noisy_counter).real)
 
-    icm = generate_inverse_confusion_matrix(n_qubits, p0=noise_level, p1=noise_level)
+    icm = generate_inverse_confusion_matrix(
+        n_qubits, p0=noise_level, p1=noise_level
+    )
     mit_executor = _make_readout_executor(n_qubits, noise_level, shots)
     mit_counter = _Counter(mit_executor)
 
@@ -226,7 +231,9 @@ def benchmark_mitiq_trex(
     from mitiq.experimental.trex import execute_with_trex
 
     obs = Observable(PauliString(spec="Z" * n_qubits))
-    noisy_counter = _Counter(_make_readout_executor(n_qubits, noise_level, shots))
+    noisy_counter = _Counter(
+        _make_readout_executor(n_qubits, noise_level, shots)
+    )
     noisy_val = float(obs.expectation(circuit, noisy_counter).real)
 
     trex_executor = _make_readout_executor(n_qubits, noise_level, shots)
@@ -361,7 +368,10 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "--circuit", choices=["ghz"], default="ghz", help="Circuit type (default: ghz)"
+        "--circuit",
+        choices=["ghz"],
+        default="ghz",
+        help="Circuit type (default: ghz)",
     )
     parser.add_argument(
         "--n-qubits", type=int, default=4, help="Number of qubits (default: 4)"
@@ -373,7 +383,10 @@ def main() -> None:
         help="Per-qubit readout bitflip probability (default: 0.05)",
     )
     parser.add_argument(
-        "--shots", type=int, default=8192, help="Shots per circuit (default: 8192)"
+        "--shots",
+        type=int,
+        default=8192,
+        help="Shots per circuit (default: 8192)",
     )
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument(

--- a/scripts/benchmark_meas_mitigation.py
+++ b/scripts/benchmark_meas_mitigation.py
@@ -22,7 +22,7 @@ Arguments
 
 Dependencies
 ------------
-    pip install -r scripts/requirements-benchmark.txt
+    pip install -e ".[benchmarking]"
 
 Output
 ------
@@ -56,7 +56,6 @@ from benchmark_utils import (
     _HDR,
     _SEP,
     _count_gates,
-    _Counter,
     _row,
     _zn_eigenvalue,
 )
@@ -169,34 +168,34 @@ def benchmark_mitiq_rem(
     shots: int,
 ) -> Tuple[float, float, float, int]:
     """Benchmark mitiq.rem (inverse confusion matrix)."""
-    from mitiq import Observable, PauliString  # isort: skip
+    from mitiq import Executor, Observable, PauliString  # isort: skip
     from mitiq.rem import execute_with_rem, generate_inverse_confusion_matrix
 
     obs = Observable(PauliString(spec="Z" * n_qubits))
-    executor = _make_readout_executor(n_qubits, noise_level, shots)
 
-    # noisy baseline (no mitigation)
-    noisy_counter = _Counter(executor)
-    noisy_val = float(obs.expectation(circuit, noisy_counter).real)
+    noisy_val = float(
+        obs.expectation(
+            circuit, _make_readout_executor(n_qubits, noise_level, shots)
+        ).real
+    )
 
     icm = generate_inverse_confusion_matrix(
         n_qubits, p0=noise_level, p1=noise_level
     )
-    mit_executor = _make_readout_executor(n_qubits, noise_level, shots)
-    mit_counter = _Counter(mit_executor)
+    mit_exec = Executor(_make_readout_executor(n_qubits, noise_level, shots))
 
     t0 = time.perf_counter()
     mitigated = float(
         execute_with_rem(
             circuit,
-            mit_counter,
+            mit_exec,
             obs,
             inverse_confusion_matrix=icm,
         ).real
     )
     elapsed = time.perf_counter() - t0
 
-    return noisy_val, mitigated, elapsed, mit_counter.n
+    return noisy_val, mitigated, elapsed, mit_exec.calls_to_executor
 
 
 # ── mitiq.experimental.trex ──────────────────────────────────────────────────
@@ -210,23 +209,23 @@ def benchmark_mitiq_trex(
     seed: int = 42,
 ) -> Tuple[float, float, float, int]:
     """Benchmark mitiq.experimental.trex (twirled readout error mitigation)."""
-    from mitiq import Observable, PauliString  # isort: skip
+    from mitiq import Executor, Observable, PauliString  # isort: skip
     from mitiq.experimental.trex import execute_with_trex
 
     obs = Observable(PauliString(spec="Z" * n_qubits))
-    noisy_counter = _Counter(
-        _make_readout_executor(n_qubits, noise_level, shots)
+    noisy_val = float(
+        obs.expectation(
+            circuit, _make_readout_executor(n_qubits, noise_level, shots)
+        ).real
     )
-    noisy_val = float(obs.expectation(circuit, noisy_counter).real)
 
-    trex_executor = _make_readout_executor(n_qubits, noise_level, shots)
-    trex_counter = _Counter(trex_executor)
+    trex_exec = Executor(_make_readout_executor(n_qubits, noise_level, shots))
 
     t0 = time.perf_counter()
     mitigated = float(
         execute_with_trex(
             circuit,
-            trex_counter,
+            trex_exec,
             obs,
             num_randomizations=32,
             random_state=seed,
@@ -234,7 +233,7 @@ def benchmark_mitiq_trex(
     )
     elapsed = time.perf_counter() - t0
 
-    return noisy_val, mitigated, elapsed, trex_counter.n
+    return noisy_val, mitigated, elapsed, trex_exec.calls_to_executor
 
 
 # ── mthree ───────────────────────────────────────────────────────────────────

--- a/scripts/benchmark_pec.py
+++ b/scripts/benchmark_pec.py
@@ -64,8 +64,8 @@ from typing import Callable, Tuple
 
 import numpy as np
 
+# ── helpers ──────────────────────────────────────────────────────────────────
 
-# ── helpers ────────────────────────────────────────────────────────────────────
 
 class _Counter:
     """Callable wrapper that counts invocations."""
@@ -81,16 +81,16 @@ class _Counter:
 
 def _zn_eigenvalue(n: int) -> np.ndarray:
     """Return eigenvalues of Z⊗n: (-1)^popcount(i) for i in [0, 2^n)."""
-    return np.array([(-1) ** bin(i).count("1") for i in range(2 ** n)], dtype=float)
+    return np.array([(-1) ** bin(i).count("1") for i in range(2**n)], dtype=float)
 
 
-# ── circuit generation ─────────────────────────────────────────────────────────
+# ── circuit generation ───────────────────────────────────────────────────────
+
 
 def get_benchmark_circuit(
     circuit_type: str, n_qubits: int, depth: int, seed: int
 ) -> Tuple:
     """Return (cirq_circuit, ideal_expval) for the chosen circuit type."""
-    import cirq
     from mitiq import benchmarks
 
     if circuit_type == "ghz":
@@ -120,7 +120,8 @@ def _ideal_expval(circuit, n_qubits: int) -> float:
     import cirq
 
     clean = cirq.Circuit(
-        op for op in circuit.all_operations()
+        op
+        for op in circuit.all_operations()
         if not isinstance(op.gate, cirq.MeasurementGate)
     )
     sv = cirq.Simulator().simulate(clean).final_state_vector.flatten()
@@ -144,7 +145,8 @@ def _count_gates(circuit) -> Tuple[int, int]:
     return n1, n2
 
 
-# ── shared cirq noisy executor (density matrix) ───────────────────────────────
+# ── shared cirq noisy executor (density matrix) ──────────────────────────────
+
 
 def _make_dm_executor(n_qubits: int, noise_level: float) -> Callable:
     """
@@ -159,7 +161,8 @@ def _make_dm_executor(n_qubits: int, noise_level: float) -> Callable:
 
     def executor(circuit: cirq.Circuit) -> float:
         clean = cirq.Circuit(
-            op for op in circuit.all_operations()
+            op
+            for op in circuit.all_operations()
             if not isinstance(op.gate, cirq.MeasurementGate)
         )
         rho = sim.simulate(clean).final_density_matrix
@@ -168,7 +171,8 @@ def _make_dm_executor(n_qubits: int, noise_level: float) -> Callable:
     return executor
 
 
-# ── mitiq PEC ─────────────────────────────────────────────────────────────────
+# ── mitiq PEC ────────────────────────────────────────────────────────────────
+
 
 def benchmark_mitiq_pec(
     circuit, n_qubits: int, noise_level: float, shots: int, num_samples: int, seed: int
@@ -204,7 +208,7 @@ def benchmark_mitiq_pec(
     return noisy_val, mitigated, elapsed, counter.n
 
 
-# ── qermit PEC — in-process bug fix ───────────────────────────────────────────
+# ── qermit PEC — in-process bug fix ──────────────────────────────────────────
 #
 # Root cause (qermit 0.9.3 / pytket-qiskit 0.77):
 #   random_commuting_clifford() calls
@@ -228,6 +232,7 @@ def benchmark_mitiq_pec(
 #
 #   This patch is idempotent (guarded by _patched_by_benchmark attribute) and
 #   does not modify any installed file, so it survives pip reinstalls.
+
 
 def _patch_qermit_random_commuting_clifford() -> bool:
     """Apply in-process fix for the qermit random_commuting_clifford qubit bug.
@@ -334,7 +339,8 @@ def _patch_qermit_random_commuting_clifford() -> bool:
     return True
 
 
-# ── qermit PEC ────────────────────────────────────────────────────────────────
+# ── qermit PEC ───────────────────────────────────────────────────────────────
+
 
 def benchmark_qermit_pec(
     circuit, n_qubits: int, noise_level: float, shots: int, seed: int
@@ -360,7 +366,11 @@ def benchmark_qermit_pec(
     from pytket.utils import QubitPauliOperator
     from pytket.extensions.qiskit import AerBackend
     from qermit import (
-        AnsatzCircuit, ObservableExperiment, ObservableTracker, SymbolsDict, MitEx,
+        AnsatzCircuit,
+        ObservableExperiment,
+        ObservableTracker,
+        SymbolsDict,
+        MitEx,
     )
     from qermit.probabilistic_error_cancellation import gen_PEC_learning_based_MitEx
     from qiskit_aer.noise import NoiseModel, depolarizing_error
@@ -413,7 +423,8 @@ def benchmark_qermit_pec(
     return noisy_val, mitigated, elapsed, n_circuits
 
 
-# ── Qiskit PEC ────────────────────────────────────────────────────────────────
+# ── Qiskit PEC ───────────────────────────────────────────────────────────────
+
 
 def benchmark_qiskit_pec(
     circuit, n_qubits: int, noise_level: float, shots: int, seed: int
@@ -482,7 +493,7 @@ def benchmark_qiskit_pec(
     return noisy_val, mitigated, elapsed, shots
 
 
-# ── table output ──────────────────────────────────────────────────────────────
+# ── table output ─────────────────────────────────────────────────────────────
 
 _COL = (25, 8, 8, 10, 8, 9, 7, 5, 5)
 _HDR = (
@@ -511,7 +522,8 @@ def _row(name, ideal, noisy, mitigated, elapsed, n_circs, n1, n2):
     )
 
 
-# ── main ──────────────────────────────────────────────────────────────────────
+# ── main ─────────────────────────────────────────────────────────────────────
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -523,15 +535,22 @@ def main() -> None:
     parser.add_argument("--depth", type=int, default=4)
     parser.add_argument("--noise-level", type=float, default=0.01)
     parser.add_argument("--shots", type=int, default=8192)
-    parser.add_argument("--pec-samples", type=int, default=200,
-                        help="Quasi-probability samples for mitiq.pec (default: 200)")
+    parser.add_argument(
+        "--pec-samples",
+        type=int,
+        default=200,
+        help="Quasi-probability samples for mitiq.pec (default: 200)",
+    )
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument(
-        "--tool", choices=["all", "mitiq", "qermit", "qiskit"], default="all",
+        "--tool",
+        choices=["all", "mitiq", "qermit", "qiskit"],
+        default="all",
     )
     args = parser.parse_args()
 
     import warnings
+
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
     warnings.filterwarnings("ignore", message=".*global phase.*")
@@ -540,6 +559,7 @@ def main() -> None:
     warnings.filterwarnings("ignore", message=".*Covariance of the parameters.*")
     try:
         from scipy.optimize import OptimizeWarning
+
         warnings.filterwarnings("ignore", category=OptimizeWarning)
     except ImportError:
         pass
@@ -558,7 +578,9 @@ def main() -> None:
         args.circuit, args.n_qubits, args.depth, args.seed
     )
     n1, n2 = _count_gates(circuit)
-    print(f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}   1Q gates: {n1}   2Q gates: {n2}\n")
+    print(
+        f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}   1Q gates: {n1}   2Q gates: {n2}\n"
+    )
     print(_HDR)
     print(_SEP)
 

--- a/scripts/benchmark_pec.py
+++ b/scripts/benchmark_pec.py
@@ -7,19 +7,20 @@ GHZ circuit with synthetic depolarising gate noise.
 Usage
 -----
     python scripts/benchmark_pec.py
-    python scripts/benchmark_pec.py --circuit ghz --n-qubits 4 --noise-level 0.01
+    python scripts/benchmark_pec.py \
+        --circuit ghz --n-qubits 4 --noise-level 0.01
 
 Arguments
 ---------
     --circuit        Circuit type: ghz | qv | mirror             (default: ghz)
     --n-qubits       Number of qubits                            (default: 4)
     --depth          Circuit depth for qv / mirror               (default: 4)
-    --noise-level    Single-qubit depolarising error              (default: 0.01)
-    --shots          Shots per circuit execution                   (default: 8192)
-    --pec-samples    Number of quasi-probability samples (mitiq)  (default: 200)
-    --seed           Random seed                                   (default: 42)
+    --noise-level    Single-qubit depolarising error            (default: 0.01)
+    --shots          Shots per circuit execution              (default: 8192)
+    --pec-samples    Number of quasi-probability samples      (default: 200)
+    --seed           Random seed                              (default: 42)
     --tool           Run a specific tool: mitiq | qermit | qiskit | all
-                                                                  (default: all)
+                                                              (default: all)
 
 Dependencies
 ------------
@@ -81,7 +82,9 @@ class _Counter:
 
 def _zn_eigenvalue(n: int) -> np.ndarray:
     """Return eigenvalues of Z⊗n: (-1)^popcount(i) for i in [0, 2^n)."""
-    return np.array([(-1) ** bin(i).count("1") for i in range(2**n)], dtype=float)
+    return np.array(
+        [(-1) ** bin(i).count("1") for i in range(2**n)], dtype=float
+    )
 
 
 # ── circuit generation ───────────────────────────────────────────────────────
@@ -130,7 +133,7 @@ def _ideal_expval(circuit, n_qubits: int) -> float:
 
 
 def _count_gates(circuit) -> Tuple[int, int]:
-    """Return (n_1q_gates, n_2q_gates) for a cirq circuit, ignoring measurements."""
+    """Return (n_1q_gates, n_2q_gates), ignoring measurements."""
     import cirq
 
     n1 = n2 = 0
@@ -175,10 +178,16 @@ def _make_dm_executor(n_qubits: int, noise_level: float) -> Callable:
 
 
 def benchmark_mitiq_pec(
-    circuit, n_qubits: int, noise_level: float, shots: int, num_samples: int, seed: int
+    circuit,
+    n_qubits: int,
+    noise_level: float,
+    shots: int,
+    num_samples: int,
+    seed: int,
 ) -> Tuple[float, float, float, int]:
     """
-    Benchmark mitiq.pec using local depolarising quasi-probability representations.
+    Benchmark mitiq.pec using local depolarising
+    quasi-probability representations.
     """
     from mitiq.pec import (
         execute_with_pec,
@@ -244,21 +253,26 @@ def _patch_qermit_random_commuting_clifford() -> bool:
     if getattr(_mod.random_commuting_clifford, "_patched_by_benchmark", False):
         return False  # already applied this session
 
-    # ── imports needed by the patched function ────────────────────────────────
+    # ── imports needed by the patched function ──────────────────────────────
     from typing import List, cast
+
     from pytket.circuit import CircBox, Node
     from pytket.passes import DecomposeBoxes
+    from pytket.pauli import QubitPauliString
     from pytket.placement import place_with_map
     from pytket.predicates import CliffordCircuitPredicate
-    from pytket.utils import get_pauli_expectation_value
-    from pytket.pauli import QubitPauliString
     from pytket.unit_id import Qubit
+    from pytket.utils import get_pauli_expectation_value
 
     # Keep a reference to the module-level random_clifford_circ helper
     _random_clifford_circ = _mod.random_clifford_circ
 
     def _fixed_random_commuting_clifford(
-        circ, qps, simulator_backend, max_count: int = 1000, n_shots: int = 1000
+        circ,
+        qps,
+        simulator_backend,
+        max_count: int = 1000,
+        n_shots: int = 1000,
     ):
         """Fixed random_commuting_clifford: uses a copy for place_with_map.
 
@@ -296,9 +310,11 @@ def _patch_qermit_random_commuting_clifford() -> bool:
             for x in qps.map:
                 new_qps_qbs.append(n_q_map[x])
                 qps_paulis.append(qps.map[x])
-            new_qps = QubitPauliString(cast(List[Qubit], new_qps_qbs), qps_paulis)
+            new_qps = QubitPauliString(
+                cast(List[Qubit], new_qps_qbs), qps_paulis
+            )
 
-            # ── THE FIX ───────────────────────────────────────────────────────
+            # ── THE FIX ─────────────────────────────────────────────────────
             # Work on a copy so that place_with_map does not rename
             # rand_cliff_circ's qubits in-place (node[i] → q[i]).
             eval_circ = rand_cliff_circ.copy()
@@ -309,13 +325,17 @@ def _patch_qermit_random_commuting_clifford() -> bool:
                 expect_val = get_pauli_expectation_value(
                     eval_circ, new_qps, simulator_backend
                 )
-            elif simulator_backend.supports_shots or simulator_backend.supports_counts:
+            elif (
+                simulator_backend.supports_shots
+                or simulator_backend.supports_counts
+            ):
                 expect_val = get_pauli_expectation_value(
                     eval_circ, new_qps, simulator_backend, n_shots=n_shots
                 )
             else:
                 raise RuntimeError(
-                    "The simulator backend does not support state, shots or counts."
+                    "The simulator backend does not support"
+                    " state, shots or counts."
                 )
 
             count += 1
@@ -327,9 +347,9 @@ def _patch_qermit_random_commuting_clifford() -> bool:
 
         if not CliffordCircuitPredicate().verify(rand_cliff_circ):
             raise RuntimeError(
-                "The resulting circuit is not a Clifford circuit. This could be "
-                "because not all Computing gates in the original circuit were "
-                "labelled as such."
+                "The resulting circuit is not a Clifford circuit."
+                " This could be because not all Computing gates"
+                " in the original circuit were labelled as such."
             )
 
         return rand_cliff_circ
@@ -355,27 +375,31 @@ def benchmark_qermit_pec(
     compile both backends to the same ``node[i]`` qubit register.
 
     Applies _patch_qermit_random_commuting_clifford() before running to fix
-    the in-place qubit-renaming bug present in qermit 0.9.3 / pytket-qiskit 0.77.
+    the in-place qubit-renaming bug present in
+    qermit 0.9.3 / pytket-qiskit 0.77.
     The patch is idempotent and does not modify any installed file.
     """
     # Apply in-process fix for the node[i]/q[i] qubit-mapping bug.
     _patch_qermit_random_commuting_clifford()
 
-    from pytket import Circuit as TKCircuit, Qubit
+    from pytket import Circuit as TKCircuit
+    from pytket import Qubit
+    from pytket.extensions.qiskit import AerBackend
     from pytket.pauli import Pauli, QubitPauliString
     from pytket.utils import QubitPauliOperator
-    from pytket.extensions.qiskit import AerBackend
     from qermit import (
         AnsatzCircuit,
+        MitEx,
         ObservableExperiment,
         ObservableTracker,
         SymbolsDict,
-        MitEx,
     )
-    from qermit.probabilistic_error_cancellation import gen_PEC_learning_based_MitEx
+    from qermit.probabilistic_error_cancellation import (
+        gen_PEC_learning_based_MitEx,
+    )
     from qiskit_aer.noise import NoiseModel, depolarizing_error
 
-    # ── pytket GHZ circuit ────────────────────────────────────────────────────
+    # ── pytket GHZ circuit ──────────────────────────────────────────────────
     tk_circuit = TKCircuit(n_qubits)
     tk_circuit.H(0)
     for i in range(n_qubits - 1):
@@ -394,16 +418,20 @@ def benchmark_qermit_pec(
         return AerBackend(noise_model=nm)
 
     noisy_backend = _make_aer_backend(noise_level, noise_level * 10)
-    # Epsilon noise forces AerBackend to compile to node[i] qubits, matching noisy_backend
+    # Epsilon noise → node[i] qubits, matching noisy_backend
     ideal_backend = _make_aer_backend(1e-9, 1e-9)
 
     # Observable on LOGICAL q[i] qubits so qermit PEC can remap
     q_qubits = [Qubit(i) for i in range(n_qubits)]
     pauli_str = QubitPauliString(q_qubits, [Pauli.Z] * n_qubits)
     observable = QubitPauliOperator({pauli_str: 1.0})
-    ansatz = AnsatzCircuit(Circuit=tk_circuit, Shots=shots, SymbolsDict=SymbolsDict())
+    ansatz = AnsatzCircuit(
+        Circuit=tk_circuit, Shots=shots, SymbolsDict=SymbolsDict()
+    )
     obs_tracker = ObservableTracker(qubit_pauli_operator=observable)
-    exp = ObservableExperiment(AnsatzCircuit=ansatz, ObservableTracker=obs_tracker)
+    exp = ObservableExperiment(
+        AnsatzCircuit=ansatz, ObservableTracker=obs_tracker
+    )
 
     noisy_val = float(MitEx(noisy_backend).run([exp])[0][pauli_str])
 
@@ -434,18 +462,19 @@ def benchmark_qiskit_pec(
 
     Requires IBM Quantum cloud credentials:
         from qiskit_ibm_runtime import QiskitRuntimeService
-        QiskitRuntimeService.save_account(channel="ibm_quantum", token="<API_TOKEN>")
+        QiskitRuntimeService.save_account(
+            channel="ibm_quantum", token="<API_TOKEN>")
 
     Without credentials this function raises RuntimeError, which is caught at
     the call site and printed as SKIP.
     """
     from qiskit import QuantumCircuit, transpile
     from qiskit.quantum_info import SparsePauliOp
-    from qiskit_ibm_runtime import QiskitRuntimeService, EstimatorV2
+    from qiskit_ibm_runtime import EstimatorV2, QiskitRuntimeService
     from qiskit_ibm_runtime.noise_learner import NoiseLearner
     from qiskit_ibm_runtime.options import NoiseLearnerOptions
 
-    # ── connect to IBM Quantum ────────────────────────────────────────────────
+    # ── connect to IBM Quantum ──────────────────────────────────────────────
     try:
         service = QiskitRuntimeService()
     except Exception as exc:
@@ -469,7 +498,7 @@ def benchmark_qiskit_pec(
     obs_raw = SparsePauliOp("Z" * n_qubits)
     obs_isa = obs_raw.apply_layout(qc_isa.layout)
 
-    # ── learn layer noise ─────────────────────────────────────────────────────
+    # ── learn layer noise ───────────────────────────────────────────────────
     nl_options = NoiseLearnerOptions()
     nl_options.shots_per_randomization = shots
     noise_learner = NoiseLearner(mode=backend, options=nl_options)
@@ -530,7 +559,9 @@ def main() -> None:
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("--circuit", choices=["ghz", "qv", "mirror"], default="ghz")
+    parser.add_argument(
+        "--circuit", choices=["ghz", "qv", "mirror"], default="ghz"
+    )
     parser.add_argument("--n-qubits", type=int, default=4)
     parser.add_argument("--depth", type=int, default=4)
     parser.add_argument("--noise-level", type=float, default=0.01)
@@ -556,7 +587,9 @@ def main() -> None:
     warnings.filterwarnings("ignore", message=".*global phase.*")
     warnings.filterwarnings("ignore", message=".*IBMFractional.*")
     warnings.filterwarnings("ignore", message=".*no effect in local.*")
-    warnings.filterwarnings("ignore", message=".*Covariance of the parameters.*")
+    warnings.filterwarnings(
+        "ignore", message=".*Covariance of the parameters.*"
+    )
     try:
         from scipy.optimize import OptimizeWarning
 
@@ -568,7 +601,8 @@ def main() -> None:
 
     print(
         f"\nPEC Benchmark\n"
-        f"circuit={args.circuit}  n_qubits={args.n_qubits}  depth={args.depth}  "
+        f"circuit={args.circuit}  n_qubits={args.n_qubits}"
+        f"  depth={args.depth}  "
         f"noise_level={args.noise_level}  shots={args.shots}  "
         f"pec_samples={args.pec_samples}"
     )
@@ -579,7 +613,8 @@ def main() -> None:
     )
     n1, n2 = _count_gates(circuit)
     print(
-        f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}   1Q gates: {n1}   2Q gates: {n2}\n"
+        f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}"
+        f"   1Q gates: {n1}   2Q gates: {n2}\n"
     )
     print(_HDR)
     print(_SEP)
@@ -610,7 +645,16 @@ def main() -> None:
                 shots=args.shots,
                 **extra,
             )
-            _row(display_name, ideal, noisy, mitigated, elapsed, n_circs, n1, n2)
+            _row(
+                display_name,
+                ideal,
+                noisy,
+                mitigated,
+                elapsed,
+                n_circs,
+                n1,
+                n2,
+            )
         except ImportError as exc:
             print(f"{display_name:<{_COL[0]}} SKIP (missing dep): {exc}")
         except RuntimeError as exc:
@@ -625,13 +669,15 @@ def main() -> None:
 
     print(_SEP)
     print(
-        "\nImprov = |noisy − ideal| / |mitigated − ideal|  "
-        "(>1 means mitigation helped)"
+        "\nImprov = |noisy − ideal| / |mitigated − ideal|"
+        "  (>1 means mitigation helped)"
     )
     print(
         "Qiskit PEC requires IBM Quantum cloud credentials (NoiseLearner).\n"
-        "qermit PEC: in-process patch applied for qermit 0.9.3 / pytket-qiskit 0.77 "
-        "qubit-mapping bug (see _patch_qermit_random_commuting_clifford)."
+        "qermit PEC: in-process patch applied for"
+        " qermit 0.9.3 / pytket-qiskit 0.77 "
+        "qubit-mapping bug"
+        " (see _patch_qermit_random_commuting_clifford)."
     )
 
 

--- a/scripts/benchmark_pec.py
+++ b/scripts/benchmark_pec.py
@@ -23,8 +23,7 @@ Arguments
 
 Dependencies
 ------------
-    pip install "mitiq>=1.0.0" "qermit>=0.9.0" pytket-qiskit qiskit-aer
-    pip install qiskit-ibm-runtime  # for Qiskit PEC (requires IBM Quantum account)
+    pip install -r scripts/requirements-benchmark.txt
 
 Output
 ------
@@ -205,6 +204,136 @@ def benchmark_mitiq_pec(
     return noisy_val, mitigated, elapsed, counter.n
 
 
+# ── qermit PEC — in-process bug fix ───────────────────────────────────────────
+#
+# Root cause (qermit 0.9.3 / pytket-qiskit 0.77):
+#   random_commuting_clifford() calls
+#       place_with_map(rand_cliff_circ, n_q_map)
+#   which renames the circuit's qubits in-place: node[i] → q[i].
+#   The returned Clifford circuit therefore has q[i] qubits, but the
+#   ObservableTracker was already relabelled to node[i] by the outer
+#   gen_initial_compilation_task.  The mismatch triggers:
+#       "ObservableTracker qubits {node[...]} are not found in circuit."
+#
+# Fix strategy — approach 3 (explicit qubit mapping via in-process patch):
+#   Replace random_commuting_clifford in the module's __dict__ with a
+#   corrected version that works on eval_circ = rand_cliff_circ.copy()
+#   before calling place_with_map, leaving the original circuit's qubit
+#   register intact.
+#
+#   Because the call site inside gen_get_clifford_training_set uses a bare
+#   name (not a module-qualified reference), replacing the name in the
+#   module's namespace is sufficient — Python's bare-name lookup goes through
+#   the module __dict__ at call time.
+#
+#   This patch is idempotent (guarded by _patched_by_benchmark attribute) and
+#   does not modify any installed file, so it survives pip reinstalls.
+
+def _patch_qermit_random_commuting_clifford() -> bool:
+    """Apply in-process fix for the qermit random_commuting_clifford qubit bug.
+
+    Returns True if the patch was applied, False if it was already in place.
+    """
+    import qermit.probabilistic_error_cancellation.pec_learning_based as _mod
+
+    if getattr(_mod.random_commuting_clifford, "_patched_by_benchmark", False):
+        return False  # already applied this session
+
+    # ── imports needed by the patched function ────────────────────────────────
+    from typing import List, cast
+    from pytket.circuit import CircBox, Node
+    from pytket.passes import DecomposeBoxes
+    from pytket.placement import place_with_map
+    from pytket.predicates import CliffordCircuitPredicate
+    from pytket.utils import get_pauli_expectation_value
+    from pytket.pauli import QubitPauliString
+    from pytket.unit_id import Qubit
+
+    # Keep a reference to the module-level random_clifford_circ helper
+    _random_clifford_circ = _mod.random_clifford_circ
+
+    def _fixed_random_commuting_clifford(
+        circ, qps, simulator_backend, max_count: int = 1000, n_shots: int = 1000
+    ):
+        """Fixed random_commuting_clifford: uses a copy for place_with_map.
+
+        Identical to the original except that place_with_map is applied to
+        eval_circ = rand_cliff_circ.copy() so the returned circuit retains
+        its original node[i] qubit register.
+        """
+        comp_opgroup_list = [
+            i["opgroup"]
+            for i in circ.to_dict()["commands"]
+            if "Computing" in i["opgroup"]
+        ]
+        if not comp_opgroup_list:
+            raise ValueError(
+                "This circuit contains no computing gates (i.e. single qubit "
+                "gates). Training is not possible."
+            )
+
+        count = 0
+        expect_val = complex(0)
+        while round(abs(expect_val)) == 0:
+            rand_cliff_circ = circ.copy()
+            rand_cliff_list = [
+                CircBox(_random_clifford_circ(1)) for _ in comp_opgroup_list
+            ]
+            for opgroup, rand_cliff in zip(comp_opgroup_list, rand_cliff_list):
+                rand_cliff_circ.substitute_named(rand_cliff, opgroup)
+            DecomposeBoxes().apply(rand_cliff_circ)
+
+            cc_qns = rand_cliff_circ.qubits
+            n_q_map = {cc_qns[i]: Node("q", i) for i in range(len(cc_qns))}
+
+            new_qps_qbs: List[Qubit] = []
+            qps_paulis = []
+            for x in qps.map:
+                new_qps_qbs.append(n_q_map[x])
+                qps_paulis.append(qps.map[x])
+            new_qps = QubitPauliString(cast(List[Qubit], new_qps_qbs), qps_paulis)
+
+            # ── THE FIX ───────────────────────────────────────────────────────
+            # Work on a copy so that place_with_map does not rename
+            # rand_cliff_circ's qubits in-place (node[i] → q[i]).
+            eval_circ = rand_cliff_circ.copy()
+            place_with_map(eval_circ, n_q_map)
+            # ─────────────────────────────────────────────────────────────────
+
+            if simulator_backend.supports_state:
+                expect_val = get_pauli_expectation_value(
+                    eval_circ, new_qps, simulator_backend
+                )
+            elif simulator_backend.supports_shots or simulator_backend.supports_counts:
+                expect_val = get_pauli_expectation_value(
+                    eval_circ, new_qps, simulator_backend, n_shots=n_shots
+                )
+            else:
+                raise RuntimeError(
+                    "The simulator backend does not support state, shots or counts."
+                )
+
+            count += 1
+            if count == max_count:
+                raise RuntimeError(
+                    "Could not find circuit with non-zero expectation. "
+                    "It's possible there are none."
+                )
+
+        if not CliffordCircuitPredicate().verify(rand_cliff_circ):
+            raise RuntimeError(
+                "The resulting circuit is not a Clifford circuit. This could be "
+                "because not all Computing gates in the original circuit were "
+                "labelled as such."
+            )
+
+        return rand_cliff_circ
+
+    _fixed_random_commuting_clifford._patched_by_benchmark = True  # type: ignore[attr-defined]
+    _mod.random_commuting_clifford = _fixed_random_commuting_clifford
+    return True
+
+
 # ── qermit PEC ────────────────────────────────────────────────────────────────
 
 def benchmark_qermit_pec(
@@ -219,9 +348,13 @@ def benchmark_qermit_pec(
     giving the ideal backend an epsilon-small noise model, forcing pytket to
     compile both backends to the same ``node[i]`` qubit register.
 
-    NOTE: This approach may fail on some qermit/pytket-qiskit version
-    combinations — the function is wrapped in a try/except at call time.
+    Applies _patch_qermit_random_commuting_clifford() before running to fix
+    the in-place qubit-renaming bug present in qermit 0.9.3 / pytket-qiskit 0.77.
+    The patch is idempotent and does not modify any installed file.
     """
+    # Apply in-process fix for the node[i]/q[i] qubit-mapping bug.
+    _patch_qermit_random_commuting_clifford()
+
     from pytket import Circuit as TKCircuit, Qubit
     from pytket.pauli import Pauli, QubitPauliString
     from pytket.utils import QubitPauliOperator
@@ -254,7 +387,7 @@ def benchmark_qermit_pec(
     # Epsilon noise forces AerBackend to compile to node[i] qubits, matching noisy_backend
     ideal_backend = _make_aer_backend(1e-9, 1e-9)
 
-    # Observable on LOGICAL q[i] qubits so qermit ZNE/PEC can remap
+    # Observable on LOGICAL q[i] qubits so qermit PEC can remap
     q_qubits = [Qubit(i) for i in range(n_qubits)]
     pauli_str = QubitPauliString(q_qubits, [Pauli.Z] * n_qubits)
     observable = QubitPauliOperator({pauli_str: 1.0})
@@ -270,19 +403,9 @@ def benchmark_qermit_pec(
         num_cliff=5,
         optimisation_level=0,
     )
-    try:
-        t0 = time.perf_counter()
-        pec_result = pec.run([exp])
-        elapsed = time.perf_counter() - t0
-    except Exception as exc:
-        msg = str(exc)
-        if "not found in circuit" in msg or "KeyError" in msg:
-            raise RuntimeError(
-                "qermit PEC qubit-mapping incompatibility between noisy and ideal "
-                "backends (known issue with pytket-qiskit). "
-                "See https://github.com/CQCL/Qermit/issues for updates."
-            ) from exc
-        raise
+    t0 = time.perf_counter()
+    pec_result = pec.run([exp])
+    elapsed = time.perf_counter() - t0
 
     mitigated = float(pec_result[0][pauli_str])
     # num_cliff random Clifford circuits per main circuit (approximate)
@@ -485,8 +608,8 @@ def main() -> None:
     )
     print(
         "Qiskit PEC requires IBM Quantum cloud credentials (NoiseLearner).\n"
-        "qermit PEC may fail with some pytket-qiskit versions; "
-        "see SKIP/ERROR message for details."
+        "qermit PEC: in-process patch applied for qermit 0.9.3 / pytket-qiskit 0.77 "
+        "qubit-mapping bug (see _patch_qermit_random_commuting_clifford)."
     )
 
 

--- a/scripts/benchmark_pec.py
+++ b/scripts/benchmark_pec.py
@@ -6,8 +6,9 @@ GHZ circuit with synthetic depolarising gate noise.
 
 Usage
 -----
-    python scripts/benchmark_pec.py               # runs ghz, qv, mirror
-    python scripts/benchmark_pec.py --circuit ghz # runs one circuit
+    python scripts/benchmark_pec.py           # local only, Qiskit PEC skipped
+    python scripts/benchmark_pec.py --circuit ghz # one circuit, local only
+    python scripts/benchmark_pec.py --ibm-account # adds real-HW row for GHZ
 
 Arguments
 ---------
@@ -20,10 +21,14 @@ Arguments
     --seed           Random seed                              (default: 42)
     --tool           Run a specific tool: mitiq | qermit | qiskit | all
                                                               (default: all)
+    --ibm-account    Connect to IBM Quantum and run Qiskit PEC on real
+                     hardware (GHZ only). Reads IBM_QUANTUM_TOKEN env var.
+                                                              (default: off)
 
 Dependencies
 ------------
-    pip install -r scripts/requirements-benchmark.txt
+    pip install -e ".[benchmarking]"
+    IBM_QUANTUM_TOKEN env var: required only with --ibm-account.
 
 Output
 ------
@@ -51,14 +56,14 @@ Notes
                 script handles this gracefully with a SKIP message.
 
     Qiskit PEC: qiskit-ibm-runtime EstimatorV2 with pec_mitigation=True.
-                Requires IBM Quantum cloud credentials.  Without credentials
-                the row is marked SKIP with a diagnostic message.
-                To configure: QiskitRuntimeService.save_account(token=...).
+                Only runs when --ibm-account is passed; skipped otherwise.
+                GHZ only — NoiseLearner cost scales badly with circuit depth.
 """
 
 from __future__ import annotations
 
 import argparse
+import math
 import time
 from typing import Callable, Tuple
 
@@ -68,7 +73,6 @@ from benchmark_utils import (
     _HDR,
     _SEP,
     _count_gates,
-    _Counter,
     _row,
     _zn_eigenvalue,
 )
@@ -163,6 +167,7 @@ def benchmark_mitiq_pec(
     Benchmark mitiq.pec using local depolarising
     quasi-probability representations.
     """
+    from mitiq import Executor
     from mitiq.pec import (
         execute_with_pec,
         represent_operations_in_circuit_with_local_depolarizing_noise,
@@ -175,8 +180,7 @@ def benchmark_mitiq_pec(
         circuit, noise_level
     )
 
-    pec_exec = _make_dm_executor(n_qubits, noise_level)
-    counter = _Counter(pec_exec)
+    counter = Executor(_make_dm_executor(n_qubits, noise_level))
 
     t0 = time.perf_counter()
     mitigated = execute_with_pec(
@@ -188,7 +192,7 @@ def benchmark_mitiq_pec(
     )
     elapsed = time.perf_counter() - t0
 
-    return noisy_val, mitigated, elapsed, counter.n
+    return noisy_val, mitigated, elapsed, counter.calls_to_executor
 
 
 # ── qermit PEC — in-process bug fix ──────────────────────────────────────────
@@ -426,18 +430,23 @@ def benchmark_qermit_pec(
 
 
 def benchmark_qiskit_pec(
-    circuit, n_qubits: int, noise_level: float, shots: int, seed: int
-) -> Tuple[float, float, float, int]:
+    circuit,
+    n_qubits: int,
+    noise_level: float,
+    shots: int,
+    seed: int,
+    backend=None,
+) -> Tuple[float, float, float, int, str, float]:
     """
     Benchmark qiskit-ibm-runtime PEC via NoiseLearner + EstimatorV2.
 
-    Requires IBM Quantum cloud credentials:
-        from qiskit_ibm_runtime import QiskitRuntimeService
-        QiskitRuntimeService.save_account(
-            channel="ibm_quantum", token="<API_TOKEN>")
+    When ``backend`` is None the function connects to IBM Quantum itself
+    (credentials must already be saved via
+    QiskitRuntimeService.save_account).  Pass a pre-connected backend
+    (obtained in main() via --ibm-account) to skip the connection step.
 
-    Without credentials this function raises RuntimeError, which is caught at
-    the call site and printed as SKIP.
+    Returns (noisy_val, mitigated, elapsed, n_circs, job_id, qpu_time_s).
+    qpu_time_s is NaN when the backend does not expose usage metrics.
     """
     import cirq
     from qiskit import QuantumCircuit, transpile
@@ -446,19 +455,19 @@ def benchmark_qiskit_pec(
     from qiskit_ibm_runtime.noise_learner import NoiseLearner
     from qiskit_ibm_runtime.options import NoiseLearnerOptions
 
-    # ── connect to IBM Quantum ──────────────────────────────────────────────
-    try:
-        service = QiskitRuntimeService()
-    except Exception as exc:
-        raise RuntimeError(
-            "IBM Quantum credentials not configured. "
-            "Run QiskitRuntimeService.save_account(token=...) first. "
-            f"Original error: {exc}"
+    if backend is None:
+        # ── connect to IBM Quantum ────────────────────────────────────────
+        try:
+            service = QiskitRuntimeService()
+        except Exception as exc:
+            raise RuntimeError(
+                "IBM Quantum credentials not configured. "
+                "Run QiskitRuntimeService.save_account(token=...) first."
+                f"  Original error: {exc}"
+            )
+        backend = service.least_busy(
+            operational=True, simulator=False, min_num_qubits=n_qubits
         )
-
-    backend = service.least_busy(
-        operational=True, simulator=False, min_num_qubits=n_qubits
-    )
 
     # Convert mitiq benchmarks circuit to Qiskit via QASM
     clean = cirq.Circuit(
@@ -491,16 +500,26 @@ def benchmark_qiskit_pec(
     est_pec.options.resilience.layer_noise_model = learned_noise
     est_pec.options.default_shots = shots
     t0 = time.perf_counter()
-    mitigated = float(est_pec.run([(qc_isa, obs_isa)]).result()[0].data.evs)
+    pec_job = est_pec.run([(qc_isa, obs_isa)])
+    pec_result = pec_job.result()
     elapsed = time.perf_counter() - t0
+    mitigated = float(pec_result[0].data.evs)
 
-    return noisy_val, mitigated, elapsed, shots
+    job_id = pec_job.job_id()
+    try:
+        qpu_time = pec_job.metrics()["usage"]["quantum_seconds"]
+    except Exception:
+        qpu_time = float("nan")
+
+    # IBM cloud PEC overhead isn't exposed via the API; count the two
+    # submitted jobs (noisy baseline + PEC mitigated).
+    return noisy_val, mitigated, elapsed, 2, job_id, qpu_time
 
 
 # ── per-circuit runner ───────────────────────────────────────────────────────
 
 
-def _run_circuit(circuit_type: str, args) -> None:
+def _run_circuit(circuit_type: str, args, backend=None) -> None:
     """Run PEC benchmark for one circuit type and print its table."""
     circuit, ideal = get_benchmark_circuit(
         circuit_type, args.n_qubits, args.depth, args.seed
@@ -546,15 +565,23 @@ def _run_circuit(circuit_type: str, args) -> None:
                 " — use --circuit ghz"
             )
             continue
-        # Qiskit PEC (cloud) requires credentials; no point submitting
-        # cloud jobs for QV/mirror circuits.  GHZ only.
+        # Qiskit PEC: GHZ only — NoiseLearner cost scales badly with depth.
         if key == "qiskit" and circuit_type != "ghz":
             print(
-                f"{'Qiskit PEC (cloud)':<{_COL[0]}} NOTE: Qiskit PEC"
+                f"{'Qiskit PEC':<{_COL[0]}} NOTE: Qiskit PEC"
                 " skipped for deep circuits (QV/mirror)"
                 " — use --circuit ghz"
             )
             continue
+        # Qiskit PEC requires --ibm-account; skip clearly when not set.
+        if key == "qiskit" and backend is None:
+            print(
+                f"{'Qiskit PEC':<{_COL[0]}} SKIP: Qiskit PEC requires"
+                " --ibm-account flag with IBM_QUANTUM_TOKEN set."
+            )
+            continue
+        if key == "qiskit":
+            display_name = "Qiskit PEC (real HW)"
         try:
             extra: dict = {}
             if key == "mitiq":
@@ -562,26 +589,47 @@ def _run_circuit(circuit_type: str, args) -> None:
                     "num_samples": args.pec_samples,
                     "seed": args.seed,
                 }
-            elif key in ("qermit", "qiskit"):
+            elif key == "qermit":
                 extra = {"seed": args.seed}
+            elif key == "qiskit":
+                extra = {"seed": args.seed, "backend": backend}
 
-            noisy, mitigated, elapsed, n_circs = fn(
+            result = fn(
                 circuit=circuit,
                 n_qubits=args.n_qubits,
                 noise_level=args.noise_level,
                 shots=args.shots,
                 **extra,
             )
-            _row(
-                display_name,
-                ideal,
-                noisy,
-                mitigated,
-                elapsed,
-                n_circs,
-                n1,
-                n2,
-            )
+
+            if key == "qiskit":
+                noisy, mitigated, elapsed, n_circs, job_id, qpu_time = result
+                _row(
+                    display_name,
+                    ideal,
+                    noisy,
+                    mitigated,
+                    elapsed,
+                    n_circs,
+                    n1,
+                    n2,
+                )
+                qpu_str = (
+                    f"{qpu_time:.1f}s" if not math.isnan(qpu_time) else "N/A"
+                )
+                print(f"  job_id={job_id}  QPU time: {qpu_str}")
+            else:
+                noisy, mitigated, elapsed, n_circs = result
+                _row(
+                    display_name,
+                    ideal,
+                    noisy,
+                    mitigated,
+                    elapsed,
+                    n_circs,
+                    n1,
+                    n2,
+                )
         except ImportError as exc:
             print(f"{display_name:<{_COL[0]}} SKIP (missing dep): {exc}")
         except RuntimeError as exc:
@@ -627,6 +675,15 @@ def main() -> None:
         choices=["all", "mitiq", "qermit", "qiskit"],
         default="all",
     )
+    parser.add_argument(
+        "--ibm-account",
+        action="store_true",
+        default=False,
+        help=(
+            "Connect to IBM Quantum and run Qiskit PEC on real hardware "
+            "(GHZ only). Requires IBM_QUANTUM_TOKEN env var."
+        ),
+    )
     args = parser.parse_args()
 
     import warnings
@@ -646,6 +703,26 @@ def main() -> None:
     except ImportError:
         pass
 
+    backend = None
+    if args.ibm_account:
+        import os
+
+        token = os.environ.get("IBM_QUANTUM_TOKEN")
+        if not token:
+            raise SystemExit(
+                "IBM_QUANTUM_TOKEN environment variable required when "
+                "--ibm-account is set."
+            )
+        from qiskit_ibm_runtime import QiskitRuntimeService
+
+        QiskitRuntimeService.save_account(token=token, overwrite=True)
+        service = QiskitRuntimeService()
+        backend = service.least_busy(
+            operational=True,
+            simulator=False,
+            min_num_qubits=args.n_qubits,
+        )
+
     np.random.seed(args.seed)
 
     circuit_types = (
@@ -662,14 +739,14 @@ def main() -> None:
     print("=" * len(_HDR))
 
     for ct in circuit_types:
-        _run_circuit(ct, args)
+        _run_circuit(ct, args, backend=backend)
 
     print(
         "\nImprov = |noisy − ideal| / |mitigated − ideal|"
         "  (>1 means mitigation helped)"
     )
     print(
-        "Qiskit PEC requires IBM Quantum cloud credentials (NoiseLearner).\n"
+        "Qiskit PEC requires --ibm-account with IBM_QUANTUM_TOKEN set.\n"
         "qermit PEC: in-process patch applied for"
         " qermit 0.9.3 / pytket-qiskit 0.77 "
         "qubit-mapping bug"

--- a/scripts/benchmark_pec.py
+++ b/scripts/benchmark_pec.py
@@ -1,0 +1,494 @@
+"""
+Probabilistic Error Cancellation (PEC) Benchmark
+=================================================
+Compare ``mitiq.pec``, ``qermit`` PEC, and ``qiskit-ibm-runtime`` PEC on a
+GHZ circuit with synthetic depolarising gate noise.
+
+Usage
+-----
+    python scripts/benchmark_pec.py
+    python scripts/benchmark_pec.py --circuit ghz --n-qubits 4 --noise-level 0.01
+
+Arguments
+---------
+    --circuit        Circuit type: ghz | qv | mirror             (default: ghz)
+    --n-qubits       Number of qubits                            (default: 4)
+    --depth          Circuit depth for qv / mirror               (default: 4)
+    --noise-level    Single-qubit depolarising error              (default: 0.01)
+    --shots          Shots per circuit execution                   (default: 8192)
+    --pec-samples    Number of quasi-probability samples (mitiq)  (default: 200)
+    --seed           Random seed                                   (default: 42)
+    --tool           Run a specific tool: mitiq | qermit | qiskit | all
+                                                                  (default: all)
+
+Dependencies
+------------
+    pip install "mitiq>=1.0.0" "qermit>=0.9.0" pytket-qiskit qiskit-aer
+    pip install qiskit-ibm-runtime  # for Qiskit PEC (requires IBM Quantum account)
+
+Output
+------
+    Prints a table with:
+      - Ideal, noisy, and mitigated expectation values (Z⊗n)
+      - Error mitigation improvement factor
+      - Wall-clock runtime
+      - Circuit execution count
+      - Single- and two-qubit gate counts
+
+Notes
+-----
+    The observable is Z⊗n (tensor product of Pauli Z on all qubits).
+    For a GHZ state with even n, the ideal expectation value is +1.0.
+
+    Noise model: single-qubit depolarising ``noise_level``,
+    two-qubit depolarising ``10 × noise_level``.
+
+    mitiq PEC: represent_operations_in_circuit_with_local_depolarizing_noise,
+               DensityMatrixSimulator executor, num_samples=pec_samples.
+
+    qermit PEC: gen_PEC_learning_based_MitEx with a matching-architecture ideal
+                backend (epsilon noise).  NOTE: may fail on some qermit/pytket
+                version combinations due to internal qubit relabelling — the
+                script handles this gracefully with a SKIP message.
+
+    Qiskit PEC: qiskit-ibm-runtime EstimatorV2 with pec_mitigation=True.
+                Requires IBM Quantum cloud credentials.  Without credentials
+                the row is marked SKIP with a diagnostic message.
+                To configure: QiskitRuntimeService.save_account(token=...).
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from typing import Callable, Tuple
+
+import numpy as np
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+class _Counter:
+    """Callable wrapper that counts invocations."""
+
+    def __init__(self, fn: Callable) -> None:
+        self._fn = fn
+        self.n = 0
+
+    def __call__(self, *args, **kwargs):
+        self.n += 1
+        return self._fn(*args, **kwargs)
+
+
+def _zn_eigenvalue(n: int) -> np.ndarray:
+    """Return eigenvalues of Z⊗n: (-1)^popcount(i) for i in [0, 2^n)."""
+    return np.array([(-1) ** bin(i).count("1") for i in range(2 ** n)], dtype=float)
+
+
+# ── circuit generation ─────────────────────────────────────────────────────────
+
+def get_benchmark_circuit(
+    circuit_type: str, n_qubits: int, depth: int, seed: int
+) -> Tuple:
+    """Return (cirq_circuit, ideal_expval) for the chosen circuit type."""
+    import cirq
+    from mitiq import benchmarks
+
+    if circuit_type == "ghz":
+        circuit = benchmarks.generate_ghz_circuit(n_qubits)
+    elif circuit_type == "qv":
+        circuit, _ = benchmarks.generate_quantum_volume_circuit(
+            n_qubits, depth, decompose=True, seed=seed
+        )
+    elif circuit_type == "mirror":
+        import networkx as nx
+
+        circuit, _ = benchmarks.generate_mirror_circuit(
+            nlayers=depth,
+            two_qubit_gate_prob=0.5,
+            connectivity_graph=nx.path_graph(n_qubits),
+            seed=seed,
+        )
+    else:
+        raise ValueError(f"Unknown circuit type: {circuit_type!r}")
+
+    ideal = _ideal_expval(circuit, n_qubits)
+    return circuit, ideal
+
+
+def _ideal_expval(circuit, n_qubits: int) -> float:
+    """Compute ideal ⟨Z⊗n⟩ via noiseless cirq statevector simulation."""
+    import cirq
+
+    clean = cirq.Circuit(
+        op for op in circuit.all_operations()
+        if not isinstance(op.gate, cirq.MeasurementGate)
+    )
+    sv = cirq.Simulator().simulate(clean).final_state_vector.flatten()
+    ev = _zn_eigenvalue(n_qubits)
+    return float(np.real(np.dot(ev, np.abs(sv) ** 2)))
+
+
+def _count_gates(circuit) -> Tuple[int, int]:
+    """Return (n_1q_gates, n_2q_gates) for a cirq circuit, ignoring measurements."""
+    import cirq
+
+    n1 = n2 = 0
+    for op in circuit.all_operations():
+        if isinstance(op.gate, cirq.MeasurementGate):
+            continue
+        nq = len(op.qubits)
+        if nq == 1:
+            n1 += 1
+        elif nq == 2:
+            n2 += 1
+    return n1, n2
+
+
+# ── shared cirq noisy executor (density matrix) ───────────────────────────────
+
+def _make_dm_executor(n_qubits: int, noise_level: float) -> Callable:
+    """
+    Cirq DensityMatrixSimulator executor returning ⟨Z⊗n⟩ as a float.
+    Two-qubit gates get 10× the single-qubit error rate.
+    """
+    import cirq
+
+    ev = _zn_eigenvalue(n_qubits)
+    noise = cirq.ConstantQubitNoiseModel(cirq.depolarize(noise_level))
+    sim = cirq.DensityMatrixSimulator(noise=noise)
+
+    def executor(circuit: cirq.Circuit) -> float:
+        clean = cirq.Circuit(
+            op for op in circuit.all_operations()
+            if not isinstance(op.gate, cirq.MeasurementGate)
+        )
+        rho = sim.simulate(clean).final_density_matrix
+        return float(np.real(np.sum(np.diag(rho) * ev)))
+
+    return executor
+
+
+# ── mitiq PEC ─────────────────────────────────────────────────────────────────
+
+def benchmark_mitiq_pec(
+    circuit, n_qubits: int, noise_level: float, shots: int, num_samples: int, seed: int
+) -> Tuple[float, float, float, int]:
+    """
+    Benchmark mitiq.pec using local depolarising quasi-probability representations.
+    """
+    from mitiq.pec import (
+        execute_with_pec,
+        represent_operations_in_circuit_with_local_depolarizing_noise,
+    )
+
+    exec_fn = _make_dm_executor(n_qubits, noise_level)
+    noisy_val = exec_fn(circuit)
+
+    reps = represent_operations_in_circuit_with_local_depolarizing_noise(
+        circuit, noise_level
+    )
+
+    pec_exec = _make_dm_executor(n_qubits, noise_level)
+    counter = _Counter(pec_exec)
+
+    t0 = time.perf_counter()
+    mitigated = execute_with_pec(
+        circuit,
+        counter,
+        representations=reps,
+        num_samples=num_samples,
+        random_state=seed,
+    )
+    elapsed = time.perf_counter() - t0
+
+    return noisy_val, mitigated, elapsed, counter.n
+
+
+# ── qermit PEC ────────────────────────────────────────────────────────────────
+
+def benchmark_qermit_pec(
+    circuit, n_qubits: int, noise_level: float, shots: int, seed: int
+) -> Tuple[float, float, float, int]:
+    """
+    Benchmark qermit gen_PEC_learning_based_MitEx.
+
+    Requires both the noisy ``device_backend`` and the ideal
+    ``simulator_backend`` to share the same qubit architecture so that
+    qermit's internal qubit relabelling is consistent.  This is achieved by
+    giving the ideal backend an epsilon-small noise model, forcing pytket to
+    compile both backends to the same ``node[i]`` qubit register.
+
+    NOTE: This approach may fail on some qermit/pytket-qiskit version
+    combinations — the function is wrapped in a try/except at call time.
+    """
+    from pytket import Circuit as TKCircuit, Qubit
+    from pytket.pauli import Pauli, QubitPauliString
+    from pytket.utils import QubitPauliOperator
+    from pytket.extensions.qiskit import AerBackend
+    from qermit import (
+        AnsatzCircuit, ObservableExperiment, ObservableTracker, SymbolsDict, MitEx,
+    )
+    from qermit.probabilistic_error_cancellation import gen_PEC_learning_based_MitEx
+    from qiskit_aer.noise import NoiseModel, depolarizing_error
+
+    # ── pytket GHZ circuit ────────────────────────────────────────────────────
+    tk_circuit = TKCircuit(n_qubits)
+    tk_circuit.H(0)
+    for i in range(n_qubits - 1):
+        tk_circuit.CX(i, i + 1)
+
+    def _make_aer_backend(error_1q: float, error_2q: float) -> AerBackend:
+        nm = NoiseModel()
+        e1 = depolarizing_error(error_1q, 1)
+        e2 = depolarizing_error(error_2q, 2)
+        for q in range(n_qubits):
+            nm.add_quantum_error(e1, ["h", "x", "sx", "u1", "u2", "u3"], [q])
+        for q1 in range(n_qubits):
+            for q2 in range(n_qubits):
+                if q1 != q2:
+                    nm.add_quantum_error(e2, ["cx", "cz"], [q1, q2])
+        return AerBackend(noise_model=nm)
+
+    noisy_backend = _make_aer_backend(noise_level, noise_level * 10)
+    # Epsilon noise forces AerBackend to compile to node[i] qubits, matching noisy_backend
+    ideal_backend = _make_aer_backend(1e-9, 1e-9)
+
+    # Observable on LOGICAL q[i] qubits so qermit ZNE/PEC can remap
+    q_qubits = [Qubit(i) for i in range(n_qubits)]
+    pauli_str = QubitPauliString(q_qubits, [Pauli.Z] * n_qubits)
+    observable = QubitPauliOperator({pauli_str: 1.0})
+    ansatz = AnsatzCircuit(Circuit=tk_circuit, Shots=shots, SymbolsDict=SymbolsDict())
+    obs_tracker = ObservableTracker(qubit_pauli_operator=observable)
+    exp = ObservableExperiment(AnsatzCircuit=ansatz, ObservableTracker=obs_tracker)
+
+    noisy_val = float(MitEx(noisy_backend).run([exp])[0][pauli_str])
+
+    pec = gen_PEC_learning_based_MitEx(
+        device_backend=noisy_backend,
+        simulator_backend=ideal_backend,
+        num_cliff=5,
+        optimisation_level=0,
+    )
+    try:
+        t0 = time.perf_counter()
+        pec_result = pec.run([exp])
+        elapsed = time.perf_counter() - t0
+    except Exception as exc:
+        msg = str(exc)
+        if "not found in circuit" in msg or "KeyError" in msg:
+            raise RuntimeError(
+                "qermit PEC qubit-mapping incompatibility between noisy and ideal "
+                "backends (known issue with pytket-qiskit). "
+                "See https://github.com/CQCL/Qermit/issues for updates."
+            ) from exc
+        raise
+
+    mitigated = float(pec_result[0][pauli_str])
+    # num_cliff random Clifford circuits per main circuit (approximate)
+    n_circuits = 5 * n_qubits
+    return noisy_val, mitigated, elapsed, n_circuits
+
+
+# ── Qiskit PEC ────────────────────────────────────────────────────────────────
+
+def benchmark_qiskit_pec(
+    circuit, n_qubits: int, noise_level: float, shots: int, seed: int
+) -> Tuple[float, float, float, int]:
+    """
+    Benchmark qiskit-ibm-runtime PEC via NoiseLearner + EstimatorV2.
+
+    Requires IBM Quantum cloud credentials:
+        from qiskit_ibm_runtime import QiskitRuntimeService
+        QiskitRuntimeService.save_account(channel="ibm_quantum", token="<API_TOKEN>")
+
+    Without credentials this function raises RuntimeError, which is caught at
+    the call site and printed as SKIP.
+    """
+    from qiskit import QuantumCircuit, transpile
+    from qiskit.quantum_info import SparsePauliOp
+    from qiskit_ibm_runtime import QiskitRuntimeService, EstimatorV2
+    from qiskit_ibm_runtime.noise_learner import NoiseLearner
+    from qiskit_ibm_runtime.options import NoiseLearnerOptions
+
+    # ── connect to IBM Quantum ────────────────────────────────────────────────
+    try:
+        service = QiskitRuntimeService()
+    except Exception as exc:
+        raise RuntimeError(
+            "IBM Quantum credentials not configured. "
+            "Run QiskitRuntimeService.save_account(token=...) first. "
+            f"Original error: {exc}"
+        )
+
+    backend = service.least_busy(
+        operational=True, simulator=False, min_num_qubits=n_qubits
+    )
+
+    # ── Qiskit GHZ + transpile to backend ISA ────────────────────────────────
+    qc = QuantumCircuit(n_qubits)
+    qc.h(0)
+    for i in range(n_qubits - 1):
+        qc.cx(i, i + 1)
+
+    qc_isa = transpile(qc, backend, optimization_level=1)
+    obs_raw = SparsePauliOp("Z" * n_qubits)
+    obs_isa = obs_raw.apply_layout(qc_isa.layout)
+
+    # ── learn layer noise ─────────────────────────────────────────────────────
+    nl_options = NoiseLearnerOptions()
+    nl_options.shots_per_randomization = shots
+    noise_learner = NoiseLearner(mode=backend, options=nl_options)
+    learned_noise = noise_learner.run([qc_isa]).result()
+
+    # ── noisy baseline (resilience_level=0) ──────────────────────────────────
+    est_noisy = EstimatorV2(mode=backend)
+    est_noisy.options.resilience_level = 0
+    est_noisy.options.default_shots = shots
+    noisy_val = float(est_noisy.run([(qc_isa, obs_isa)]).result()[0].data.evs)
+
+    # ── PEC (resilience.pec_mitigation=True + layer_noise_model) ─────────────
+    est_pec = EstimatorV2(mode=backend)
+    est_pec.options.resilience.pec_mitigation = True
+    est_pec.options.resilience.layer_noise_model = learned_noise
+    est_pec.options.default_shots = shots
+    t0 = time.perf_counter()
+    mitigated = float(est_pec.run([(qc_isa, obs_isa)]).result()[0].data.evs)
+    elapsed = time.perf_counter() - t0
+
+    return noisy_val, mitigated, elapsed, shots
+
+
+# ── table output ──────────────────────────────────────────────────────────────
+
+_COL = (25, 8, 8, 10, 8, 9, 7, 5, 5)
+_HDR = (
+    f"{'Tool':<{_COL[0]}} {'Ideal':>{_COL[1]}} {'Noisy':>{_COL[2]}} "
+    f"{'Mitigated':>{_COL[3]}} {'Improv':>{_COL[4]}} "
+    f"{'Time(s)':>{_COL[5]}} {'Circs':>{_COL[6]}} "
+    f"{'1Q':>{_COL[7]}} {'2Q':>{_COL[8]}}"
+)
+_SEP = "-" * len(_HDR)
+
+
+def _improv(noisy: float, mitigated: float, ideal: float) -> str:
+    denom = abs(mitigated - ideal)
+    if denom < 1e-10:
+        return "∞"
+    return f"{abs(noisy - ideal) / denom:.2f}×"
+
+
+def _row(name, ideal, noisy, mitigated, elapsed, n_circs, n1, n2):
+    factor = _improv(noisy, mitigated, ideal)
+    print(
+        f"{name:<{_COL[0]}} {ideal:>{_COL[1]}.4f} {noisy:>{_COL[2]}.4f} "
+        f"{mitigated:>{_COL[3]}.4f} {factor:>{_COL[4]}} "
+        f"{elapsed:>{_COL[5]}.2f} {n_circs:>{_COL[6]}} "
+        f"{n1:>{_COL[7]}} {n2:>{_COL[8]}}"
+    )
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--circuit", choices=["ghz", "qv", "mirror"], default="ghz")
+    parser.add_argument("--n-qubits", type=int, default=4)
+    parser.add_argument("--depth", type=int, default=4)
+    parser.add_argument("--noise-level", type=float, default=0.01)
+    parser.add_argument("--shots", type=int, default=8192)
+    parser.add_argument("--pec-samples", type=int, default=200,
+                        help="Quasi-probability samples for mitiq.pec (default: 200)")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--tool", choices=["all", "mitiq", "qermit", "qiskit"], default="all",
+    )
+    args = parser.parse_args()
+
+    import warnings
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
+    warnings.filterwarnings("ignore", message=".*global phase.*")
+    warnings.filterwarnings("ignore", message=".*IBMFractional.*")
+    warnings.filterwarnings("ignore", message=".*no effect in local.*")
+    warnings.filterwarnings("ignore", message=".*Covariance of the parameters.*")
+    try:
+        from scipy.optimize import OptimizeWarning
+        warnings.filterwarnings("ignore", category=OptimizeWarning)
+    except ImportError:
+        pass
+
+    np.random.seed(args.seed)
+
+    print(
+        f"\nPEC Benchmark\n"
+        f"circuit={args.circuit}  n_qubits={args.n_qubits}  depth={args.depth}  "
+        f"noise_level={args.noise_level}  shots={args.shots}  "
+        f"pec_samples={args.pec_samples}"
+    )
+    print("=" * len(_HDR))
+
+    circuit, ideal = get_benchmark_circuit(
+        args.circuit, args.n_qubits, args.depth, args.seed
+    )
+    n1, n2 = _count_gates(circuit)
+    print(f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}   1Q gates: {n1}   2Q gates: {n2}\n")
+    print(_HDR)
+    print(_SEP)
+
+    benchmarks_map = {
+        "mitiq": ("mitiq.pec", benchmark_mitiq_pec),
+        "qermit": ("qermit PEC", benchmark_qermit_pec),
+        "qiskit": ("Qiskit PEC (cloud)", benchmark_qiskit_pec),
+    }
+    tools_to_run = (
+        list(benchmarks_map.items())
+        if args.tool == "all"
+        else [(args.tool, benchmarks_map[args.tool])]
+    )
+
+    for key, (display_name, fn) in tools_to_run:
+        try:
+            extra: dict = {}
+            if key == "mitiq":
+                extra = {"num_samples": args.pec_samples, "seed": args.seed}
+            elif key in ("qermit", "qiskit"):
+                extra = {"seed": args.seed}
+
+            noisy, mitigated, elapsed, n_circs = fn(
+                circuit=circuit,
+                n_qubits=args.n_qubits,
+                noise_level=args.noise_level,
+                shots=args.shots,
+                **extra,
+            )
+            _row(display_name, ideal, noisy, mitigated, elapsed, n_circs, n1, n2)
+        except ImportError as exc:
+            print(f"{display_name:<{_COL[0]}} SKIP (missing dep): {exc}")
+        except RuntimeError as exc:
+            print(f"{display_name:<{_COL[0]}} SKIP: {exc}")
+        except Exception as exc:
+            import traceback
+
+            msg = str(exc).splitlines()[0][:80]
+            print(f"{display_name:<{_COL[0]}} ERROR: {msg}")
+            if "--debug" in __import__("sys").argv:
+                traceback.print_exc()
+
+    print(_SEP)
+    print(
+        "\nImprov = |noisy − ideal| / |mitigated − ideal|  "
+        "(>1 means mitigation helped)"
+    )
+    print(
+        "Qiskit PEC requires IBM Quantum cloud credentials (NoiseLearner).\n"
+        "qermit PEC may fail with some pytket-qiskit versions; "
+        "see SKIP/ERROR message for details."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_pec.py
+++ b/scripts/benchmark_pec.py
@@ -6,13 +6,12 @@ GHZ circuit with synthetic depolarising gate noise.
 
 Usage
 -----
-    python scripts/benchmark_pec.py
-    python scripts/benchmark_pec.py \
-        --circuit ghz --n-qubits 4 --noise-level 0.01
+    python scripts/benchmark_pec.py               # runs ghz, qv, mirror
+    python scripts/benchmark_pec.py --circuit ghz # runs one circuit
 
 Arguments
 ---------
-    --circuit        Circuit type: ghz | qv | mirror             (default: ghz)
+    --circuit        Circuit type: ghz | qv | mirror | all       (default: all)
     --n-qubits       Number of qubits                            (default: 4)
     --depth          Circuit depth for qv / mirror               (default: 4)
     --noise-level    Single-qubit depolarising error            (default: 0.01)
@@ -64,28 +63,15 @@ import time
 from typing import Callable, Tuple
 
 import numpy as np
-
-# ── helpers ──────────────────────────────────────────────────────────────────
-
-
-class _Counter:
-    """Callable wrapper that counts invocations."""
-
-    def __init__(self, fn: Callable) -> None:
-        self._fn = fn
-        self.n = 0
-
-    def __call__(self, *args, **kwargs):
-        self.n += 1
-        return self._fn(*args, **kwargs)
-
-
-def _zn_eigenvalue(n: int) -> np.ndarray:
-    """Return eigenvalues of Z⊗n: (-1)^popcount(i) for i in [0, 2^n)."""
-    return np.array(
-        [(-1) ** bin(i).count("1") for i in range(2**n)], dtype=float
-    )
-
+from benchmark_utils import (
+    _COL,
+    _HDR,
+    _SEP,
+    _count_gates,
+    _Counter,
+    _row,
+    _zn_eigenvalue,
+)
 
 # ── circuit generation ───────────────────────────────────────────────────────
 
@@ -132,22 +118,6 @@ def _ideal_expval(circuit, n_qubits: int) -> float:
     return float(np.real(np.dot(ev, np.abs(sv) ** 2)))
 
 
-def _count_gates(circuit) -> Tuple[int, int]:
-    """Return (n_1q_gates, n_2q_gates), ignoring measurements."""
-    import cirq
-
-    n1 = n2 = 0
-    for op in circuit.all_operations():
-        if isinstance(op.gate, cirq.MeasurementGate):
-            continue
-        nq = len(op.qubits)
-        if nq == 1:
-            n1 += 1
-        elif nq == 2:
-            n2 += 1
-    return n1, n2
-
-
 # ── shared cirq noisy executor (density matrix) ──────────────────────────────
 
 
@@ -171,6 +141,10 @@ def _make_dm_executor(n_qubits: int, noise_level: float) -> Callable:
         rho = sim.simulate(clean).final_density_matrix
         return float(np.real(np.sum(np.diag(rho) * ev)))
 
+    # Override string annotations produced by `from __future__ import
+    # annotations` with real type objects so mitiq's Executor can
+    # identify the return type (float in FloatLike).
+    executor.__annotations__ = {"circuit": cirq.Circuit, "return": float}
     return executor
 
 
@@ -314,7 +288,7 @@ def _patch_qermit_random_commuting_clifford() -> bool:
                 cast(List[Qubit], new_qps_qbs), qps_paulis
             )
 
-            # ── THE FIX ─────────────────────────────────────────────────────
+            # ── THE FIX ──────────────────────────────────────────────────────
             # Work on a copy so that place_with_map does not rename
             # rand_cliff_circ's qubits in-place (node[i] → q[i]).
             eval_circ = rand_cliff_circ.copy()
@@ -382,10 +356,10 @@ def benchmark_qermit_pec(
     # Apply in-process fix for the node[i]/q[i] qubit-mapping bug.
     _patch_qermit_random_commuting_clifford()
 
-    from pytket import Circuit as TKCircuit
     from pytket import Qubit
     from pytket.extensions.qiskit import AerBackend
     from pytket.pauli import Pauli, QubitPauliString
+    from pytket.qasm import circuit_from_qasm_str
     from pytket.utils import QubitPauliOperator
     from qermit import (
         AnsatzCircuit,
@@ -399,11 +373,8 @@ def benchmark_qermit_pec(
     )
     from qiskit_aer.noise import NoiseModel, depolarizing_error
 
-    # ── pytket GHZ circuit ──────────────────────────────────────────────────
-    tk_circuit = TKCircuit(n_qubits)
-    tk_circuit.H(0)
-    for i in range(n_qubits - 1):
-        tk_circuit.CX(i, i + 1)
+    # Convert mitiq benchmarks circuit → pytket via QASM
+    tk_circuit = circuit_from_qasm_str(circuit.to_qasm())
 
     def _make_aer_backend(error_1q: float, error_2q: float) -> AerBackend:
         nm = NoiseModel()
@@ -468,6 +439,7 @@ def benchmark_qiskit_pec(
     Without credentials this function raises RuntimeError, which is caught at
     the call site and printed as SKIP.
     """
+    import cirq
     from qiskit import QuantumCircuit, transpile
     from qiskit.quantum_info import SparsePauliOp
     from qiskit_ibm_runtime import EstimatorV2, QiskitRuntimeService
@@ -488,11 +460,14 @@ def benchmark_qiskit_pec(
         operational=True, simulator=False, min_num_qubits=n_qubits
     )
 
-    # ── Qiskit GHZ + transpile to backend ISA ────────────────────────────────
-    qc = QuantumCircuit(n_qubits)
-    qc.h(0)
-    for i in range(n_qubits - 1):
-        qc.cx(i, i + 1)
+    # Convert mitiq benchmarks circuit to Qiskit via QASM
+    clean = cirq.Circuit(
+        op
+        for op in circuit.all_operations()
+        if not isinstance(op.gate, cirq.MeasurementGate)
+    )
+    qasm_str = clean.to_qasm()
+    qc = QuantumCircuit.from_qasm_str(qasm_str)
 
     qc_isa = transpile(qc, backend, optimization_level=1)
     obs_raw = SparsePauliOp("Z" * n_qubits)
@@ -522,33 +497,104 @@ def benchmark_qiskit_pec(
     return noisy_val, mitigated, elapsed, shots
 
 
-# ── table output ─────────────────────────────────────────────────────────────
-
-_COL = (25, 8, 8, 10, 8, 9, 7, 5, 5)
-_HDR = (
-    f"{'Tool':<{_COL[0]}} {'Ideal':>{_COL[1]}} {'Noisy':>{_COL[2]}} "
-    f"{'Mitigated':>{_COL[3]}} {'Improv':>{_COL[4]}} "
-    f"{'Time(s)':>{_COL[5]}} {'Circs':>{_COL[6]}} "
-    f"{'1Q':>{_COL[7]}} {'2Q':>{_COL[8]}}"
-)
-_SEP = "-" * len(_HDR)
+# ── per-circuit runner ───────────────────────────────────────────────────────
 
 
-def _improv(noisy: float, mitigated: float, ideal: float) -> str:
-    denom = abs(mitigated - ideal)
-    if denom < 1e-10:
-        return "∞"
-    return f"{abs(noisy - ideal) / denom:.2f}×"
-
-
-def _row(name, ideal, noisy, mitigated, elapsed, n_circs, n1, n2):
-    factor = _improv(noisy, mitigated, ideal)
-    print(
-        f"{name:<{_COL[0]}} {ideal:>{_COL[1]}.4f} {noisy:>{_COL[2]}.4f} "
-        f"{mitigated:>{_COL[3]}.4f} {factor:>{_COL[4]}} "
-        f"{elapsed:>{_COL[5]}.2f} {n_circs:>{_COL[6]}} "
-        f"{n1:>{_COL[7]}} {n2:>{_COL[8]}}"
+def _run_circuit(circuit_type: str, args) -> None:
+    """Run PEC benchmark for one circuit type and print its table."""
+    circuit, ideal = get_benchmark_circuit(
+        circuit_type, args.n_qubits, args.depth, args.seed
     )
+    n1, n2 = _count_gates(circuit)
+
+    print(f"\ncircuit: {circuit_type}")
+    print(
+        f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}"
+        f"   1Q gates: {n1}   2Q gates: {n2}"
+    )
+    print(_HDR)
+    print(_SEP)
+
+    benchmarks_map = {
+        "mitiq": ("mitiq.pec", benchmark_mitiq_pec),
+        "qermit": ("qermit PEC", benchmark_qermit_pec),
+        "qiskit": ("Qiskit PEC (cloud)", benchmark_qiskit_pec),
+    }
+    tools_to_run = (
+        list(benchmarks_map.items())
+        if args.tool == "all"
+        else [(args.tool, benchmarks_map[args.tool])]
+    )
+
+    for key, (display_name, fn) in tools_to_run:
+        # mitiq.pec uses DensityMatrixSimulator, which raises a tensor-view
+        # error on QV/mirror circuits ("target_tensor and available_buffer
+        # must be views").  GHZ only.
+        if key == "mitiq" and circuit_type != "ghz":
+            print(
+                f"  {display_name}: NOTE: mitiq.pec"
+                " DensityMatrixSimulator not compatible with"
+                " deep circuits (QV/mirror) — skipping"
+            )
+            continue
+        # qermit PEC hangs on QV/mirror (Clifford training loop does not
+        # converge for deep circuits).  GHZ only.
+        if key == "qermit" and circuit_type != "ghz":
+            print(
+                f"{'qermit PEC':<{_COL[0]}} NOTE: qermit PEC skipped"
+                " for deep circuits (QV/mirror)"
+                " — use --circuit ghz"
+            )
+            continue
+        # Qiskit PEC (cloud) requires credentials; no point submitting
+        # cloud jobs for QV/mirror circuits.  GHZ only.
+        if key == "qiskit" and circuit_type != "ghz":
+            print(
+                f"{'Qiskit PEC (cloud)':<{_COL[0]}} NOTE: Qiskit PEC"
+                " skipped for deep circuits (QV/mirror)"
+                " — use --circuit ghz"
+            )
+            continue
+        try:
+            extra: dict = {}
+            if key == "mitiq":
+                extra = {
+                    "num_samples": args.pec_samples,
+                    "seed": args.seed,
+                }
+            elif key in ("qermit", "qiskit"):
+                extra = {"seed": args.seed}
+
+            noisy, mitigated, elapsed, n_circs = fn(
+                circuit=circuit,
+                n_qubits=args.n_qubits,
+                noise_level=args.noise_level,
+                shots=args.shots,
+                **extra,
+            )
+            _row(
+                display_name,
+                ideal,
+                noisy,
+                mitigated,
+                elapsed,
+                n_circs,
+                n1,
+                n2,
+            )
+        except ImportError as exc:
+            print(f"{display_name:<{_COL[0]}} SKIP (missing dep): {exc}")
+        except RuntimeError as exc:
+            print(f"{display_name:<{_COL[0]}} SKIP: {exc}")
+        except Exception as exc:
+            import traceback
+
+            msg = str(exc).splitlines()[0][:80]
+            print(f"{display_name:<{_COL[0]}} ERROR: {msg}")
+            if "--debug" in __import__("sys").argv:
+                traceback.print_exc()
+
+    print(_SEP)
 
 
 # ── main ─────────────────────────────────────────────────────────────────────
@@ -560,7 +606,10 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "--circuit", choices=["ghz", "qv", "mirror"], default="ghz"
+        "--circuit",
+        choices=["ghz", "qv", "mirror", "all"],
+        default="all",
+        help="Circuit type, or 'all' to run ghz/qv/mirror (default: all)",
     )
     parser.add_argument("--n-qubits", type=int, default=4)
     parser.add_argument("--depth", type=int, default=4)
@@ -599,6 +648,10 @@ def main() -> None:
 
     np.random.seed(args.seed)
 
+    circuit_types = (
+        ["ghz", "qv", "mirror"] if args.circuit == "all" else [args.circuit]
+    )
+
     print(
         f"\nPEC Benchmark\n"
         f"circuit={args.circuit}  n_qubits={args.n_qubits}"
@@ -608,66 +661,9 @@ def main() -> None:
     )
     print("=" * len(_HDR))
 
-    circuit, ideal = get_benchmark_circuit(
-        args.circuit, args.n_qubits, args.depth, args.seed
-    )
-    n1, n2 = _count_gates(circuit)
-    print(
-        f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}"
-        f"   1Q gates: {n1}   2Q gates: {n2}\n"
-    )
-    print(_HDR)
-    print(_SEP)
+    for ct in circuit_types:
+        _run_circuit(ct, args)
 
-    benchmarks_map = {
-        "mitiq": ("mitiq.pec", benchmark_mitiq_pec),
-        "qermit": ("qermit PEC", benchmark_qermit_pec),
-        "qiskit": ("Qiskit PEC (cloud)", benchmark_qiskit_pec),
-    }
-    tools_to_run = (
-        list(benchmarks_map.items())
-        if args.tool == "all"
-        else [(args.tool, benchmarks_map[args.tool])]
-    )
-
-    for key, (display_name, fn) in tools_to_run:
-        try:
-            extra: dict = {}
-            if key == "mitiq":
-                extra = {"num_samples": args.pec_samples, "seed": args.seed}
-            elif key in ("qermit", "qiskit"):
-                extra = {"seed": args.seed}
-
-            noisy, mitigated, elapsed, n_circs = fn(
-                circuit=circuit,
-                n_qubits=args.n_qubits,
-                noise_level=args.noise_level,
-                shots=args.shots,
-                **extra,
-            )
-            _row(
-                display_name,
-                ideal,
-                noisy,
-                mitigated,
-                elapsed,
-                n_circs,
-                n1,
-                n2,
-            )
-        except ImportError as exc:
-            print(f"{display_name:<{_COL[0]}} SKIP (missing dep): {exc}")
-        except RuntimeError as exc:
-            print(f"{display_name:<{_COL[0]}} SKIP: {exc}")
-        except Exception as exc:
-            import traceback
-
-            msg = str(exc).splitlines()[0][:80]
-            print(f"{display_name:<{_COL[0]}} ERROR: {msg}")
-            if "--debug" in __import__("sys").argv:
-                traceback.print_exc()
-
-    print(_SEP)
     print(
         "\nImprov = |noisy − ideal| / |mitigated − ideal|"
         "  (>1 means mitigation helped)"

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -2,30 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Callable, Tuple
+from typing import Tuple
 
 import numpy as np
-
-# ── callable counter ─────────────────────────────────────────────────────────
-
-
-class _Counter:
-    """Callable wrapper that counts invocations.
-
-    Copies ``__annotations__`` from the wrapped callable so that mitiq's
-    executor type-hint inspection still works correctly.
-    """
-
-    def __init__(self, fn: Callable) -> None:
-        self._fn = fn
-        self.n = 0
-        func = self.__call__.__func__  # type: ignore[attr-defined]
-        func.__annotations__ = getattr(fn, "__annotations__", {})
-
-    def __call__(self, *args, **kwargs):
-        self.n += 1
-        return self._fn(*args, **kwargs)
-
 
 # ── observable helpers ───────────────────────────────────────────────────────
 

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -1,0 +1,95 @@
+"""Shared utilities for ZNE, PEC, and measurement-error benchmarks."""
+
+from __future__ import annotations
+
+from typing import Callable, Tuple
+
+import numpy as np
+
+# ── callable counter ─────────────────────────────────────────────────────────
+
+
+class _Counter:
+    """Callable wrapper that counts invocations.
+
+    Copies ``__annotations__`` from the wrapped callable so that mitiq's
+    executor type-hint inspection still works correctly.
+    """
+
+    def __init__(self, fn: Callable) -> None:
+        self._fn = fn
+        self.n = 0
+        func = self.__call__.__func__  # type: ignore[attr-defined]
+        func.__annotations__ = getattr(fn, "__annotations__", {})
+
+    def __call__(self, *args, **kwargs):
+        self.n += 1
+        return self._fn(*args, **kwargs)
+
+
+# ── observable helpers ───────────────────────────────────────────────────────
+
+
+def _zn_eigenvalue(n: int) -> np.ndarray:
+    """Return eigenvalues of Z⊗n: (-1)^popcount(i) for i in [0, 2^n)."""
+    return np.array(
+        [(-1) ** bin(i).count("1") for i in range(2**n)],
+        dtype=float,
+    )
+
+
+# ── circuit statistics ───────────────────────────────────────────────────────
+
+
+def _count_gates(circuit) -> Tuple[int, int]:
+    """Return (n_1q_gates, n_2q_gates), ignoring measurements."""
+    import cirq
+
+    n1 = n2 = 0
+    for op in circuit.all_operations():
+        if isinstance(op.gate, cirq.MeasurementGate):
+            continue
+        nq = len(op.qubits)
+        if nq == 1:
+            n1 += 1
+        elif nq == 2:
+            n2 += 1
+    return n1, n2
+
+
+# ── table layout ─────────────────────────────────────────────────────────────
+
+_COL = (25, 8, 8, 10, 8, 9, 7, 5, 5)
+_HDR = (
+    f"{'Tool':<{_COL[0]}} {'Ideal':>{_COL[1]}} {'Noisy':>{_COL[2]}} "
+    f"{'Mitigated':>{_COL[3]}} {'Improv':>{_COL[4]}} "
+    f"{'Time(s)':>{_COL[5]}} {'Circs':>{_COL[6]}} "
+    f"{'1Q':>{_COL[7]}} {'2Q':>{_COL[8]}}"
+)
+_SEP = "-" * len(_HDR)
+
+
+def _improv(noisy: float, mitigated: float, ideal: float) -> str:
+    denom = abs(mitigated - ideal)
+    if denom < 1e-10:
+        return "∞"
+    return f"{abs(noisy - ideal) / denom:.2f}×"
+
+
+def _row(
+    name: str,
+    ideal: float,
+    noisy: float,
+    mitigated: float,
+    elapsed: float,
+    n_circs: int,
+    n1: int,
+    n2: int,
+) -> None:
+    factor = _improv(noisy, mitigated, ideal)
+    print(
+        f"{name:<{_COL[0]}} {ideal:>{_COL[1]}.4f} {noisy:>{_COL[2]}.4f} "
+        f"{mitigated:>{_COL[3]}.4f} {factor:>{_COL[4]}} "
+        f"{elapsed:>{_COL[5]}.2f} {n_circs:>{_COL[6]}} "
+        f"{n1:>{_COL[7]}} {n2:>{_COL[8]}}"
+    )

--- a/scripts/benchmark_zne.py
+++ b/scripts/benchmark_zne.py
@@ -9,6 +9,7 @@ Usage
     python scripts/benchmark_zne.py               # runs ghz, qv, mirror
     python scripts/benchmark_zne.py --circuit ghz # runs one circuit
     python scripts/benchmark_zne.py --factories   # all factories, all circuits
+    python scripts/benchmark_zne.py --ibm-account # adds real-HW row
 
     # Compare extrapolation factories for a specific tool:
     python scripts/benchmark_zne.py --factories --tool mitiq
@@ -26,10 +27,14 @@ Arguments
                                                                  (default: all)
     --factories    Run all extrapolation factories / fits for
                    each selected tool instead of the default.
+    --ibm-account  Connect to IBM Quantum and add a Qiskit Runtime ZNE
+                   row on real hardware. Reads IBM_QUANTUM_TOKEN from
+                   the environment.                      (default: off)
 
 Dependencies
 ------------
-    pip install -r scripts/requirements-benchmark.txt
+    pip install -e ".[benchmarking]"
+    IBM_QUANTUM_TOKEN env var: required only with --ibm-account.
 
 Output
 ------
@@ -71,6 +76,7 @@ Notes
 from __future__ import annotations
 
 import argparse
+import math
 import time
 from typing import Callable, Tuple
 
@@ -80,7 +86,6 @@ from benchmark_utils import (
     _HDR,
     _SEP,
     _count_gates,
-    _Counter,
     _row,
     _zn_eigenvalue,
 )
@@ -274,6 +279,7 @@ def benchmark_mitiq_zne(
     Uses a Qiskit AerSimulator executor (cirq → QASM → Qiskit) so that all
     circuit types — including QV — run without errors.
     """
+    from mitiq import Executor
     from mitiq.zne import execute_with_zne
     from mitiq.zne.inference import LinearFactory
     from mitiq.zne.scaling import fold_gates_at_random
@@ -284,7 +290,7 @@ def benchmark_mitiq_zne(
     exec_fn = _make_qiskit_executor(n_qubits, noise_level, shots)
     noisy_val = exec_fn(circuit)
 
-    counter = _Counter(_make_qiskit_executor(n_qubits, noise_level, shots))
+    counter = Executor(_make_qiskit_executor(n_qubits, noise_level, shots))
 
     t0 = time.perf_counter()
     mitigated = execute_with_zne(
@@ -295,7 +301,7 @@ def benchmark_mitiq_zne(
     )
     elapsed = time.perf_counter() - t0
 
-    return noisy_val, mitigated, elapsed, counter.n
+    return noisy_val, mitigated, elapsed, counter.calls_to_executor
 
 
 # ── qermit ZNE ───────────────────────────────────────────────────────────────
@@ -426,11 +432,7 @@ def _fold_circuit_global(qc, scale: int):
 
 
 def _get_qiskit_circuit(circuit, n_qubits: int):
-    """
-    Convert the benchmark circuit to a Qiskit QuantumCircuit via QASM.
-
-    Falls back to a GHZ circuit if QASM conversion fails.
-    """
+    """Convert the benchmark circuit to a Qiskit QuantumCircuit via QASM."""
     from qiskit import QuantumCircuit
 
     try:
@@ -438,15 +440,12 @@ def _get_qiskit_circuit(circuit, n_qubits: int):
         qc = QuantumCircuit.from_qasm_str(qasm_str)
         qc.remove_final_measurements(inplace=True)
         return qc
-    except Exception:
-        pass
-
-    # Fallback: build GHZ in Qiskit
-    qc = QuantumCircuit(n_qubits)
-    qc.h(0)
-    for i in range(n_qubits - 1):
-        qc.cx(i, i + 1)
-    return qc
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to convert benchmark circuit to Qiskit via QASM: "
+            f"{exc}. Cannot proceed with Qiskit ZNE benchmark for this "
+            f"circuit type."
+        ) from exc
 
 
 def benchmark_qiskit_zne(
@@ -510,10 +509,68 @@ def benchmark_qiskit_zne(
     return noisy_val, mitigated, elapsed, len(scale_factors)
 
 
+# ── Qiskit Runtime ZNE (real hardware) ──────────────────────────────────────
+
+
+def benchmark_qiskit_runtime_zne(
+    circuit,
+    n_qubits: int,
+    shots: int,
+    backend,
+) -> Tuple[float, float, float, int, str, float]:
+    """
+    Benchmark Qiskit Runtime ZNE on a real IBM backend via EstimatorV2.
+
+    Runs two jobs: a noisy baseline (resilience_level=0) and a ZNE-mitigated
+    run (zne_mitigation=True, noise_factors=(1,3,5), linear extrapolation).
+    optimization_level=1 is required; level 3 would let the transpiler cancel
+    folded gates U U† U → U, destroying ZNE's noise amplification.
+
+    Returns (noisy_val, mitigated, elapsed, n_circs, job_id, qpu_time_s).
+    n_circs = 1 (noisy job) + 3 (ZNE scale factors).
+    qpu_time_s is NaN when the backend does not expose usage metrics.
+    """
+    from qiskit import transpile
+    from qiskit.quantum_info import SparsePauliOp
+    from qiskit_ibm_runtime import EstimatorV2
+
+    qc = _get_qiskit_circuit(circuit, n_qubits)
+    qc_isa = transpile(qc, backend, optimization_level=1)
+    obs_raw = SparsePauliOp("Z" * n_qubits)
+    obs_isa = obs_raw.apply_layout(qc_isa.layout)
+
+    # noisy baseline (resilience_level=0 — no mitigation)
+    est_noisy = EstimatorV2(mode=backend)
+    est_noisy.options.default_shots = shots
+    est_noisy.options.resilience_level = 0
+    noisy_val = float(est_noisy.run([(qc_isa, obs_isa)]).result()[0].data.evs)
+
+    # ZNE mitigated
+    est_zne = EstimatorV2(mode=backend)
+    est_zne.options.default_shots = shots
+    est_zne.options.resilience.zne_mitigation = True
+    est_zne.options.resilience.zne.noise_factors = (1, 3, 5)
+    est_zne.options.resilience.zne.extrapolator = "linear"
+    t0 = time.perf_counter()
+    zne_job = est_zne.run([(qc_isa, obs_isa)])
+    zne_result = zne_job.result()
+    elapsed = time.perf_counter() - t0
+    mitigated = float(zne_result[0].data.evs)
+
+    job_id = zne_job.job_id()
+    try:
+        qpu_time = zne_job.metrics()["usage"]["quantum_seconds"]
+    except Exception:
+        qpu_time = float("nan")
+
+    # 1 noisy job + 3 ZNE scale-factor circuits
+    return noisy_val, mitigated, elapsed, 4, job_id, qpu_time
+
+
 # ── per-circuit runner ───────────────────────────────────────────────────────
 
 
-def _run_circuit(circuit_type: str, args) -> None:
+def _run_circuit(circuit_type: str, args, backend=None) -> None:
     """Run ZNE benchmark for one circuit type and print its table."""
     circuit, ideal = get_benchmark_circuit(
         circuit_type, args.n_qubits, args.depth, args.seed
@@ -595,6 +652,45 @@ def _run_circuit(circuit_type: str, args) -> None:
             else:
                 _run_row("Qiskit ZNE (manual)", benchmark_qiskit_zne)
 
+            if backend is not None:
+                try:
+                    (
+                        noisy,
+                        mitigated,
+                        elapsed,
+                        n_circs,
+                        job_id,
+                        qpu_time,
+                    ) = benchmark_qiskit_runtime_zne(
+                        circuit, args.n_qubits, args.shots, backend
+                    )
+                    _row(
+                        "Qiskit Runtime ZNE",
+                        ideal,
+                        noisy,
+                        mitigated,
+                        elapsed,
+                        n_circs,
+                        n1,
+                        n2,
+                    )
+                    qpu_str = (
+                        f"{qpu_time:.1f}s"
+                        if not math.isnan(qpu_time)
+                        else "N/A"
+                    )
+                    print(f"  job_id={job_id}  QPU time: {qpu_str}")
+                except ImportError as exc:
+                    print(
+                        f"{'Qiskit Runtime ZNE':<{_COL[0]}}"
+                        f" SKIP (missing dep): {exc}"
+                    )
+                except Exception as exc:
+                    print(
+                        f"{'Qiskit Runtime ZNE':<{_COL[0]}}"
+                        f" ERROR: {str(exc)[:60]}"
+                    )
+
     print(_SEP)
 
 
@@ -648,6 +744,15 @@ def main() -> None:
             "instead of only the default linear one."
         ),
     )
+    parser.add_argument(
+        "--ibm-account",
+        action="store_true",
+        default=False,
+        help=(
+            "Connect to IBM Quantum and add a Qiskit Runtime ZNE row on "
+            "real hardware. Requires IBM_QUANTUM_TOKEN env var."
+        ),
+    )
     args = parser.parse_args()
 
     import warnings
@@ -668,6 +773,26 @@ def main() -> None:
     except ImportError:
         pass
 
+    backend = None
+    if args.ibm_account:
+        import os
+
+        token = os.environ.get("IBM_QUANTUM_TOKEN")
+        if not token:
+            raise SystemExit(
+                "IBM_QUANTUM_TOKEN environment variable required when "
+                "--ibm-account is set."
+            )
+        from qiskit_ibm_runtime import QiskitRuntimeService
+
+        QiskitRuntimeService.save_account(token=token, overwrite=True)
+        service = QiskitRuntimeService()
+        backend = service.least_busy(
+            operational=True,
+            simulator=False,
+            min_num_qubits=args.n_qubits,
+        )
+
     np.random.seed(args.seed)
 
     circuit_types = (
@@ -683,7 +808,7 @@ def main() -> None:
     print("=" * len(_HDR))
 
     for ct in circuit_types:
-        _run_circuit(ct, args)
+        _run_circuit(ct, args, backend=backend)
 
     print(
         "\nImprov = |noisy − ideal| / |mitigated − ideal|"

--- a/scripts/benchmark_zne.py
+++ b/scripts/benchmark_zne.py
@@ -29,7 +29,7 @@ Arguments
 
 Dependencies
 ------------
-    pip install "mitiq>=1.0.0" "qermit>=0.9.0" pytket-qiskit qiskit-aer networkx
+    pip install -r scripts/requirements-benchmark.txt
 
 Output
 ------

--- a/scripts/benchmark_zne.py
+++ b/scripts/benchmark_zne.py
@@ -185,7 +185,9 @@ def _expval_from_counts(counts: dict, n: int) -> float:
 # ── shared noisy executor (Qiskit AerSimulator) ──────────────────────────────
 
 
-def _make_qiskit_executor(n_qubits: int, noise_level: float, shots: int) -> Callable:
+def _make_qiskit_executor(
+    n_qubits: int, noise_level: float, shots: int
+) -> Callable:
     """
     Return a cirq-circuit executor backed by Qiskit AerSimulator.
 
@@ -252,8 +254,8 @@ def _get_mitiq_factories() -> "dict[str, object]":
     return {
         # name                  factory                            scale pts
         "linear": LinearFactory([1.0, 2.0, 3.0]),  # 3 → deg-1
-        "richardson": RichardsonFactory([1.0, 2.0, 3.0]),  # 3 → deg-2 Richardson
-        "poly-deg2": PolyFactory([1.0, 2.0, 3.0], order=2),  # 3 pts, deg-2 poly
+        "richardson": RichardsonFactory([1.0, 2.0, 3.0]),  # deg-2 Richardson
+        "poly-deg2": PolyFactory([1.0, 2.0, 3.0], order=2),  # deg-2 poly
         "exp": ExpFactory([1.0, 2.0, 3.0]),  # 3 pts, a·exp(b·x)+c
         "poly-exp-deg2": PolyExpFactory(  # 4 pts, poly inside exp
             [1.0, 2.0, 3.0, 4.0], order=2
@@ -367,16 +369,17 @@ def benchmark_qermit_zne(
     ``10 × noise_level`` for 2-qubit gates (cx / cz).
     Observable: Z⊗n specified on logical qubits (q[0]…q[n-1]).
     """
-    from pytket import Circuit as TKCircuit, Qubit
+    from pytket import Circuit as TKCircuit
+    from pytket import Qubit
+    from pytket.extensions.qiskit import AerBackend
     from pytket.pauli import Pauli, QubitPauliString
     from pytket.utils import QubitPauliOperator
-    from pytket.extensions.qiskit import AerBackend
     from qermit import (
         AnsatzCircuit,
+        MitEx,
         ObservableExperiment,
         ObservableTracker,
         SymbolsDict,
-        MitEx,
     )
     from qermit.zero_noise_extrapolation import Folding, gen_ZNE_MitEx
     from qermit.zero_noise_extrapolation.zne import Fit
@@ -413,9 +416,13 @@ def benchmark_qermit_zne(
     q_qubits = [Qubit(i) for i in range(n_qubits)]
     pauli_str = QubitPauliString(q_qubits, [Pauli.Z] * n_qubits)
     observable = QubitPauliOperator({pauli_str: 1.0})
-    ansatz = AnsatzCircuit(Circuit=tk_circuit, Shots=shots, SymbolsDict=SymbolsDict())
+    ansatz = AnsatzCircuit(
+        Circuit=tk_circuit, Shots=shots, SymbolsDict=SymbolsDict()
+    )
     obs_tracker = ObservableTracker(qubit_pauli_operator=observable)
-    exp = ObservableExperiment(AnsatzCircuit=ansatz, ObservableTracker=obs_tracker)
+    exp = ObservableExperiment(
+        AnsatzCircuit=ansatz, ObservableTracker=obs_tracker
+    )
 
     if fit_type is None:
         fit_type = Fit.linear
@@ -523,8 +530,12 @@ def benchmark_qiskit_zne(
     qc = _get_qiskit_circuit(circuit, n_qubits)
 
     nm = NoiseModel()
-    nm.add_all_qubit_quantum_error(depolarizing_error(noise_level, 1), ["h", "x"])
-    nm.add_all_qubit_quantum_error(depolarizing_error(noise_level * 10, 2), ["cx"])
+    nm.add_all_qubit_quantum_error(
+        depolarizing_error(noise_level, 1), ["h", "x"]
+    )
+    nm.add_all_qubit_quantum_error(
+        depolarizing_error(noise_level * 10, 2), ["cx"]
+    )
     sim = AerSimulator(noise_model=nm)
 
     vals: list[float] = []
@@ -593,7 +604,10 @@ def main() -> None:
         "--n-qubits", type=int, default=4, help="Number of qubits (default: 4)"
     )
     parser.add_argument(
-        "--depth", type=int, default=4, help="Circuit depth for qv/mirror (default: 4)"
+        "--depth",
+        type=int,
+        default=4,
+        help="Circuit depth for qv/mirror (default: 4)",
     )
     parser.add_argument(
         "--noise-level",
@@ -602,7 +616,10 @@ def main() -> None:
         help="Single-qubit depolarising probability (default: 0.01)",
     )
     parser.add_argument(
-        "--shots", type=int, default=8192, help="Shots per circuit (default: 8192)"
+        "--shots",
+        type=int,
+        default=8192,
+        help="Shots per circuit (default: 8192)",
     )
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument(
@@ -629,7 +646,9 @@ def main() -> None:
     warnings.filterwarnings("ignore", message=".*very short.*")
     warnings.filterwarnings("ignore", message=".*IBMFractional.*")
     warnings.filterwarnings("ignore", message=".*no effect in local.*")
-    warnings.filterwarnings("ignore", message=".*Covariance of the parameters.*")
+    warnings.filterwarnings(
+        "ignore", message=".*Covariance of the parameters.*"
+    )
     try:
         from scipy.optimize import OptimizeWarning
 
@@ -658,9 +677,11 @@ def main() -> None:
     print(_HDR)
     print(_SEP)
 
-    tools_to_run = ["mitiq", "qermit", "qiskit"] if args.tool == "all" else [args.tool]
+    tools_to_run = (
+        ["mitiq", "qermit", "qiskit"] if args.tool == "all" else [args.tool]
+    )
 
-    # ── helper to emit one row ─────────────────────────────────────────────────
+    # ── helper to emit one row ───────────────────────────────────────────────
     def _run_row(display_name, fn, extra_kwargs=None):
         try:
             kw = dict(
@@ -687,21 +708,23 @@ def main() -> None:
         except Exception as exc:
             print(f"{display_name:<{_COL[0]}} ERROR: {str(exc)[:60]}")
 
-    # ── per-tool dispatch ──────────────────────────────────────────────────────
+    # ── per-tool dispatch ────────────────────────────────────────────────────
     for key in tools_to_run:
         if key == "mitiq":
             if args.factories:
-                print(f"\n── mitiq.zne factories ({'─'*40})")
+                print(f"\n── mitiq.zne factories ({'─' * 40})")
                 for fname, fac in _get_mitiq_factories().items():
                     _run_row(
-                        f"mitiq.zne ({fname})", benchmark_mitiq_zne, {"factory": fac}
+                        f"mitiq.zne ({fname})",
+                        benchmark_mitiq_zne,
+                        {"factory": fac},
                     )
             else:
                 _run_row("mitiq.zne", benchmark_mitiq_zne)
 
         elif key == "qermit":
             if args.factories:
-                print(f"\n── qermit ZNE fits ({'─'*43})")
+                print(f"\n── qermit ZNE fits ({'─' * 43})")
                 for fname, (fit_t, scales) in _get_qermit_fits().items():
                     _run_row(
                         f"qermit ({fname})",
@@ -713,7 +736,7 @@ def main() -> None:
 
         elif key == "qiskit":
             if args.factories:
-                print(f"\n── Qiskit ZNE (manual) fits ({'─'*35})")
+                print(f"\n── Qiskit ZNE (manual) fits ({'─' * 35})")
                 for fname, (deg, scales) in _QISKIT_ZNE_FITS.items():
                     _run_row(
                         f"Qiskit ZNE ({fname})",
@@ -725,8 +748,8 @@ def main() -> None:
 
     print(_SEP)
     print(
-        "\nImprov = |noisy − ideal| / |mitigated − ideal|  "
-        "(>1 means mitigation helped)"
+        "\nImprov = |noisy − ideal| / |mitigated − ideal|"
+        "  (>1 means mitigation helped)"
     )
     if args.factories:
         print(

--- a/scripts/benchmark_zne.py
+++ b/scripts/benchmark_zne.py
@@ -1,0 +1,690 @@
+"""
+Zero-Noise Extrapolation (ZNE) Benchmark
+==========================================
+Compare ``mitiq.zne``, ``qermit`` ZNE, and Qiskit ZNE on standardised circuit
+workloads with synthetic depolarising gate noise.
+
+Usage
+-----
+    python scripts/benchmark_zne.py
+    python scripts/benchmark_zne.py --circuit ghz --n-qubits 4 --noise-level 0.01 --shots 8192
+
+    # Compare all extrapolation factories across every tool:
+    python scripts/benchmark_zne.py --factories
+    python scripts/benchmark_zne.py --factories --tool mitiq
+    python scripts/benchmark_zne.py --factories --tool qermit
+
+Arguments
+---------
+    --circuit      Circuit type: ghz | qv | mirror              (default: ghz)
+    --n-qubits     Number of qubits                             (default: 4)
+    --depth        Circuit depth for qv / mirror circuits        (default: 4)
+    --noise-level  Single-qubit depolarizing error probability   (default: 0.01)
+    --shots        Shots per circuit execution                    (default: 8192)
+    --seed         Random seed for reproducibility               (default: 42)
+    --tool         Run a specific tool: mitiq | qermit | qiskit | all
+                                                                 (default: all)
+    --factories    Run all extrapolation factories / fits for each selected tool
+                   instead of just the default (linear) one.
+
+Dependencies
+------------
+    pip install "mitiq>=1.0.0" "qermit>=0.9.0" pytket-qiskit qiskit-aer networkx
+
+Output
+------
+    Prints a table with:
+      - Ideal, noisy, and mitigated expectation values (Z⊗n)
+      - Error mitigation improvement factor
+      - Wall-clock runtime
+      - Circuit execution count
+      - Single- and two-qubit gate counts of the benchmark circuit
+
+Notes
+-----
+    The observable is Z⊗n (tensor product of Pauli Z on all qubits).
+    For a GHZ state with even n, the ideal expectation value is +1.0.
+
+    Noise model: single-qubit depolarising error ``noise_level``,
+    two-qubit depolarising error ``10 × noise_level`` (applied per gate).
+
+    All three tools share the same Qiskit AerSimulator executor built from
+    ``_make_qiskit_executor``.  This is more robust than cirq's
+    DensityMatrixSimulator (which fails on QV circuits due to an internal
+    tensor-shape mismatch in ConstantQubitNoiseModel) and ensures a consistent
+    noise model and simulation back-end across all tools.
+
+    mitiq ZNE: Qiskit AerSimulator executor.  Default: LinearFactory([1, 2, 3]).
+               With --factories: Linear, Richardson, Poly-deg2, Exp,
+               PolyExp-deg2, AdaExp(steps=4).
+    qermit ZNE: AerBackend with per-qubit depolarising noise.  Default: linear fit.
+               With --factories: linear, polynomial, exponential, cube_root,
+               richardson (all with scale factors [1, 2, 3]).
+    Qiskit ZNE (manual): AerSimulator.  Default: linear extrapolation.
+               With --factories: adds poly-deg2 (quadratic via numpy.polyfit).
+                The benchmark circuit is converted cirq → QASM → pytket so
+                that mirror / QV workloads are benchmarked correctly.
+    Qiskit ZNE (manual): AerSimulator with global circuit folding (scales 1, 3, 5)
+                and linear extrapolation.  Uses a synthetic depolarising noise model
+                keyed to --noise-level.  No cloud credentials required.
+
+    Qiskit ZNE uses ``optimization_level=0`` during transpilation so that
+    the compiler does not cancel the deliberately repeated (folded) gates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from typing import Callable, Tuple
+
+import numpy as np
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+class _Counter:
+    """Callable wrapper that counts invocations."""
+
+    def __init__(self, fn: Callable) -> None:
+        self._fn = fn
+        self.n = 0
+
+    def __call__(self, *args, **kwargs):
+        self.n += 1
+        return self._fn(*args, **kwargs)
+
+
+def _zn_eigenvalue(n: int) -> np.ndarray:
+    """Return eigenvalues of Z⊗n: (-1)^popcount(i) for i in [0, 2^n)."""
+    return np.array([(-1) ** bin(i).count("1") for i in range(2 ** n)], dtype=float)
+
+
+# ── circuit generation ─────────────────────────────────────────────────────────
+
+def get_benchmark_circuit(
+    circuit_type: str, n_qubits: int, depth: int, seed: int
+) -> Tuple:
+    """Return (cirq_circuit, ideal_expval) for the chosen circuit type."""
+    import cirq
+    from mitiq import benchmarks
+
+    if circuit_type == "ghz":
+        circuit = benchmarks.generate_ghz_circuit(n_qubits)
+    elif circuit_type == "qv":
+        circuit, _ = benchmarks.generate_quantum_volume_circuit(
+            n_qubits, depth, decompose=True, seed=seed
+        )
+    elif circuit_type == "mirror":
+        import networkx as nx
+
+        circuit, _ = benchmarks.generate_mirror_circuit(
+            nlayers=depth,
+            two_qubit_gate_prob=0.5,
+            connectivity_graph=nx.path_graph(n_qubits),
+            seed=seed,
+        )
+    else:
+        raise ValueError(f"Unknown circuit type: {circuit_type!r}")
+
+    ideal = _ideal_expval(circuit, n_qubits)
+    return circuit, ideal
+
+
+def _ideal_expval(circuit, n_qubits: int) -> float:
+    """Compute ideal ⟨Z⊗n⟩ via noiseless cirq statevector simulation."""
+    import cirq
+
+    clean = cirq.Circuit(
+        op for op in circuit.all_operations()
+        if not isinstance(op.gate, cirq.MeasurementGate)
+    )
+    sv = cirq.Simulator().simulate(clean).final_state_vector.flatten()
+    ev = _zn_eigenvalue(n_qubits)
+    return float(np.real(np.dot(ev, np.abs(sv) ** 2)))
+
+
+def _count_gates(circuit) -> Tuple[int, int]:
+    """Return (n_1q_gates, n_2q_gates) for a cirq circuit, ignoring measurements."""
+    import cirq
+
+    n1 = n2 = 0
+    for op in circuit.all_operations():
+        if isinstance(op.gate, cirq.MeasurementGate):
+            continue
+        nq = len(op.qubits)
+        if nq == 1:
+            n1 += 1
+        elif nq == 2:
+            n2 += 1
+    return n1, n2
+
+
+# ── shared helper ────────────────────────────────────────────────────────────
+
+def _expval_from_counts(counts: dict, n: int) -> float:
+    """Compute ⟨Z⊗n⟩ from a Qiskit counts dictionary.
+
+    Bitstrings use Qiskit's convention (rightmost character = qubit 0).
+    Parity is bit-order-invariant (sum of all bits), so this is correct
+    regardless of endianness.
+    """
+    total = sum(counts.values())
+    ev = 0.0
+    for bs, cnt in counts.items():
+        parity = sum(int(b) for b in bs.replace(" ", "")) % 2
+        ev += (-1) ** parity * cnt / total
+    return ev
+
+
+# ── shared noisy executor (Qiskit AerSimulator) ──────────────────────────────
+
+def _make_qiskit_executor(n_qubits: int, noise_level: float, shots: int) -> Callable:
+    """
+    Return a cirq-circuit executor backed by Qiskit AerSimulator.
+
+    The circuit is exported to QASM, parsed by Qiskit, and run on AerSimulator
+    with an all-qubit depolarising noise model:
+      - 1Q gates: ``noise_level``
+      - 2Q gates: ``10 × noise_level``
+
+    This is robust for all circuit types (GHZ, QV, mirror) because it does not
+    rely on cirq's ``ConstantQubitNoiseModel``, which fails on circuits that
+    contain parallel multi-qubit gates (e.g. decomposed Quantum Volume circuits).
+
+    Returns ⟨Z⊗n⟩ estimated from shot-based sampling.
+    """
+    import cirq
+    from qiskit import QuantumCircuit, transpile
+    from qiskit_aer import AerSimulator
+    from qiskit_aer.noise import NoiseModel, depolarizing_error
+
+    nm = NoiseModel()
+    # Cover the basis gates that AerSimulator uses after transpilation
+    nm.add_all_qubit_quantum_error(
+        depolarizing_error(noise_level, 1),
+        ["rx", "ry", "rz", "h", "x", "sx", "u1", "u2", "u3"],
+    )
+    nm.add_all_qubit_quantum_error(
+        depolarizing_error(noise_level * 10, 2),
+        ["cx", "cz"],
+    )
+    sim = AerSimulator(noise_model=nm)
+
+    def executor(circuit: cirq.Circuit) -> float:
+        clean = cirq.Circuit(
+            op for op in circuit.all_operations()
+            if not isinstance(op.gate, cirq.MeasurementGate)
+        )
+        qasm_str = clean.to_qasm()
+        qk = QuantumCircuit.from_qasm_str(qasm_str)
+        qk.measure_all()
+        t_qc = transpile(qk, sim, optimization_level=0)
+        counts = sim.run(t_qc, shots=shots).result().get_counts()
+        return _expval_from_counts(counts, n_qubits)
+
+    return executor
+
+
+# ── mitiq ZNE factories ────────────────────────────────────────────────────────
+# Populated lazily so the module imports even when mitiq is not installed.
+
+def _get_mitiq_factories() -> "dict[str, object]":
+    """Return an ordered dict mapping short name → mitiq factory instance."""
+    from mitiq.zne.inference import (
+        AdaExpFactory, ExpFactory, LinearFactory,
+        PolyExpFactory, PolyFactory, RichardsonFactory,
+    )
+    return {
+        # name                  factory                            scale pts
+        "linear":         LinearFactory([1.0, 2.0, 3.0]),        # 3 → deg-1
+        "richardson":     RichardsonFactory([1.0, 2.0, 3.0]),    # 3 → deg-2 Richardson
+        "poly-deg2":      PolyFactory([1.0, 2.0, 3.0], order=2), # 3 pts, deg-2 poly
+        "exp":            ExpFactory([1.0, 2.0, 3.0]),            # 3 pts, a·exp(b·x)+c
+        "poly-exp-deg2":  PolyExpFactory(                         # 4 pts, poly inside exp
+                              [1.0, 2.0, 3.0, 4.0], order=2),
+        "ada-exp":        AdaExpFactory(steps=4),                  # adaptive exp (4 calls)
+    }
+
+
+# ── qermit ZNE fits ────────────────────────────────────────────────────────────
+
+def _get_qermit_fits() -> "dict[str, tuple]":
+    """Return an ordered dict mapping short name → (Fit, noise_scaling_list)."""
+    from qermit.zero_noise_extrapolation.zne import Fit
+    scales = [1, 2, 3]
+    return {
+        "linear":      (Fit.linear,      scales),
+        "polynomial":  (Fit.polynomial,  scales),  # deg-2 poly (3 pts)
+        "exponential": (Fit.exponential, scales),
+        "cube-root":   (Fit.cube_root,   scales),
+        "richardson":  (Fit.richardson,  scales),  # Richardson with 3 pts
+    }
+
+
+# ── Qiskit manual ZNE fits ─────────────────────────────────────────────────────
+
+#  degree → (scale_factors, human_readable_label)
+_QISKIT_ZNE_FITS: "dict[str, tuple]" = {
+    "linear":    (1, [1, 3, 5]),
+    "poly-deg2": (2, [1, 3, 5, 7]),  # 4 pts for stable deg-2 fit
+}
+
+
+# ── mitiq ZNE ─────────────────────────────────────────────────────────────────
+
+def benchmark_mitiq_zne(
+    circuit, n_qubits: int, noise_level: float, shots: int,
+    factory=None,
+) -> Tuple[float, float, float, int]:
+    """
+    Benchmark mitiq.zne with gate folding (fold_gates_at_random).
+
+    Parameters
+    ----------
+    factory : mitiq ZNE factory instance, optional
+        Default: ``LinearFactory([1.0, 2.0, 3.0])``.
+        Pass any factory from ``mitiq.zne.inference`` for a different
+        extrapolation strategy.
+
+    Uses a Qiskit AerSimulator executor (cirq → QASM → Qiskit) so that all
+    circuit types — including QV — run without errors.
+    """
+    from mitiq.zne import execute_with_zne
+    from mitiq.zne.inference import LinearFactory
+    from mitiq.zne.scaling import fold_gates_at_random
+
+    if factory is None:
+        factory = LinearFactory([1.0, 2.0, 3.0])
+
+    exec_fn = _make_qiskit_executor(n_qubits, noise_level, shots)
+    noisy_val = exec_fn(circuit)
+
+    counter = _Counter(_make_qiskit_executor(n_qubits, noise_level, shots))
+
+    t0 = time.perf_counter()
+    mitigated = execute_with_zne(
+        circuit,
+        counter,
+        factory=factory,
+        scale_noise=fold_gates_at_random,
+    )
+    elapsed = time.perf_counter() - t0
+
+    return noisy_val, mitigated, elapsed, counter.n
+
+
+# ── qermit ZNE ────────────────────────────────────────────────────────────────
+
+def benchmark_qermit_zne(
+    circuit, n_qubits: int, noise_level: float, shots: int,
+    fit_type=None,
+    noise_scaling_list=None,
+) -> Tuple[float, float, float, int]:
+    """
+    Benchmark qermit ZNE using AerBackend with a per-qubit depolarising noise model.
+
+    Parameters
+    ----------
+    fit_type : qermit Fit enum value, optional
+        Default: ``Fit.linear``.
+        Available: ``Fit.linear``, ``Fit.polynomial``, ``Fit.exponential``,
+        ``Fit.cube_root``, ``Fit.richardson``.
+    noise_scaling_list : list of int, optional
+        Noise scale factors.  Default: ``[1, 2, 3]``.
+
+    The benchmark circuit is converted cirq → QASM → pytket so that the same
+    workload (GHZ, QV, mirror) is used across all tools.  Falls back to a
+    native GHZ pytket circuit if QASM conversion fails.
+
+    The noise model uses ``noise_level`` for 1-qubit gates and
+    ``10 × noise_level`` for 2-qubit gates (cx / cz).
+    Observable: Z⊗n specified on logical qubits (q[0]…q[n-1]).
+    """
+    from pytket import Circuit as TKCircuit, Qubit
+    from pytket.pauli import Pauli, QubitPauliString
+    from pytket.utils import QubitPauliOperator
+    from pytket.extensions.qiskit import AerBackend
+    from qermit import (
+        AnsatzCircuit, ObservableExperiment, ObservableTracker, SymbolsDict, MitEx,
+    )
+    from qermit.zero_noise_extrapolation import Folding, gen_ZNE_MitEx
+    from qermit.zero_noise_extrapolation.zne import Fit
+    from qiskit_aer.noise import NoiseModel, depolarizing_error
+
+    # ── convert cirq circuit → pytket via QASM ───────────────────────────────
+    # This ensures qermit benchmarks the same circuit as the other tools.
+    # GHZ / mirror / decomposed QV all export to valid QASM 2.0.
+    try:
+        from pytket.qasm import circuit_from_qasm_str
+        tk_circuit = circuit_from_qasm_str(circuit.to_qasm())
+    except Exception:
+        # Fallback: build GHZ natively (e.g. if circuit uses non-QASM gates)
+        tk_circuit = TKCircuit(n_qubits)
+        tk_circuit.H(0)
+        for i in range(n_qubits - 1):
+            tk_circuit.CX(i, i + 1)
+
+    # ── per-qubit noise model (add_all_qubit_quantum_error is rejected by AerBackend) ─
+    nm = NoiseModel()
+    e1 = depolarizing_error(noise_level, 1)
+    e2 = depolarizing_error(noise_level * 10, 2)
+    for q in range(n_qubits):
+        nm.add_quantum_error(e1, ["h", "x", "sx", "u1", "u2", "u3"], [q])
+    for q1 in range(n_qubits):
+        for q2 in range(n_qubits):
+            if q1 != q2:
+                nm.add_quantum_error(e2, ["cx", "cz"], [q1, q2])
+    backend = AerBackend(noise_model=nm)
+
+    # ── observable on LOGICAL q[i] qubits; qermit ZNE handles remapping ─────
+    q_qubits = [Qubit(i) for i in range(n_qubits)]
+    pauli_str = QubitPauliString(q_qubits, [Pauli.Z] * n_qubits)
+    observable = QubitPauliOperator({pauli_str: 1.0})
+    ansatz = AnsatzCircuit(Circuit=tk_circuit, Shots=shots, SymbolsDict=SymbolsDict())
+    obs_tracker = ObservableTracker(qubit_pauli_operator=observable)
+    exp = ObservableExperiment(AnsatzCircuit=ansatz, ObservableTracker=obs_tracker)
+
+    if fit_type is None:
+        fit_type = Fit.linear
+    if noise_scaling_list is None:
+        noise_scaling_list = [1, 2, 3]
+
+    # noisy (scale = 1, no mitigation)
+    noisy_result = MitEx(backend).run([exp])
+    noisy_val = float(noisy_result[0][pauli_str])
+
+    # ZNE with the requested fit type and scale factors
+    zne = gen_ZNE_MitEx(
+        backend=backend,
+        noise_scaling_list=noise_scaling_list,
+        folding_type=Folding.gate,
+        fit_type=fit_type,
+        optimisation_level=0,
+    )
+    t0 = time.perf_counter()
+    zne_result = zne.run([exp])
+    elapsed = time.perf_counter() - t0
+    mitigated = float(zne_result[0][pauli_str])
+
+    return noisy_val, mitigated, elapsed, len(noise_scaling_list)
+
+
+# ── Qiskit ZNE ────────────────────────────────────────────────────────────────
+
+def _fold_circuit_global(qc, scale: int):
+    """
+    Globally fold a Qiskit circuit to achieve integer noise scale factor.
+    c ↦ c · c† · c  (scale=3), c · c† · c · c† · c  (scale=5), etc.
+    ``scale`` must be an odd positive integer.
+    """
+    n_fold = (scale - 1) // 2
+    folded = qc.copy()
+    inv = qc.inverse()
+    for _ in range(n_fold):
+        folded.compose(inv, inplace=True)
+        folded.compose(qc, inplace=True)
+    return folded
+
+
+def _get_qiskit_circuit(circuit, n_qubits: int) -> "QuantumCircuit":
+    """
+    Convert the benchmark circuit to a Qiskit QuantumCircuit.
+
+    For the GHZ circuit this is built natively.  For QV / mirror circuits the
+    function attempts a QASM conversion via cirq; falls back to a GHZ circuit
+    if conversion fails.
+    """
+    from qiskit import QuantumCircuit
+
+    try:
+        import cirq
+        # Use cirq's QASM export (works for Clifford + CX circuits)
+        qasm_str = circuit.to_qasm()
+        qc = QuantumCircuit.from_qasm_str(qasm_str)
+        qc.remove_final_measurements(inplace=True)
+        return qc
+    except Exception:
+        pass
+
+    # Fallback: build GHZ in Qiskit
+    qc = QuantumCircuit(n_qubits)
+    qc.h(0)
+    for i in range(n_qubits - 1):
+        qc.cx(i, i + 1)
+    return qc
+
+
+def benchmark_qiskit_zne(
+    circuit, n_qubits: int, noise_level: float, shots: int,
+    degree: int = 1,
+    scale_factors: "list[int] | None" = None,
+) -> Tuple[float, float, float, int]:
+    """
+    Benchmark Qiskit ZNE using global circuit folding and AerSimulator.
+
+    Parameters
+    ----------
+    degree : int, optional
+        Polynomial degree for extrapolation (default 1 = linear).
+        Requires at least ``degree + 1`` scale factors.
+        ``degree=1`` → linear (numpy.polyfit order 1)
+        ``degree=2`` → quadratic (numpy.polyfit order 2, needs ≥ 3 pts)
+    scale_factors : list of odd ints, optional
+        Default: ``[1, 3, 5]`` for ``degree=1``;
+        ``[1, 3, 5, 7]`` for ``degree=2`` (4 pts for a stable quadratic fit).
+
+    Noise model: all-qubit depolarising, 1Q = noise_level, 2Q = 10×noise_level.
+    Uses ``optimization_level=0`` in transpile to prevent gate cancellations.
+    No cloud credentials required.
+    """
+    from qiskit import QuantumCircuit, transpile
+    from qiskit_aer import AerSimulator
+    from qiskit_aer.noise import NoiseModel, depolarizing_error
+
+    if scale_factors is None:
+        scale_factors = [1, 3, 5] if degree == 1 else [1, 3, 5, 7]
+
+    qc = _get_qiskit_circuit(circuit, n_qubits)
+
+    nm = NoiseModel()
+    nm.add_all_qubit_quantum_error(depolarizing_error(noise_level, 1), ["h", "x"])
+    nm.add_all_qubit_quantum_error(depolarizing_error(noise_level * 10, 2), ["cx"])
+    sim = AerSimulator(noise_model=nm)
+
+    vals: list[float] = []
+    t0 = time.perf_counter()
+    for sf in scale_factors:
+        folded = _fold_circuit_global(qc, sf)
+        folded.measure_all()
+        t_qc = transpile(folded, sim, optimization_level=0)
+        counts = sim.run(t_qc, shots=shots).result().get_counts()
+        vals.append(_expval_from_counts(counts, n_qubits))
+    elapsed = time.perf_counter() - t0
+
+    noisy_val = vals[0]
+    # Polynomial extrapolation of requested degree: fit, then evaluate at x=0
+    x = np.array(scale_factors, dtype=float)
+    coeffs = np.polyfit(x, vals, degree)
+    mitigated = float(np.polyval(coeffs, 0))
+
+    return noisy_val, mitigated, elapsed, len(scale_factors)
+
+
+
+# ── table output ──────────────────────────────────────────────────────────────
+
+_COL = (25, 8, 8, 10, 8, 9, 7, 5, 5)
+_HDR = (
+    f"{'Tool':<{_COL[0]}} {'Ideal':>{_COL[1]}} {'Noisy':>{_COL[2]}} "
+    f"{'Mitigated':>{_COL[3]}} {'Improv':>{_COL[4]}} "
+    f"{'Time(s)':>{_COL[5]}} {'Circs':>{_COL[6]}} "
+    f"{'1Q':>{_COL[7]}} {'2Q':>{_COL[8]}}"
+)
+_SEP = "-" * len(_HDR)
+
+
+def _improv(noisy: float, mitigated: float, ideal: float) -> str:
+    denom = abs(mitigated - ideal)
+    if denom < 1e-10:
+        return "∞"
+    return f"{abs(noisy - ideal) / denom:.2f}×"
+
+
+def _row(name, ideal, noisy, mitigated, elapsed, n_circs, n1, n2):
+    factor = _improv(noisy, mitigated, ideal)
+    print(
+        f"{name:<{_COL[0]}} {ideal:>{_COL[1]}.4f} {noisy:>{_COL[2]}.4f} "
+        f"{mitigated:>{_COL[3]}.4f} {factor:>{_COL[4]}} "
+        f"{elapsed:>{_COL[5]}.2f} {n_circs:>{_COL[6]}} "
+        f"{n1:>{_COL[7]}} {n2:>{_COL[8]}}"
+    )
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--circuit", choices=["ghz", "qv", "mirror"], default="ghz",
+        help="Circuit type (default: ghz)",
+    )
+    parser.add_argument("--n-qubits", type=int, default=4,
+                        help="Number of qubits (default: 4)")
+    parser.add_argument("--depth", type=int, default=4,
+                        help="Circuit depth for qv/mirror (default: 4)")
+    parser.add_argument("--noise-level", type=float, default=0.01,
+                        help="Single-qubit depolarising probability (default: 0.01)")
+    parser.add_argument("--shots", type=int, default=8192,
+                        help="Shots per circuit (default: 8192)")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--tool",
+        choices=["all", "mitiq", "qermit", "qiskit"],
+        default="all",
+        help="Run a specific tool only (default: all).",
+    )
+    parser.add_argument(
+        "--factories", action="store_true",
+        help=(
+            "Run all extrapolation factories / fits for each selected tool "
+            "instead of only the default linear one."
+        ),
+    )
+    args = parser.parse_args()
+
+    import warnings
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
+    warnings.filterwarnings("ignore", message=".*global phase.*")
+    warnings.filterwarnings("ignore", message=".*very short.*")
+    warnings.filterwarnings("ignore", message=".*IBMFractional.*")
+    warnings.filterwarnings("ignore", message=".*no effect in local.*")
+    warnings.filterwarnings("ignore", message=".*Covariance of the parameters.*")
+    try:
+        from scipy.optimize import OptimizeWarning
+        warnings.filterwarnings("ignore", category=OptimizeWarning)
+    except ImportError:
+        pass
+
+    np.random.seed(args.seed)
+
+    print(
+        f"\nZNE Benchmark\n"
+        f"circuit={args.circuit}  n_qubits={args.n_qubits}  depth={args.depth}  "
+        f"noise_level={args.noise_level}  shots={args.shots}"
+    )
+    print("=" * len(_HDR))
+
+    circuit, ideal = get_benchmark_circuit(
+        args.circuit, args.n_qubits, args.depth, args.seed
+    )
+    n1, n2 = _count_gates(circuit)
+    print(f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}   1Q gates: {n1}   2Q gates: {n2}\n")
+    print(_HDR)
+    print(_SEP)
+
+    tools_to_run = (
+        ["mitiq", "qermit", "qiskit"]
+        if args.tool == "all"
+        else [args.tool]
+    )
+
+    # ── helper to emit one row ─────────────────────────────────────────────────
+    def _run_row(display_name, fn, extra_kwargs=None):
+        try:
+            kw = dict(circuit=circuit, n_qubits=args.n_qubits,
+                      noise_level=args.noise_level, shots=args.shots)
+            if extra_kwargs:
+                kw.update(extra_kwargs)
+            noisy, mitigated, elapsed, n_circs = fn(**kw)
+            _row(display_name, ideal, noisy, mitigated, elapsed, n_circs, n1, n2)
+        except ImportError as exc:
+            print(f"{display_name:<{_COL[0]}} SKIP (missing dep): {exc}")
+        except Exception as exc:
+            print(f"{display_name:<{_COL[0]}} ERROR: {str(exc)[:60]}")
+
+    # ── per-tool dispatch ──────────────────────────────────────────────────────
+    for key in tools_to_run:
+        if key == "mitiq":
+            if args.factories:
+                print(f"\n── mitiq.zne factories ({'─'*40})")
+                for fname, fac in _get_mitiq_factories().items():
+                    _run_row(f"mitiq.zne ({fname})", benchmark_mitiq_zne,
+                             {"factory": fac})
+            else:
+                _run_row("mitiq.zne", benchmark_mitiq_zne)
+
+        elif key == "qermit":
+            if args.factories:
+                print(f"\n── qermit ZNE fits ({'─'*43})")
+                for fname, (fit_t, scales) in _get_qermit_fits().items():
+                    _run_row(f"qermit ({fname})", benchmark_qermit_zne,
+                             {"fit_type": fit_t, "noise_scaling_list": scales})
+            else:
+                _run_row("qermit ZNE", benchmark_qermit_zne)
+
+        elif key == "qiskit":
+            if args.factories:
+                print(f"\n── Qiskit ZNE (manual) fits ({'─'*35})")
+                for fname, (deg, scales) in _QISKIT_ZNE_FITS.items():
+                    _run_row(f"Qiskit ZNE ({fname})", benchmark_qiskit_zne,
+                             {"degree": deg, "scale_factors": scales})
+            else:
+                _run_row("Qiskit ZNE (manual)", benchmark_qiskit_zne)
+
+    print(_SEP)
+    print(
+        "\nImprov = |noisy − ideal| / |mitigated − ideal|  "
+        "(>1 means mitigation helped)"
+    )
+    if args.factories:
+        print(
+            "\nFactory notes:"
+            "\n  mitiq  — LinearFactory: linear fit (min 2 pts)."
+            "\n         — RichardsonFactory: degree-2 Richardson (3 pts)."
+            "\n         — PolyFactory(deg=2): quadratic fit (3 pts)."
+            "\n         — ExpFactory: a·exp(b·x)+c (3 pts)."
+            "\n         — PolyExpFactory(deg=2): (a+bx+cx²)·exp(dx) (4 pts)."
+            "\n         — AdaExpFactory(steps=4): adaptive exp — queries 4 pts chosen on-the-fly."
+            "\n  qermit — polynomial: degree-2 poly (3 pts)."
+            "\n         — cube_root: a+b(x+c)^(1/3) (3 pts)."
+            "\n         — richardson: Richardson extrapolation (3 pts)."
+            "\n  Qiskit — poly-deg2: quadratic numpy.polyfit (4 pts, scales 1,3,5,7)."
+            "\n"
+            "\nHigher-order factories are more sensitive to shot noise."
+            " Increase --shots for stable results."
+        )
+    if not args.factories:
+        print(
+            "Qiskit ZNE (manual) uses AerSimulator with global circuit folding "
+            "(scales 1,3,5) + linear extrapolation — works locally without cloud credentials."
+            "\nUse --factories to compare all extrapolation variants."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_zne.py
+++ b/scripts/benchmark_zne.py
@@ -6,18 +6,17 @@ workloads with synthetic depolarising gate noise.
 
 Usage
 -----
-    python scripts/benchmark_zne.py
-    python scripts/benchmark_zne.py \
-        --circuit ghz --n-qubits 4 --noise-level 0.01 --shots 8192
+    python scripts/benchmark_zne.py               # runs ghz, qv, mirror
+    python scripts/benchmark_zne.py --circuit ghz # runs one circuit
+    python scripts/benchmark_zne.py --factories   # all factories, all circuits
 
-    # Compare all extrapolation factories across every tool:
-    python scripts/benchmark_zne.py --factories
+    # Compare extrapolation factories for a specific tool:
     python scripts/benchmark_zne.py --factories --tool mitiq
     python scripts/benchmark_zne.py --factories --tool qermit
 
 Arguments
 ---------
-    --circuit      Circuit type: ghz | qv | mirror              (default: ghz)
+    --circuit      Circuit type: ghz | qv | mirror | all        (default: all)
     --n-qubits     Number of qubits                             (default: 4)
     --depth        Circuit depth for qv / mirror circuits        (default: 4)
     --noise-level  Single-qubit depolarizing error prob  (default: 0.01)
@@ -67,9 +66,6 @@ Notes
                (scales 1, 3, 5), linear extrapolation.
                With --factories: adds poly-deg2.
                No cloud credentials required.
-
-    Qiskit ZNE uses ``optimization_level=0`` during transpilation so that
-    the compiler does not cancel the deliberately repeated (folded) gates.
 """
 
 from __future__ import annotations
@@ -79,29 +75,15 @@ import time
 from typing import Callable, Tuple
 
 import numpy as np
-
-# ── helpers ──────────────────────────────────────────────────────────────────
-
-
-class _Counter:
-    """Callable wrapper that counts invocations."""
-
-    def __init__(self, fn: Callable) -> None:
-        self._fn = fn
-        self.n = 0
-
-    def __call__(self, *args, **kwargs):
-        self.n += 1
-        return self._fn(*args, **kwargs)
-
-
-def _zn_eigenvalue(n: int) -> np.ndarray:
-    """Return eigenvalues of Z⊗n: (-1)^popcount(i) for i in [0, 2^n)."""
-    return np.array(
-        [(-1) ** bin(i).count("1") for i in range(2**n)],
-        dtype=float,
-    )
-
+from benchmark_utils import (
+    _COL,
+    _HDR,
+    _SEP,
+    _count_gates,
+    _Counter,
+    _row,
+    _zn_eigenvalue,
+)
 
 # ── circuit generation ───────────────────────────────────────────────────────
 
@@ -146,22 +128,6 @@ def _ideal_expval(circuit, n_qubits: int) -> float:
     sv = cirq.Simulator().simulate(clean).final_state_vector.flatten()
     ev = _zn_eigenvalue(n_qubits)
     return float(np.real(np.dot(ev, np.abs(sv) ** 2)))
-
-
-def _count_gates(circuit) -> Tuple[int, int]:
-    """Return (n_1q_gates, n_2q_gates), ignoring measurements."""
-    import cirq
-
-    n1 = n2 = 0
-    for op in circuit.all_operations():
-        if isinstance(op.gate, cirq.MeasurementGate):
-            continue
-        nq = len(op.qubits)
-        if nq == 1:
-            n1 += 1
-        elif nq == 2:
-            n2 += 1
-    return n1, n2
 
 
 # ── shared helper ────────────────────────────────────────────────────────────
@@ -233,6 +199,10 @@ def _make_qiskit_executor(
         counts = sim.run(t_qc, shots=shots).result().get_counts()
         return _expval_from_counts(counts, n_qubits)
 
+    # Override string annotations produced by `from __future__ import
+    # annotations` with real type objects so mitiq's Executor can
+    # identify the return type (float in FloatLike).
+    executor.__annotations__ = {"circuit": cirq.Circuit, "return": float}
     return executor
 
 
@@ -279,15 +249,6 @@ def _get_qermit_fits() -> "dict[str, tuple]":
         "cube-root": (Fit.cube_root, scales),
         "richardson": (Fit.richardson, scales),  # Richardson with 3 pts
     }
-
-
-# ── Qiskit manual ZNE fits ───────────────────────────────────────────────────
-
-#  degree → (scale_factors, human_readable_label)
-_QISKIT_ZNE_FITS: "dict[str, tuple]" = {
-    "linear": (1, [1, 3, 5]),
-    "poly-deg2": (2, [1, 3, 5, 7]),  # 4 pts for stable deg-2 fit
-}
 
 
 # ── mitiq ZNE ────────────────────────────────────────────────────────────────
@@ -362,17 +323,16 @@ def benchmark_qermit_zne(
         Noise scale factors.  Default: ``[1, 2, 3]``.
 
     The benchmark circuit is converted cirq → QASM → pytket so that the same
-    workload (GHZ, QV, mirror) is used across all tools.  Falls back to a
-    native GHZ pytket circuit if QASM conversion fails.
+    workload (GHZ, QV, mirror) is used across all tools.
 
     The noise model uses ``noise_level`` for 1-qubit gates and
     ``10 × noise_level`` for 2-qubit gates (cx / cz).
     Observable: Z⊗n specified on logical qubits (q[0]…q[n-1]).
     """
-    from pytket import Circuit as TKCircuit
     from pytket import Qubit
     from pytket.extensions.qiskit import AerBackend
     from pytket.pauli import Pauli, QubitPauliString
+    from pytket.qasm import circuit_from_qasm_str
     from pytket.utils import QubitPauliOperator
     from qermit import (
         AnsatzCircuit,
@@ -385,19 +345,8 @@ def benchmark_qermit_zne(
     from qermit.zero_noise_extrapolation.zne import Fit
     from qiskit_aer.noise import NoiseModel, depolarizing_error
 
-    # ── convert cirq circuit → pytket via QASM ───────────────────────────────
-    # This ensures qermit benchmarks the same circuit as the other tools.
-    # GHZ / mirror / decomposed QV all export to valid QASM 2.0.
-    try:
-        from pytket.qasm import circuit_from_qasm_str
-
-        tk_circuit = circuit_from_qasm_str(circuit.to_qasm())
-    except Exception:
-        # Fallback: build GHZ natively (e.g. if circuit uses non-QASM gates)
-        tk_circuit = TKCircuit(n_qubits)
-        tk_circuit.H(0)
-        for i in range(n_qubits - 1):
-            tk_circuit.CX(i, i + 1)
+    # Convert mitiq benchmarks circuit → pytket via QASM
+    tk_circuit = circuit_from_qasm_str(circuit.to_qasm())
 
     # per-qubit noise model
     # (add_all_qubit_quantum_error is rejected by AerBackend)
@@ -449,6 +398,15 @@ def benchmark_qermit_zne(
     return noisy_val, mitigated, elapsed, len(noise_scaling_list)
 
 
+# ── Qiskit manual ZNE fits ───────────────────────────────────────────────────
+
+#  degree → (scale_factors, human_readable_label)
+_QISKIT_ZNE_FITS: "dict[str, tuple]" = {
+    "linear": (1, [1, 3, 5]),
+    "poly-deg2": (2, [1, 3, 5, 7]),  # 4 pts for stable deg-2 fit
+}
+
+
 # ── Qiskit ZNE ───────────────────────────────────────────────────────────────
 
 
@@ -469,16 +427,13 @@ def _fold_circuit_global(qc, scale: int):
 
 def _get_qiskit_circuit(circuit, n_qubits: int):
     """
-    Convert the benchmark circuit to a Qiskit QuantumCircuit.
+    Convert the benchmark circuit to a Qiskit QuantumCircuit via QASM.
 
-    For the GHZ circuit this is built natively.  For QV / mirror circuits the
-    function attempts a QASM conversion via cirq; falls back to a GHZ circuit
-    if conversion fails.
+    Falls back to a GHZ circuit if QASM conversion fails.
     """
     from qiskit import QuantumCircuit
 
     try:
-        # Use cirq's QASM export (works for Clifford + CX circuits)
         qasm_str = circuit.to_qasm()
         qc = QuantumCircuit.from_qasm_str(qasm_str)
         qc.remove_final_measurements(inplace=True)
@@ -510,11 +465,9 @@ def benchmark_qiskit_zne(
     degree : int, optional
         Polynomial degree for extrapolation (default 1 = linear).
         Requires at least ``degree + 1`` scale factors.
-        ``degree=1`` → linear (numpy.polyfit order 1)
-        ``degree=2`` → quadratic (numpy.polyfit order 2, needs ≥ 3 pts)
     scale_factors : list of odd ints, optional
         Default: ``[1, 3, 5]`` for ``degree=1``;
-        ``[1, 3, 5, 7]`` for ``degree=2`` (4 pts for a stable quadratic fit).
+        ``[1, 3, 5, 7]`` for ``degree=2`` (4 pts for stable quadratic fit).
 
     Noise model: all-qubit depolarising, 1Q = noise_level, 2Q = 10×noise_level.
     Uses ``optimization_level=0`` in transpile to prevent gate cancellations.
@@ -557,33 +510,92 @@ def benchmark_qiskit_zne(
     return noisy_val, mitigated, elapsed, len(scale_factors)
 
 
-# ── table output ─────────────────────────────────────────────────────────────
-
-_COL = (25, 8, 8, 10, 8, 9, 7, 5, 5)
-_HDR = (
-    f"{'Tool':<{_COL[0]}} {'Ideal':>{_COL[1]}} {'Noisy':>{_COL[2]}} "
-    f"{'Mitigated':>{_COL[3]}} {'Improv':>{_COL[4]}} "
-    f"{'Time(s)':>{_COL[5]}} {'Circs':>{_COL[6]}} "
-    f"{'1Q':>{_COL[7]}} {'2Q':>{_COL[8]}}"
-)
-_SEP = "-" * len(_HDR)
+# ── per-circuit runner ───────────────────────────────────────────────────────
 
 
-def _improv(noisy: float, mitigated: float, ideal: float) -> str:
-    denom = abs(mitigated - ideal)
-    if denom < 1e-10:
-        return "∞"
-    return f"{abs(noisy - ideal) / denom:.2f}×"
-
-
-def _row(name, ideal, noisy, mitigated, elapsed, n_circs, n1, n2):
-    factor = _improv(noisy, mitigated, ideal)
-    print(
-        f"{name:<{_COL[0]}} {ideal:>{_COL[1]}.4f} {noisy:>{_COL[2]}.4f} "
-        f"{mitigated:>{_COL[3]}.4f} {factor:>{_COL[4]}} "
-        f"{elapsed:>{_COL[5]}.2f} {n_circs:>{_COL[6]}} "
-        f"{n1:>{_COL[7]}} {n2:>{_COL[8]}}"
+def _run_circuit(circuit_type: str, args) -> None:
+    """Run ZNE benchmark for one circuit type and print its table."""
+    circuit, ideal = get_benchmark_circuit(
+        circuit_type, args.n_qubits, args.depth, args.seed
     )
+    n1, n2 = _count_gates(circuit)
+
+    print(f"\ncircuit: {circuit_type}")
+    print(
+        f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}"
+        f"   1Q gates: {n1}   2Q gates: {n2}"
+    )
+    print(_HDR)
+    print(_SEP)
+
+    tools_to_run = (
+        ["mitiq", "qermit", "qiskit"] if args.tool == "all" else [args.tool]
+    )
+
+    def _run_row(display_name, fn, extra_kwargs=None):
+        try:
+            kw = dict(
+                circuit=circuit,
+                n_qubits=args.n_qubits,
+                noise_level=args.noise_level,
+                shots=args.shots,
+            )
+            if extra_kwargs:
+                kw.update(extra_kwargs)
+            noisy, mitigated, elapsed, n_circs = fn(**kw)
+            _row(
+                display_name,
+                ideal,
+                noisy,
+                mitigated,
+                elapsed,
+                n_circs,
+                n1,
+                n2,
+            )
+        except ImportError as exc:
+            print(f"{display_name:<{_COL[0]}} SKIP (missing dep): {exc}")
+        except Exception as exc:
+            print(f"{display_name:<{_COL[0]}} ERROR: {str(exc)[:60]}")
+
+    for key in tools_to_run:
+        if key == "mitiq":
+            if args.factories:
+                print(f"\n── mitiq.zne factories ({'─' * 40})")
+                for fname, fac in _get_mitiq_factories().items():
+                    _run_row(
+                        f"mitiq.zne ({fname})",
+                        benchmark_mitiq_zne,
+                        {"factory": fac},
+                    )
+            else:
+                _run_row("mitiq.zne", benchmark_mitiq_zne)
+
+        elif key == "qermit":
+            if args.factories:
+                print(f"\n── qermit ZNE fits ({'─' * 43})")
+                for fname, (fit_t, scales) in _get_qermit_fits().items():
+                    _run_row(
+                        f"qermit ({fname})",
+                        benchmark_qermit_zne,
+                        {"fit_type": fit_t, "noise_scaling_list": scales},
+                    )
+            else:
+                _run_row("qermit ZNE", benchmark_qermit_zne)
+
+        elif key == "qiskit":
+            if args.factories:
+                print(f"\n── Qiskit ZNE (manual) fits ({'─' * 35})")
+                for fname, (deg, scales) in _QISKIT_ZNE_FITS.items():
+                    _run_row(
+                        f"Qiskit ZNE ({fname})",
+                        benchmark_qiskit_zne,
+                        {"degree": deg, "scale_factors": scales},
+                    )
+            else:
+                _run_row("Qiskit ZNE (manual)", benchmark_qiskit_zne)
+
+    print(_SEP)
 
 
 # ── main ─────────────────────────────────────────────────────────────────────
@@ -596,9 +608,9 @@ def main() -> None:
     )
     parser.add_argument(
         "--circuit",
-        choices=["ghz", "qv", "mirror"],
-        default="ghz",
-        help="Circuit type (default: ghz)",
+        choices=["ghz", "qv", "mirror", "all"],
+        default="all",
+        help="Circuit type, or 'all' to run ghz/qv/mirror (default: all)",
     )
     parser.add_argument(
         "--n-qubits", type=int, default=4, help="Number of qubits (default: 4)"
@@ -658,6 +670,10 @@ def main() -> None:
 
     np.random.seed(args.seed)
 
+    circuit_types = (
+        ["ghz", "qv", "mirror"] if args.circuit == "all" else [args.circuit]
+    )
+
     print(
         f"\nZNE Benchmark\n"
         f"circuit={args.circuit}  n_qubits={args.n_qubits}  "
@@ -666,87 +682,9 @@ def main() -> None:
     )
     print("=" * len(_HDR))
 
-    circuit, ideal = get_benchmark_circuit(
-        args.circuit, args.n_qubits, args.depth, args.seed
-    )
-    n1, n2 = _count_gates(circuit)
-    print(
-        f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}"
-        f"   1Q gates: {n1}   2Q gates: {n2}\n"
-    )
-    print(_HDR)
-    print(_SEP)
+    for ct in circuit_types:
+        _run_circuit(ct, args)
 
-    tools_to_run = (
-        ["mitiq", "qermit", "qiskit"] if args.tool == "all" else [args.tool]
-    )
-
-    # ── helper to emit one row ───────────────────────────────────────────────
-    def _run_row(display_name, fn, extra_kwargs=None):
-        try:
-            kw = dict(
-                circuit=circuit,
-                n_qubits=args.n_qubits,
-                noise_level=args.noise_level,
-                shots=args.shots,
-            )
-            if extra_kwargs:
-                kw.update(extra_kwargs)
-            noisy, mitigated, elapsed, n_circs = fn(**kw)
-            _row(
-                display_name,
-                ideal,
-                noisy,
-                mitigated,
-                elapsed,
-                n_circs,
-                n1,
-                n2,
-            )
-        except ImportError as exc:
-            print(f"{display_name:<{_COL[0]}} SKIP (missing dep): {exc}")
-        except Exception as exc:
-            print(f"{display_name:<{_COL[0]}} ERROR: {str(exc)[:60]}")
-
-    # ── per-tool dispatch ────────────────────────────────────────────────────
-    for key in tools_to_run:
-        if key == "mitiq":
-            if args.factories:
-                print(f"\n── mitiq.zne factories ({'─' * 40})")
-                for fname, fac in _get_mitiq_factories().items():
-                    _run_row(
-                        f"mitiq.zne ({fname})",
-                        benchmark_mitiq_zne,
-                        {"factory": fac},
-                    )
-            else:
-                _run_row("mitiq.zne", benchmark_mitiq_zne)
-
-        elif key == "qermit":
-            if args.factories:
-                print(f"\n── qermit ZNE fits ({'─' * 43})")
-                for fname, (fit_t, scales) in _get_qermit_fits().items():
-                    _run_row(
-                        f"qermit ({fname})",
-                        benchmark_qermit_zne,
-                        {"fit_type": fit_t, "noise_scaling_list": scales},
-                    )
-            else:
-                _run_row("qermit ZNE", benchmark_qermit_zne)
-
-        elif key == "qiskit":
-            if args.factories:
-                print(f"\n── Qiskit ZNE (manual) fits ({'─' * 35})")
-                for fname, (deg, scales) in _QISKIT_ZNE_FITS.items():
-                    _run_row(
-                        f"Qiskit ZNE ({fname})",
-                        benchmark_qiskit_zne,
-                        {"degree": deg, "scale_factors": scales},
-                    )
-            else:
-                _run_row("Qiskit ZNE (manual)", benchmark_qiskit_zne)
-
-    print(_SEP)
     print(
         "\nImprov = |noisy − ideal| / |mitigated − ideal|"
         "  (>1 means mitigation helped)"

--- a/scripts/benchmark_zne.py
+++ b/scripts/benchmark_zne.py
@@ -7,7 +7,8 @@ workloads with synthetic depolarising gate noise.
 Usage
 -----
     python scripts/benchmark_zne.py
-    python scripts/benchmark_zne.py --circuit ghz --n-qubits 4 --noise-level 0.01 --shots 8192
+    python scripts/benchmark_zne.py \
+        --circuit ghz --n-qubits 4 --noise-level 0.01 --shots 8192
 
     # Compare all extrapolation factories across every tool:
     python scripts/benchmark_zne.py --factories
@@ -19,13 +20,13 @@ Arguments
     --circuit      Circuit type: ghz | qv | mirror              (default: ghz)
     --n-qubits     Number of qubits                             (default: 4)
     --depth        Circuit depth for qv / mirror circuits        (default: 4)
-    --noise-level  Single-qubit depolarizing error probability   (default: 0.01)
-    --shots        Shots per circuit execution                    (default: 8192)
+    --noise-level  Single-qubit depolarizing error prob  (default: 0.01)
+    --shots        Shots per circuit execution         (default: 8192)
     --seed         Random seed for reproducibility               (default: 42)
     --tool         Run a specific tool: mitiq | qermit | qiskit | all
                                                                  (default: all)
-    --factories    Run all extrapolation factories / fits for each selected tool
-                   instead of just the default (linear) one.
+    --factories    Run all extrapolation factories / fits for
+                   each selected tool instead of the default.
 
 Dependencies
 ------------
@@ -54,19 +55,18 @@ Notes
     tensor-shape mismatch in ConstantQubitNoiseModel) and ensures a consistent
     noise model and simulation back-end across all tools.
 
-    mitiq ZNE: Qiskit AerSimulator executor.  Default: LinearFactory([1, 2, 3]).
+    mitiq ZNE: Qiskit AerSimulator executor.
+               Default: LinearFactory([1, 2, 3]).
                With --factories: Linear, Richardson, Poly-deg2, Exp,
                PolyExp-deg2, AdaExp(steps=4).
-    qermit ZNE: AerBackend with per-qubit depolarising noise.  Default: linear fit.
+    qermit ZNE: AerBackend with per-qubit depolarising noise.
+               Default: linear fit.
                With --factories: linear, polynomial, exponential, cube_root,
                richardson (all with scale factors [1, 2, 3]).
-    Qiskit ZNE (manual): AerSimulator.  Default: linear extrapolation.
-               With --factories: adds poly-deg2 (quadratic via numpy.polyfit).
-                The benchmark circuit is converted cirq → QASM → pytket so
-                that mirror / QV workloads are benchmarked correctly.
-    Qiskit ZNE (manual): AerSimulator with global circuit folding (scales 1, 3, 5)
-                and linear extrapolation.  Uses a synthetic depolarising noise model
-                keyed to --noise-level.  No cloud credentials required.
+    Qiskit ZNE (manual): AerSimulator, global circuit folding
+               (scales 1, 3, 5), linear extrapolation.
+               With --factories: adds poly-deg2.
+               No cloud credentials required.
 
     Qiskit ZNE uses ``optimization_level=0`` during transpilation so that
     the compiler does not cancel the deliberately repeated (folded) gates.
@@ -80,8 +80,8 @@ from typing import Callable, Tuple
 
 import numpy as np
 
+# ── helpers ──────────────────────────────────────────────────────────────────
 
-# ── helpers ────────────────────────────────────────────────────────────────────
 
 class _Counter:
     """Callable wrapper that counts invocations."""
@@ -97,16 +97,19 @@ class _Counter:
 
 def _zn_eigenvalue(n: int) -> np.ndarray:
     """Return eigenvalues of Z⊗n: (-1)^popcount(i) for i in [0, 2^n)."""
-    return np.array([(-1) ** bin(i).count("1") for i in range(2 ** n)], dtype=float)
+    return np.array(
+        [(-1) ** bin(i).count("1") for i in range(2**n)],
+        dtype=float,
+    )
 
 
-# ── circuit generation ─────────────────────────────────────────────────────────
+# ── circuit generation ───────────────────────────────────────────────────────
+
 
 def get_benchmark_circuit(
     circuit_type: str, n_qubits: int, depth: int, seed: int
 ) -> Tuple:
     """Return (cirq_circuit, ideal_expval) for the chosen circuit type."""
-    import cirq
     from mitiq import benchmarks
 
     if circuit_type == "ghz":
@@ -136,7 +139,8 @@ def _ideal_expval(circuit, n_qubits: int) -> float:
     import cirq
 
     clean = cirq.Circuit(
-        op for op in circuit.all_operations()
+        op
+        for op in circuit.all_operations()
         if not isinstance(op.gate, cirq.MeasurementGate)
     )
     sv = cirq.Simulator().simulate(clean).final_state_vector.flatten()
@@ -145,7 +149,7 @@ def _ideal_expval(circuit, n_qubits: int) -> float:
 
 
 def _count_gates(circuit) -> Tuple[int, int]:
-    """Return (n_1q_gates, n_2q_gates) for a cirq circuit, ignoring measurements."""
+    """Return (n_1q_gates, n_2q_gates), ignoring measurements."""
     import cirq
 
     n1 = n2 = 0
@@ -161,6 +165,7 @@ def _count_gates(circuit) -> Tuple[int, int]:
 
 
 # ── shared helper ────────────────────────────────────────────────────────────
+
 
 def _expval_from_counts(counts: dict, n: int) -> float:
     """Compute ⟨Z⊗n⟩ from a Qiskit counts dictionary.
@@ -179,6 +184,7 @@ def _expval_from_counts(counts: dict, n: int) -> float:
 
 # ── shared noisy executor (Qiskit AerSimulator) ──────────────────────────────
 
+
 def _make_qiskit_executor(n_qubits: int, noise_level: float, shots: int) -> Callable:
     """
     Return a cirq-circuit executor backed by Qiskit AerSimulator.
@@ -190,7 +196,8 @@ def _make_qiskit_executor(n_qubits: int, noise_level: float, shots: int) -> Call
 
     This is robust for all circuit types (GHZ, QV, mirror) because it does not
     rely on cirq's ``ConstantQubitNoiseModel``, which fails on circuits that
-    contain parallel multi-qubit gates (e.g. decomposed Quantum Volume circuits).
+    contain parallel multi-qubit gates (e.g. decomposed Quantum
+    Volume circuits).
 
     Returns ⟨Z⊗n⟩ estimated from shot-based sampling.
     """
@@ -213,7 +220,8 @@ def _make_qiskit_executor(n_qubits: int, noise_level: float, shots: int) -> Call
 
     def executor(circuit: cirq.Circuit) -> float:
         clean = cirq.Circuit(
-            op for op in circuit.all_operations()
+            op
+            for op in circuit.all_operations()
             if not isinstance(op.gate, cirq.MeasurementGate)
         )
         qasm_str = clean.to_qasm()
@@ -226,55 +234,68 @@ def _make_qiskit_executor(n_qubits: int, noise_level: float, shots: int) -> Call
     return executor
 
 
-# ── mitiq ZNE factories ────────────────────────────────────────────────────────
+# ── mitiq ZNE factories ──────────────────────────────────────────────────────
 # Populated lazily so the module imports even when mitiq is not installed.
+
 
 def _get_mitiq_factories() -> "dict[str, object]":
     """Return an ordered dict mapping short name → mitiq factory instance."""
     from mitiq.zne.inference import (
-        AdaExpFactory, ExpFactory, LinearFactory,
-        PolyExpFactory, PolyFactory, RichardsonFactory,
+        AdaExpFactory,
+        ExpFactory,
+        LinearFactory,
+        PolyExpFactory,
+        PolyFactory,
+        RichardsonFactory,
     )
+
     return {
         # name                  factory                            scale pts
-        "linear":         LinearFactory([1.0, 2.0, 3.0]),        # 3 → deg-1
-        "richardson":     RichardsonFactory([1.0, 2.0, 3.0]),    # 3 → deg-2 Richardson
-        "poly-deg2":      PolyFactory([1.0, 2.0, 3.0], order=2), # 3 pts, deg-2 poly
-        "exp":            ExpFactory([1.0, 2.0, 3.0]),            # 3 pts, a·exp(b·x)+c
-        "poly-exp-deg2":  PolyExpFactory(                         # 4 pts, poly inside exp
-                              [1.0, 2.0, 3.0, 4.0], order=2),
-        "ada-exp":        AdaExpFactory(steps=4),                  # adaptive exp (4 calls)
+        "linear": LinearFactory([1.0, 2.0, 3.0]),  # 3 → deg-1
+        "richardson": RichardsonFactory([1.0, 2.0, 3.0]),  # 3 → deg-2 Richardson
+        "poly-deg2": PolyFactory([1.0, 2.0, 3.0], order=2),  # 3 pts, deg-2 poly
+        "exp": ExpFactory([1.0, 2.0, 3.0]),  # 3 pts, a·exp(b·x)+c
+        "poly-exp-deg2": PolyExpFactory(  # 4 pts, poly inside exp
+            [1.0, 2.0, 3.0, 4.0], order=2
+        ),
+        "ada-exp": AdaExpFactory(steps=4),  # adaptive exp (4 calls)
     }
 
 
-# ── qermit ZNE fits ────────────────────────────────────────────────────────────
+# ── qermit ZNE fits ──────────────────────────────────────────────────────────
+
 
 def _get_qermit_fits() -> "dict[str, tuple]":
-    """Return an ordered dict mapping short name → (Fit, noise_scaling_list)."""
+    """Return ordered dict: short name → (Fit, noise_scaling_list)."""
     from qermit.zero_noise_extrapolation.zne import Fit
+
     scales = [1, 2, 3]
     return {
-        "linear":      (Fit.linear,      scales),
-        "polynomial":  (Fit.polynomial,  scales),  # deg-2 poly (3 pts)
+        "linear": (Fit.linear, scales),
+        "polynomial": (Fit.polynomial, scales),  # deg-2 poly (3 pts)
         "exponential": (Fit.exponential, scales),
-        "cube-root":   (Fit.cube_root,   scales),
-        "richardson":  (Fit.richardson,  scales),  # Richardson with 3 pts
+        "cube-root": (Fit.cube_root, scales),
+        "richardson": (Fit.richardson, scales),  # Richardson with 3 pts
     }
 
 
-# ── Qiskit manual ZNE fits ─────────────────────────────────────────────────────
+# ── Qiskit manual ZNE fits ───────────────────────────────────────────────────
 
 #  degree → (scale_factors, human_readable_label)
 _QISKIT_ZNE_FITS: "dict[str, tuple]" = {
-    "linear":    (1, [1, 3, 5]),
+    "linear": (1, [1, 3, 5]),
     "poly-deg2": (2, [1, 3, 5, 7]),  # 4 pts for stable deg-2 fit
 }
 
 
-# ── mitiq ZNE ─────────────────────────────────────────────────────────────────
+# ── mitiq ZNE ────────────────────────────────────────────────────────────────
+
 
 def benchmark_mitiq_zne(
-    circuit, n_qubits: int, noise_level: float, shots: int,
+    circuit,
+    n_qubits: int,
+    noise_level: float,
+    shots: int,
     factory=None,
 ) -> Tuple[float, float, float, int]:
     """
@@ -314,15 +335,20 @@ def benchmark_mitiq_zne(
     return noisy_val, mitigated, elapsed, counter.n
 
 
-# ── qermit ZNE ────────────────────────────────────────────────────────────────
+# ── qermit ZNE ───────────────────────────────────────────────────────────────
+
 
 def benchmark_qermit_zne(
-    circuit, n_qubits: int, noise_level: float, shots: int,
+    circuit,
+    n_qubits: int,
+    noise_level: float,
+    shots: int,
     fit_type=None,
     noise_scaling_list=None,
 ) -> Tuple[float, float, float, int]:
     """
-    Benchmark qermit ZNE using AerBackend with a per-qubit depolarising noise model.
+    Benchmark qermit ZNE using AerBackend with per-qubit
+    depolarising noise model.
 
     Parameters
     ----------
@@ -346,7 +372,11 @@ def benchmark_qermit_zne(
     from pytket.utils import QubitPauliOperator
     from pytket.extensions.qiskit import AerBackend
     from qermit import (
-        AnsatzCircuit, ObservableExperiment, ObservableTracker, SymbolsDict, MitEx,
+        AnsatzCircuit,
+        ObservableExperiment,
+        ObservableTracker,
+        SymbolsDict,
+        MitEx,
     )
     from qermit.zero_noise_extrapolation import Folding, gen_ZNE_MitEx
     from qermit.zero_noise_extrapolation.zne import Fit
@@ -357,6 +387,7 @@ def benchmark_qermit_zne(
     # GHZ / mirror / decomposed QV all export to valid QASM 2.0.
     try:
         from pytket.qasm import circuit_from_qasm_str
+
         tk_circuit = circuit_from_qasm_str(circuit.to_qasm())
     except Exception:
         # Fallback: build GHZ natively (e.g. if circuit uses non-QASM gates)
@@ -365,7 +396,8 @@ def benchmark_qermit_zne(
         for i in range(n_qubits - 1):
             tk_circuit.CX(i, i + 1)
 
-    # ── per-qubit noise model (add_all_qubit_quantum_error is rejected by AerBackend) ─
+    # per-qubit noise model
+    # (add_all_qubit_quantum_error is rejected by AerBackend)
     nm = NoiseModel()
     e1 = depolarizing_error(noise_level, 1)
     e2 = depolarizing_error(noise_level * 10, 2)
@@ -410,7 +442,8 @@ def benchmark_qermit_zne(
     return noisy_val, mitigated, elapsed, len(noise_scaling_list)
 
 
-# ── Qiskit ZNE ────────────────────────────────────────────────────────────────
+# ── Qiskit ZNE ───────────────────────────────────────────────────────────────
+
 
 def _fold_circuit_global(qc, scale: int):
     """
@@ -427,7 +460,7 @@ def _fold_circuit_global(qc, scale: int):
     return folded
 
 
-def _get_qiskit_circuit(circuit, n_qubits: int) -> "QuantumCircuit":
+def _get_qiskit_circuit(circuit, n_qubits: int):
     """
     Convert the benchmark circuit to a Qiskit QuantumCircuit.
 
@@ -438,7 +471,6 @@ def _get_qiskit_circuit(circuit, n_qubits: int) -> "QuantumCircuit":
     from qiskit import QuantumCircuit
 
     try:
-        import cirq
         # Use cirq's QASM export (works for Clifford + CX circuits)
         qasm_str = circuit.to_qasm()
         qc = QuantumCircuit.from_qasm_str(qasm_str)
@@ -456,7 +488,10 @@ def _get_qiskit_circuit(circuit, n_qubits: int) -> "QuantumCircuit":
 
 
 def benchmark_qiskit_zne(
-    circuit, n_qubits: int, noise_level: float, shots: int,
+    circuit,
+    n_qubits: int,
+    noise_level: float,
+    shots: int,
     degree: int = 1,
     scale_factors: "list[int] | None" = None,
 ) -> Tuple[float, float, float, int]:
@@ -478,7 +513,7 @@ def benchmark_qiskit_zne(
     Uses ``optimization_level=0`` in transpile to prevent gate cancellations.
     No cloud credentials required.
     """
-    from qiskit import QuantumCircuit, transpile
+    from qiskit import transpile
     from qiskit_aer import AerSimulator
     from qiskit_aer.noise import NoiseModel, depolarizing_error
 
@@ -511,8 +546,7 @@ def benchmark_qiskit_zne(
     return noisy_val, mitigated, elapsed, len(scale_factors)
 
 
-
-# ── table output ──────────────────────────────────────────────────────────────
+# ── table output ─────────────────────────────────────────────────────────────
 
 _COL = (25, 8, 8, 10, 8, 9, 7, 5, 5)
 _HDR = (
@@ -541,7 +575,8 @@ def _row(name, ideal, noisy, mitigated, elapsed, n_circs, n1, n2):
     )
 
 
-# ── main ──────────────────────────────────────────────────────────────────────
+# ── main ─────────────────────────────────────────────────────────────────────
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -549,17 +584,26 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "--circuit", choices=["ghz", "qv", "mirror"], default="ghz",
+        "--circuit",
+        choices=["ghz", "qv", "mirror"],
+        default="ghz",
         help="Circuit type (default: ghz)",
     )
-    parser.add_argument("--n-qubits", type=int, default=4,
-                        help="Number of qubits (default: 4)")
-    parser.add_argument("--depth", type=int, default=4,
-                        help="Circuit depth for qv/mirror (default: 4)")
-    parser.add_argument("--noise-level", type=float, default=0.01,
-                        help="Single-qubit depolarising probability (default: 0.01)")
-    parser.add_argument("--shots", type=int, default=8192,
-                        help="Shots per circuit (default: 8192)")
+    parser.add_argument(
+        "--n-qubits", type=int, default=4, help="Number of qubits (default: 4)"
+    )
+    parser.add_argument(
+        "--depth", type=int, default=4, help="Circuit depth for qv/mirror (default: 4)"
+    )
+    parser.add_argument(
+        "--noise-level",
+        type=float,
+        default=0.01,
+        help="Single-qubit depolarising probability (default: 0.01)",
+    )
+    parser.add_argument(
+        "--shots", type=int, default=8192, help="Shots per circuit (default: 8192)"
+    )
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument(
         "--tool",
@@ -568,7 +612,8 @@ def main() -> None:
         help="Run a specific tool only (default: all).",
     )
     parser.add_argument(
-        "--factories", action="store_true",
+        "--factories",
+        action="store_true",
         help=(
             "Run all extrapolation factories / fits for each selected tool "
             "instead of only the default linear one."
@@ -577,6 +622,7 @@ def main() -> None:
     args = parser.parse_args()
 
     import warnings
+
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
     warnings.filterwarnings("ignore", message=".*global phase.*")
@@ -586,6 +632,7 @@ def main() -> None:
     warnings.filterwarnings("ignore", message=".*Covariance of the parameters.*")
     try:
         from scipy.optimize import OptimizeWarning
+
         warnings.filterwarnings("ignore", category=OptimizeWarning)
     except ImportError:
         pass
@@ -594,8 +641,9 @@ def main() -> None:
 
     print(
         f"\nZNE Benchmark\n"
-        f"circuit={args.circuit}  n_qubits={args.n_qubits}  depth={args.depth}  "
-        f"noise_level={args.noise_level}  shots={args.shots}"
+        f"circuit={args.circuit}  n_qubits={args.n_qubits}  "
+        f"depth={args.depth}  noise_level={args.noise_level}  "
+        f"shots={args.shots}"
     )
     print("=" * len(_HDR))
 
@@ -603,25 +651,37 @@ def main() -> None:
         args.circuit, args.n_qubits, args.depth, args.seed
     )
     n1, n2 = _count_gates(circuit)
-    print(f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}   1Q gates: {n1}   2Q gates: {n2}\n")
+    print(
+        f"Ideal ⟨Z⊗{args.n_qubits}⟩ = {ideal:.6f}"
+        f"   1Q gates: {n1}   2Q gates: {n2}\n"
+    )
     print(_HDR)
     print(_SEP)
 
-    tools_to_run = (
-        ["mitiq", "qermit", "qiskit"]
-        if args.tool == "all"
-        else [args.tool]
-    )
+    tools_to_run = ["mitiq", "qermit", "qiskit"] if args.tool == "all" else [args.tool]
 
     # ── helper to emit one row ─────────────────────────────────────────────────
     def _run_row(display_name, fn, extra_kwargs=None):
         try:
-            kw = dict(circuit=circuit, n_qubits=args.n_qubits,
-                      noise_level=args.noise_level, shots=args.shots)
+            kw = dict(
+                circuit=circuit,
+                n_qubits=args.n_qubits,
+                noise_level=args.noise_level,
+                shots=args.shots,
+            )
             if extra_kwargs:
                 kw.update(extra_kwargs)
             noisy, mitigated, elapsed, n_circs = fn(**kw)
-            _row(display_name, ideal, noisy, mitigated, elapsed, n_circs, n1, n2)
+            _row(
+                display_name,
+                ideal,
+                noisy,
+                mitigated,
+                elapsed,
+                n_circs,
+                n1,
+                n2,
+            )
         except ImportError as exc:
             print(f"{display_name:<{_COL[0]}} SKIP (missing dep): {exc}")
         except Exception as exc:
@@ -633,8 +693,9 @@ def main() -> None:
             if args.factories:
                 print(f"\n── mitiq.zne factories ({'─'*40})")
                 for fname, fac in _get_mitiq_factories().items():
-                    _run_row(f"mitiq.zne ({fname})", benchmark_mitiq_zne,
-                             {"factory": fac})
+                    _run_row(
+                        f"mitiq.zne ({fname})", benchmark_mitiq_zne, {"factory": fac}
+                    )
             else:
                 _run_row("mitiq.zne", benchmark_mitiq_zne)
 
@@ -642,8 +703,11 @@ def main() -> None:
             if args.factories:
                 print(f"\n── qermit ZNE fits ({'─'*43})")
                 for fname, (fit_t, scales) in _get_qermit_fits().items():
-                    _run_row(f"qermit ({fname})", benchmark_qermit_zne,
-                             {"fit_type": fit_t, "noise_scaling_list": scales})
+                    _run_row(
+                        f"qermit ({fname})",
+                        benchmark_qermit_zne,
+                        {"fit_type": fit_t, "noise_scaling_list": scales},
+                    )
             else:
                 _run_row("qermit ZNE", benchmark_qermit_zne)
 
@@ -651,8 +715,11 @@ def main() -> None:
             if args.factories:
                 print(f"\n── Qiskit ZNE (manual) fits ({'─'*35})")
                 for fname, (deg, scales) in _QISKIT_ZNE_FITS.items():
-                    _run_row(f"Qiskit ZNE ({fname})", benchmark_qiskit_zne,
-                             {"degree": deg, "scale_factors": scales})
+                    _run_row(
+                        f"Qiskit ZNE ({fname})",
+                        benchmark_qiskit_zne,
+                        {"degree": deg, "scale_factors": scales},
+                    )
             else:
                 _run_row("Qiskit ZNE (manual)", benchmark_qiskit_zne)
 
@@ -669,20 +736,23 @@ def main() -> None:
             "\n         — PolyFactory(deg=2): quadratic fit (3 pts)."
             "\n         — ExpFactory: a·exp(b·x)+c (3 pts)."
             "\n         — PolyExpFactory(deg=2): (a+bx+cx²)·exp(dx) (4 pts)."
-            "\n         — AdaExpFactory(steps=4): adaptive exp — queries 4 pts chosen on-the-fly."
+            "\n         — AdaExpFactory(steps=4): adaptive exp,"
+            "  queries 4 pts on-the-fly."
             "\n  qermit — polynomial: degree-2 poly (3 pts)."
             "\n         — cube_root: a+b(x+c)^(1/3) (3 pts)."
             "\n         — richardson: Richardson extrapolation (3 pts)."
-            "\n  Qiskit — poly-deg2: quadratic numpy.polyfit (4 pts, scales 1,3,5,7)."
+            "\n  Qiskit — poly-deg2: quadratic polyfit"
+            " (4 pts, scales 1,3,5,7)."
             "\n"
             "\nHigher-order factories are more sensitive to shot noise."
             " Increase --shots for stable results."
         )
     if not args.factories:
         print(
-            "Qiskit ZNE (manual) uses AerSimulator with global circuit folding "
-            "(scales 1,3,5) + linear extrapolation — works locally without cloud credentials."
-            "\nUse --factories to compare all extrapolation variants."
+            "Qiskit ZNE (manual): AerSimulator, global folding"
+            " (scales 1,3,5) + linear extrapolation.\n"
+            "No cloud credentials required.\n"
+            "Use --factories to compare all extrapolation variants."
         )
 
 

--- a/scripts/requirements-benchmark.txt
+++ b/scripts/requirements-benchmark.txt
@@ -1,0 +1,6 @@
+mitiq>=1.0.0
+mthree
+qermit
+qiskit
+qiskit-aer
+qiskit-ibm-runtime

--- a/scripts/requirements-benchmark.txt
+++ b/scripts/requirements-benchmark.txt
@@ -1,6 +1,0 @@
-mitiq>=1.0.0
-mthree
-qermit
-qiskit
-qiskit-aer
-qiskit-ibm-runtime


### PR DESCRIPTION
## Description

Closes #2876

Three standalone benchmark scripts under `scripts/` comparing mitiq against equivalent tools on standard quantum circuits:

- `scripts/benchmark_zne.py`: mitiq.zne, qermit, Qiskit manual ZNE on GHZ/QV/mirror
- `scripts/benchmark_meas_mitigation.py`: mitiq.rem, TREX, mthree on GHZ
- `scripts/benchmark_pec.py`: mitiq.pec and qermit PEC (monkey-patch fix for `random_commuting_clifford` qubit-mapping bug in pytket-qiskit 0.77); Qiskit PEC skipped (requires IBM Quantum cloud credentials)
- `pyproject.toml`: dependency groups `[meas]`, `[zne]`, `[pec]`, `[dev]`

### How to run

```bash
pip install -e ".[meas,zne,pec]"
python scripts/benchmark_meas_mitigation.py
python scripts/benchmark_zne.py --circuit ghz
python scripts/benchmark_zne.py --circuit qv
python scripts/benchmark_zne.py --circuit mirror
python scripts/benchmark_pec.py
```

AI assistance disclosed: Claude used for scaffolding and boilerplate; all quantum logic, results, and analysis manually verified and executed locally.

---

### License
- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

- [ ] I added unit tests for new code.
- [x] I used type hints in function signatures.
- [x] I used Google-style docstrings for functions.
- [ ] I updated the documentation where relevant.