### PR TITLE
Support representations directly in PEA (closes #2936)

### DIFF
--- a/docs/source/guide/pea-1-intro.md
+++ b/docs/source/guide/pea-1-intro.md
@@ -103,6 +103,15 @@ print(f"Error with PEA: {abs(ideal_value - mitigated_result):.3f}")
 
 Here we observe that the application of PEA reduces the estimation error when compared to the unmitigated result.
 In the example above, both the noise amplification and extrapolation steps were taken behind the scenes thanks to the default options of {func}`.execute_with_pea`.
+
+```{note}
+Above we let Mitiq build the noise representations from the `noise_model` string. This is the legacy
+interface and emits a `DeprecationWarning`. The recommended way is to pass `representations`, a list of
+{class}`.OperationRepresentation` objects (one per operation), which also lets PEA work with noise
+learned from hardware. See [What additional options are available in PEA?](pea-3-options.md) for
+details.
+```
+
 In the following pages, we describe additional options and show how to apply the two steps of PEA independently.
 
 ## Two-stage PEA workflow

--- a/docs/source/guide/pea-3-options.md
+++ b/docs/source/guide/pea-3-options.md
@@ -14,8 +14,54 @@ kernelspec:
 # What additional options are available in PEA?
 
 {func}`.execute_with_pea` exposes several optional arguments beyond the required `circuit`, `executor`,
-`scale_factors`, `noise_model`, `epsilon`, and `extrapolation_method`.
+`scale_factors`, and `extrapolation_method`, together with the noise amplification specified either by
+`representations` or by the legacy `noise_model` and `epsilon` pair.
 This page describes each one.
+
+## Choosing how the noise is amplified
+
+PEA needs a quasi-probability representation of each operation in the circuit so it can amplify the
+noise in a controlled way. There are two mutually exclusive ways to provide it.
+
+The recommended way is to pass `representations`, a list of {class}`.OperationRepresentation` objects
+(one per unique operation in the circuit). Because these can be learned from hardware characterization,
+this is the only interface that lets PEA run on noise that is neither local nor global depolarizing:
+
+```{code} python
+# reps: list[OperationRepresentation], e.g. learned from hardware
+mitigated = pea.execute_with_pea(
+    circuit,
+    executor,
+    scale_factors=[1.0, 1.2, 1.6],
+    extrapolation_method=LinearFactory.extrapolate,
+    representations=reps,
+)
+```
+
+The representations are amplified with the canonical noise scaling of Section D of
+{cite}`Mari_2021_PRA`: the deviation of each representation from the identity is scaled by the scale
+factor, which keeps the coefficients summing to one. That construction shows any quasi-probability
+representation induces a canonical noise channel that is linear in a single noise parameter, so this
+scaling is well defined for noise that is neither local nor global depolarizing.
+
+The legacy way is to pass `noise_model` together with `epsilon`. Mitiq then builds the depolarizing
+representations for you. This path is kept for backward compatibility and emits a `DeprecationWarning`;
+prefer `representations`:
+
+```{code} python
+mitigated = pea.execute_with_pea(
+    circuit,
+    executor,
+    scale_factors=[1.0, 1.2, 1.6],
+    extrapolation_method=LinearFactory.extrapolate,
+    noise_model="local_depolarizing",   # legacy
+    epsilon=0.005,
+)
+```
+
+Passing both `representations` and `noise_model`, or neither, raises a `ValueError`. When the
+representations correspond to a global depolarizing model, the two paths produce identical results at
+every scale factor.
 
 ## Controlling the sampling budget
 
@@ -105,6 +151,7 @@ If no observable is provided, the executor must return the expectation value dir
 ## Supported noise models
 
 ```{attention}
-The only supported noise models are currently `"local_depolarizing"` and `"global_depolarizing"`.
-Please [open an issue](https://github.com/unitaryfoundation/mitiq/issues/new) to request additional noise models.
+The built-in `noise_model` strings are currently `"local_depolarizing"` and `"global_depolarizing"`.
+To amplify any other noise, pass `representations` directly (see [Choosing how the noise is
+amplified](#choosing-how-the-noise-is-amplified) above), which is not restricted to these two models.
 ```

--- a/docs/source/guide/pea-3-options.md
+++ b/docs/source/guide/pea-3-options.md
@@ -38,11 +38,14 @@ mitigated = pea.execute_with_pea(
 )
 ```
 
-The representations are amplified with the canonical noise scaling of Section D of
-{cite}`Mari_2021_PRA`: the deviation of each representation from the identity is scaled by the scale
-factor, which keeps the coefficients summing to one. That construction shows any quasi-probability
-representation induces a canonical noise channel that is linear in a single noise parameter, so this
-scaling is well defined for noise that is neither local nor global depolarizing.
+The representations are amplified with the canonical noise scaling of Sec. VI D of
+{cite}`Mari_2021_PRA`. The rule depends on the sign structure of each representation. An all-positive
+representation (a genuine probability distribution, e.g. one learned from hardware) is scaled by its
+deviation from the identity. A signed representation (one with negative coefficients, e.g. a PEC-style
+decomposition) is scaled by the canonical sign-partition rule of Eq. (43), which scales the positive and
+negative volumes separately so that amplifying it adds noise instead of amplifying the error
+cancellation. Both rules keep the coefficients summing to one, and the scaling is well defined for noise
+that is neither local nor global depolarizing.
 
 The legacy way is to pass `noise_model` together with `epsilon`. Mitiq then builds the depolarizing
 representations for you. This path is kept for backward compatibility and emits a `DeprecationWarning`;

--- a/docs/source/guide/pea-4-low-level.md
+++ b/docs/source/guide/pea-4-low-level.md
@@ -76,6 +76,10 @@ scaled_circuits, scaled_signs, scaled_norms = pea.construct_circuits(
 )
 ```
 
+Here we use the legacy `noise_model` interface for brevity. You can instead pass `representations` (a
+list of {class}`.OperationRepresentation`, e.g. learned from hardware), which is the recommended option.
+See [What additional options are available in PEA?](pea-3-options.md).
+
 For each scale factor, `construct_circuits` returns a list of probabilistically sampled circuits.
 We can inspect how many circuits were sampled and examine an example from each scale factor:
 

--- a/mitiq/experimental/pea/pea.py
+++ b/mitiq/experimental/pea/pea.py
@@ -15,7 +15,9 @@ from cirq import Circuit
 from mitiq import QPROGRAM, Executor, Observable, QuantumResult
 from mitiq.experimental.pea.scale_amplifications import (
     scale_circuit_amplifications,
+    scale_representations,
 )
+from mitiq.pec import OperationRepresentation
 from mitiq.pec.pec import (
     _LARGE_SAMPLE_WARN,
     LargeSampleWarning,
@@ -23,11 +25,80 @@ from mitiq.pec.pec import (
 )
 
 
+def _resolve_amplifications(
+    circuit: Circuit,
+    representations: Sequence[OperationRepresentation] | None,
+    noise_model: str | None,
+    epsilon: float | None,
+) -> Callable[[float], Sequence[OperationRepresentation]]:
+    """Validates the noise-amplification arguments and returns a function that
+    builds the amplified representations at a given scale factor.
+
+    Exactly one of ``representations`` or the ``(noise_model, epsilon)`` pair
+    must be supplied. When ``representations`` is given, the returned function
+    scales them with canonical noise scaling. When ``noise_model`` is given
+    (the legacy path), the returned function rebuilds the amplifications at
+    ``scale_factor * epsilon`` and a ``DeprecationWarning`` steers the caller
+    toward ``representations``.
+
+    Args:
+        circuit: The ideal circuit whose operations are represented.
+        representations: User-supplied quasi-probability representations, or
+            None to use the noise-model path.
+        noise_model: The legacy noise-model string, or None.
+        epsilon: The baseline noise level for the legacy path, or None.
+
+    Returns:
+        A function mapping a scale factor to the amplified representations.
+
+    Raises:
+        ValueError: If both ``representations`` and ``noise_model`` are given,
+            or if neither is given.
+    """
+    if representations is not None and noise_model is not None:
+        raise ValueError(
+            "Provide either 'representations' or 'noise_model', not both."
+        )
+    if representations is None and noise_model is None:
+        raise ValueError(
+            "Provide either 'representations' (a list of "
+            "OperationRepresentation) or 'noise_model' together with "
+            "'epsilon'."
+        )
+
+    if representations is not None:
+        if len(representations) == 0:
+            raise ValueError(
+                "'representations' is empty. Provide one "
+                "OperationRepresentation per unique operation of the circuit."
+            )
+        reps = representations
+        return lambda scale_factor: scale_representations(reps, scale_factor)
+
+    if epsilon is None:
+        raise ValueError(
+            "'epsilon' must be given together with 'noise_model'."
+        )
+    assert noise_model is not None  # guaranteed by the checks above
+    model, base_noise = noise_model, epsilon
+    warnings.warn(
+        "The 'noise_model'/'epsilon' interface is legacy. Pass "
+        "'representations' (a list of OperationRepresentation) instead, which "
+        "also works with noise learned from hardware. See the PEA user guide.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    return lambda scale_factor: scale_circuit_amplifications(
+        circuit, scale_factor, model, base_noise
+    )
+
+
 def construct_circuits(
     circuit: Circuit,
     scale_factors: list[float],
-    noise_model: str,
-    epsilon: float,
+    representations: Sequence[OperationRepresentation] | None = None,
+    noise_model: str | None = None,
+    epsilon: float | None = None,
     random_state: int | np.random.RandomState | None = None,
     precision: float = 0.1,
     num_samples: int | None = None,
@@ -40,15 +111,29 @@ def construct_circuits(
     for instance U = V W, as long as a representation is known. Similarly, A
     and B can be sequences of operations (circuits) or just single operations.
 
+    The noise amplification can be specified in two ways, which are mutually
+    exclusive. Either pass ``representations`` (a list of
+    :class:`.OperationRepresentation`, e.g. learned from hardware) which are
+    amplified directly with canonical noise scaling, or pass the legacy
+    ``noise_model`` string together with ``epsilon``.
+
     Args:
         circuit: The ideal circuit from which an implementable
             sequence is sampled.
         scale_factors: A list of (positive) numbers by which the baseline
             noise level is to be amplified.
+        representations: A list of :class:`.OperationRepresentation`, one per
+            unique operation of ``circuit``, giving the quasi-probability
+            decomposition of each ideal operation. When provided, these are
+            amplified directly and ``noise_model``/``epsilon`` must not be
+            given. This is the recommended interface and is the only one that
+            supports noise learned from hardware.
         noise_model: A string describing the noise model to be used for the
             noise-scaled representations, e.g. "local_depolarizing" or
-            "global_depolarizing".
-        epsilon: Baseline noise level.
+            "global_depolarizing". Legacy: prefer ``representations``. Must be
+            given together with ``epsilon``.
+        epsilon: Baseline noise level for the legacy ``noise_model`` path.
+            Ignored when ``representations`` is given.
         random_state: The random state or seed for reproducibility.
         precision: The desired precision for the sampling process.
             Default is 0.1.
@@ -58,8 +143,14 @@ def construct_circuits(
     Returns:
         The scaled circuits, their signs and norms at each scale factor.
     Raises:
-        ValueError: If the precision is not within the interval (0, 1].
+        ValueError: If the precision is not within the interval (0, 1], or if
+            the noise-amplification arguments are not given as exactly one of
+            ``representations`` or the ``(noise_model, epsilon)`` pair.
     """
+    amplify = _resolve_amplifications(
+        circuit, representations, noise_model, epsilon
+    )
+
     if isinstance(random_state, int):
         random_state = np.random.RandomState(random_state)
 
@@ -72,7 +163,7 @@ def construct_circuits(
     # Get the 1-norm of the circuit quasi-probability representation
     _, _, norm = sample_circuit(
         circuit,
-        scale_circuit_amplifications(circuit, 1.0, noise_model, epsilon),
+        amplify(1.0),
         num_samples=1,
     )
 
@@ -89,7 +180,7 @@ def construct_circuits(
     for s in scale_factors:
         sampled_circuits, signs, norm = sample_circuit(
             circuit,
-            scale_circuit_amplifications(circuit, s, noise_model, epsilon),
+            amplify(s),
             num_samples=num_samples,
             random_state=random_state,
         )
@@ -148,9 +239,10 @@ def execute_with_pea(
     circuit: Circuit,
     executor: Executor | Callable[[QPROGRAM], QuantumResult],
     scale_factors: list[float],
-    noise_model: str,
-    epsilon: float,
     extrapolation_method: Callable[[Sequence[float], Sequence[float]], float],
+    representations: Sequence[OperationRepresentation] | None = None,
+    noise_model: str | None = None,
+    epsilon: float | None = None,
     observable: Observable | None = None,
     random_state: int | np.random.RandomState | None = None,
     precision: float = 0.1,
@@ -180,13 +272,21 @@ def execute_with_pea(
             unmitigated ``QuantumResult`` (e.g. an expectation value).
         scale_factors: A list of (positive) numbers by which the baseline
             noise level is to be amplified.
-        noise_model: A string describing the noise model to be used for the
-            noise-scaled representations, e.g. "local_depolarizing" or
-            "global_depolarizing".
-        epsilon: Baseline noise level.
         extrapolation_method: The method of extrapolation to use when fitting
             the measured results. A list of built-in functions can be found
             in ``mitiq.zne.inference``.
+        representations: A list of :class:`.OperationRepresentation`, one per
+            unique operation of ``circuit``, giving the quasi-probability
+            decomposition of each ideal operation. When provided, these are
+            amplified directly and ``noise_model``/``epsilon`` must not be
+            given. This is the recommended interface and is the only one that
+            supports noise learned from hardware.
+        noise_model: A string describing the noise model to be used for the
+            noise-scaled representations, e.g. "local_depolarizing" or
+            "global_depolarizing". Legacy: prefer ``representations``. Must be
+            given together with ``epsilon``.
+        epsilon: Baseline noise level for the legacy ``noise_model`` path.
+            Ignored when ``representations`` is given.
         observable: Observable to compute the expectation value of. If None,
             the `executor` must return an expectation value. Otherwise,
             the `QuantumResult` returned by `executor` is used to compute the
@@ -207,15 +307,21 @@ def execute_with_pea(
         which contains all the raw data involved in the PEA process. If
         ``full_output`` is ``False``, only ``pea_value`` is
         returned.
+
+    Raises:
+        ValueError: If the noise-amplification arguments are not given as
+            exactly one of ``representations`` or the ``(noise_model,
+            epsilon)`` pair.
     """
     scaled_circuits, scaled_signs, scaled_norms = construct_circuits(
         circuit,
         scale_factors,
-        noise_model,
-        epsilon,
-        random_state,
-        precision,
-        num_samples,
+        representations=representations,
+        noise_model=noise_model,
+        epsilon=epsilon,
+        random_state=random_state,
+        precision=precision,
+        num_samples=num_samples,
     )
     # Execute all sampled circuits
     if not isinstance(executor, Executor):

--- a/mitiq/experimental/pea/pea.py
+++ b/mitiq/experimental/pea/pea.py
@@ -53,7 +53,9 @@ def _resolve_amplifications(
 
     Raises:
         ValueError: If both ``representations`` and ``noise_model`` are given,
-            or if neither is given.
+            if neither is given, or if ``epsilon`` is passed together with
+            ``representations`` (``epsilon`` only applies to the legacy
+            ``noise_model`` path).
     """
     if representations is not None and noise_model is not None:
         raise ValueError(
@@ -64,6 +66,11 @@ def _resolve_amplifications(
             "Provide either 'representations' (a list of "
             "OperationRepresentation) or 'noise_model' together with "
             "'epsilon'."
+        )
+    if representations is not None and epsilon is not None:
+        raise ValueError(
+            "'epsilon' only applies to the legacy 'noise_model' path; do "
+            "not pass it together with 'representations'."
         )
 
     if representations is not None:
@@ -133,7 +140,7 @@ def construct_circuits(
             "global_depolarizing". Legacy: prefer ``representations``. Must be
             given together with ``epsilon``.
         epsilon: Baseline noise level for the legacy ``noise_model`` path.
-            Ignored when ``representations`` is given.
+            Must not be combined with ``representations``.
         random_state: The random state or seed for reproducibility.
         precision: The desired precision for the sampling process.
             Default is 0.1.
@@ -286,7 +293,7 @@ def execute_with_pea(
             "global_depolarizing". Legacy: prefer ``representations``. Must be
             given together with ``epsilon``.
         epsilon: Baseline noise level for the legacy ``noise_model`` path.
-            Ignored when ``representations`` is given.
+            Must not be combined with ``representations``.
         observable: Observable to compute the expectation value of. If None,
             the `executor` must return an expectation value. Otherwise,
             the `QuantumResult` returned by `executor` is used to compute the

--- a/mitiq/experimental/pea/scale_amplifications.py
+++ b/mitiq/experimental/pea/scale_amplifications.py
@@ -54,6 +54,12 @@ def scale_circuit_amplifications(
     return amp_fn(ideal_circuit, scale_factor * epsilon)
 
 
+# Coefficients with magnitude below this are treated as zero when classifying
+# the sign structure of a representation, so floating-point dust does not
+# misroute the scaling rule.
+_SIGN_TOL = 1e-12
+
+
 def scale_representations(
     representations: Sequence[OperationRepresentation],
     scale_factor: float,
@@ -67,24 +73,24 @@ def scale_representations(
     representations (e.g. learned from hardware characterization) so that PEA
     can be applied to arbitrary noise.
 
-    The scaling follows the "Canonical noise scaling" prescription of Section D
-    of :cite:`Mari_2021_PRA`. That construction shows a quasi-probability
-    representation of an ideal gate induces a canonical noise channel that
-    depends linearly on a single noise parameter, so noise scaling is always
-    well defined for an arbitrary representation. Each representation is a
-    quasi-probability decomposition of an ideal operation into the ideal
-    operation itself (the "identity" term, coefficient :math:`a_0`) plus a set
-    of error terms (coefficients :math:`a_k`). The deviation from the identity
-    is amplified linearly by the scale factor :math:`s`:
+    The scaling follows the "Canonical noise scaling" prescription of Section
+    VI D (Eqs. 38-44) of :cite:`Mari_2021_PRA`. That construction splits a
+    quasi-probability representation into a positive and a negative volume and
+    rescales them so that noise scaling is well defined for an arbitrary
+    representation. The exact rule applied to each representation depends on
+    its sign structure:
 
-    .. math::
+    * **All-positive** representations (a genuine probability distribution,
+      e.g. an ``amplify_*`` decomposition or a noise model learned from
+      hardware, with an explicit identity term) are scaled by deviation from
+      the identity. See :func:`_scale_positive_representation`.
+    * **Signed** representations (containing negative coefficients, e.g. a
+      PEC-style ``represent_operation_with_*`` decomposition) are scaled by
+      the canonical sign-partition rule of Eq. (43). See
+      :func:`_scale_signed_representation`. Scaling these by deviation from the
+      identity would amplify the error cancellation instead of the noise.
 
-        a_0 \rightarrow 1 - s\,(1 - a_0), \qquad a_k \rightarrow s\,a_k .
-
-    This preserves the unit sum of the coefficients and, for the global
-    depolarizing model (and any single-qubit depolarizing channel), reproduces
-    the analytic rebuild at noise level :math:`s\,\epsilon` exactly at every
-    scale factor.
+    Both rules preserve the unit sum of the coefficients.
 
     Args:
         representations: The base (unscaled) quasi-probability representations,
@@ -98,9 +104,44 @@ def scale_representations(
         operations are unchanged; only the coefficients differ.
 
     Raises:
-        ValueError: If a representation has no identity term (a noisy operation
-            equal to its ideal operation) or that term has zero weight, so the
-            deviation from the identity cannot be determined.
+        ValueError: If an all-positive representation has no identity term or a
+            zero-weight identity term, or if a signed representation has no
+            positive volume or ``scale_factor`` exceeds its canonical limit.
+    """
+    return [
+        _scale_signed_representation(rep, scale_factor)
+        if any(coeff < -_SIGN_TOL for coeff in rep.coeffs)
+        else _scale_positive_representation(rep, scale_factor)
+        for rep in representations
+    ]
+
+
+def _scale_positive_representation(
+    representation: OperationRepresentation,
+    scale_factor: float,
+) -> OperationRepresentation:
+    r"""Scales an all-positive representation by deviation from the identity.
+
+    The representation is a quasi-probability decomposition of an ideal
+    operation into the ideal operation itself (the "identity" term,
+    coefficient :math:`a_0`) plus a set of error terms (coefficients
+    :math:`a_k`). The deviation from the identity is amplified linearly by the
+    scale factor :math:`s`:
+
+    .. math::
+
+        a_0 \rightarrow 1 - s\,(1 - a_0), \qquad a_k \rightarrow s\,a_k .
+
+    This preserves the unit sum of the coefficients and, for the global
+    depolarizing model (and any single-qubit depolarizing channel), reproduces
+    the analytic rebuild at noise level :math:`s\,\epsilon` exactly at every
+    scale factor. It is the :math:`\gamma^- = 0` special case of the canonical
+    sign-partition rule (:func:`_scale_signed_representation`).
+
+    Raises:
+        ValueError: If the representation has no identity term (a noisy
+            operation equal to its ideal operation) or that term has zero
+            weight, so the deviation from the identity cannot be determined.
 
     .. note::
         For the two-qubit ``local_depolarizing`` model the per-qubit channels
@@ -110,42 +151,102 @@ def scale_representations(
         single-qubit operations) when exact equivalence with the legacy
         ``noise_model`` path is required.
     """
-    scaled = []
-    for rep in representations:
-        ideal = rep.ideal
-        identity_indices = [
-            i
-            for i, op in enumerate(rep.noisy_operations)
-            if op.circuit == ideal
-        ]
-        identity_weight = sum(rep.coeffs[i] for i in identity_indices)
-        if not identity_indices or identity_weight == 0:
-            raise ValueError(
-                "Cannot scale a representation without a non-zero identity "
-                "term (a noisy operation equal to the ideal operation). The "
-                "canonical noise scaling needs it to measure the deviation "
-                "from the identity."
-            )
-
-        scaled_identity_weight = 1.0 - scale_factor * (1.0 - identity_weight)
-
-        new_coeffs = []
-        for i, coeff in enumerate(rep.coeffs):
-            if i in identity_indices:
-                # Split the scaled identity weight across the identity term(s)
-                # in their original proportions (a single term in practice).
-                new_coeffs.append(
-                    float(coeff / identity_weight * scaled_identity_weight)
-                )
-            else:
-                new_coeffs.append(float(scale_factor * coeff))
-
-        scaled.append(
-            OperationRepresentation(
-                rep.ideal,
-                rep.noisy_operations,
-                new_coeffs,
-                rep.is_qubit_dependent,
-            )
+    ideal = representation.ideal
+    identity_indices = [
+        i
+        for i, op in enumerate(representation.noisy_operations)
+        if op.circuit == ideal
+    ]
+    identity_weight = sum(representation.coeffs[i] for i in identity_indices)
+    if not identity_indices or identity_weight == 0:
+        raise ValueError(
+            "Cannot scale a representation without a non-zero identity "
+            "term (a noisy operation equal to the ideal operation). The "
+            "canonical noise scaling needs it to measure the deviation "
+            "from the identity."
         )
-    return scaled
+
+    scaled_identity_weight = 1.0 - scale_factor * (1.0 - identity_weight)
+
+    new_coeffs = []
+    for i, coeff in enumerate(representation.coeffs):
+        if i in identity_indices:
+            # Split the scaled identity weight across the identity term(s)
+            # in their original proportions (a single term in practice).
+            new_coeffs.append(
+                float(coeff / identity_weight * scaled_identity_weight)
+            )
+        else:
+            new_coeffs.append(float(scale_factor * coeff))
+
+    return OperationRepresentation(
+        representation.ideal,
+        representation.noisy_operations,
+        new_coeffs,
+        representation.is_qubit_dependent,
+    )
+
+
+def _scale_signed_representation(
+    representation: OperationRepresentation,
+    scale_factor: float,
+) -> OperationRepresentation:
+    r"""Scales a signed representation by canonical sign-partition scaling.
+
+    This implements the canonical noise scaling of Section VI D (Eq. 43) of
+    :cite:`Mari_2021_PRA`. The coefficients are split by sign into a positive
+    volume :math:`\gamma^+` and a negative volume :math:`\gamma^-` (with
+    :math:`\gamma^+ - \gamma^- = 1`), and each group is rescaled by
+
+    .. math::
+
+        a_i^+ \rightarrow a_i^+\,
+            \frac{\gamma^+ - s\,\gamma^-}{\gamma^+}, \qquad
+        a_i^- \rightarrow a_i^-\,(1 - s) .
+
+    This preserves the unit sum. In the amplification band
+    :math:`1 \le s \le \gamma^+/\gamma^-` the negative volume vanishes, so the
+    representation becomes a genuine probability distribution (one-norm 1):
+    amplifying it adds real noise rather than amplifying the error
+    cancellation. The scaling is defined up to the canonical limit
+    :math:`s \le \gamma^+/\gamma^-`, where the positive volume reaches zero.
+
+    Raises:
+        ValueError: If the representation has no positive volume, or if
+            ``scale_factor`` exceeds the canonical limit
+            :math:`\gamma^+/\gamma^-`.
+    """
+    coeffs = representation.coeffs
+    pos_volume = sum(coeff for coeff in coeffs if coeff > _SIGN_TOL)
+    neg_volume = -sum(coeff for coeff in coeffs if coeff < -_SIGN_TOL)
+
+    if pos_volume <= 0:
+        raise ValueError(
+            "Cannot scale a signed representation without positive total "
+            "mass (gamma+ > 0)."
+        )
+    if neg_volume > 0 and scale_factor > pos_volume / neg_volume:
+        raise ValueError(
+            f"scale_factor={scale_factor} exceeds the canonical limit "
+            f"gamma+/gamma- = {pos_volume / neg_volume}, beyond which the "
+            "noise-scaled representation is undefined."
+        )
+
+    pos_scaling = (pos_volume - scale_factor * neg_volume) / pos_volume
+    neg_scaling = 1.0 - scale_factor
+
+    new_coeffs = []
+    for coeff in coeffs:
+        if coeff > _SIGN_TOL:
+            new_coeffs.append(float(coeff * pos_scaling))
+        elif coeff < -_SIGN_TOL:
+            new_coeffs.append(float(coeff * neg_scaling))
+        else:
+            new_coeffs.append(0.0)
+
+    return OperationRepresentation(
+        representation.ideal,
+        representation.noisy_operations,
+        new_coeffs,
+        representation.is_qubit_dependent,
+    )

--- a/mitiq/experimental/pea/scale_amplifications.py
+++ b/mitiq/experimental/pea/scale_amplifications.py
@@ -52,3 +52,100 @@ def scale_circuit_amplifications(
         # TODO allow use of custom noise model
 
     return amp_fn(ideal_circuit, scale_factor * epsilon)
+
+
+def scale_representations(
+    representations: Sequence[OperationRepresentation],
+    scale_factor: float,
+) -> list[OperationRepresentation]:
+    r"""Amplifies a list of quasi-probability representations by a scale factor
+    using canonical noise scaling.
+
+    This is the representation-based counterpart of
+    :func:`scale_circuit_amplifications`. Instead of rebuilding the
+    amplifications from a known noise model, it scales user-supplied
+    representations (e.g. learned from hardware characterization) so that PEA
+    can be applied to arbitrary noise.
+
+    The scaling follows the "Canonical noise scaling" prescription of Section D
+    of :cite:`Mari_2021_PRA`. That construction shows a quasi-probability
+    representation of an ideal gate induces a canonical noise channel that
+    depends linearly on a single noise parameter, so noise scaling is always
+    well defined for an arbitrary representation. Each representation is a
+    quasi-probability decomposition of an ideal operation into the ideal
+    operation itself (the "identity" term, coefficient :math:`a_0`) plus a set
+    of error terms (coefficients :math:`a_k`). The deviation from the identity
+    is amplified linearly by the scale factor :math:`s`:
+
+    .. math::
+
+        a_0 \rightarrow 1 - s\,(1 - a_0), \qquad a_k \rightarrow s\,a_k .
+
+    This preserves the unit sum of the coefficients and, for the global
+    depolarizing model (and any single-qubit depolarizing channel), reproduces
+    the analytic rebuild at noise level :math:`s\,\epsilon` exactly at every
+    scale factor.
+
+    Args:
+        representations: The base (unscaled) quasi-probability representations,
+            one per unique operation in the circuit.
+        scale_factor: A (positive) number by which the baseline noise is
+            amplified.
+
+    Returns:
+        A new list of representations with coefficients scaled by
+        ``scale_factor``. The ideal operations and the implementable noisy
+        operations are unchanged; only the coefficients differ.
+
+    Raises:
+        ValueError: If a representation has no identity term (a noisy operation
+            equal to its ideal operation) or that term has zero weight, so the
+            deviation from the identity cannot be determined.
+
+    .. note::
+        For the two-qubit ``local_depolarizing`` model the per-qubit channels
+        combine as a tensor product, so the identity coefficient depends
+        quadratically on the noise level. Linear deviation scaling cannot
+        reproduce that exactly; use ``global_depolarizing`` representations (or
+        single-qubit operations) when exact equivalence with the legacy
+        ``noise_model`` path is required.
+    """
+    scaled = []
+    for rep in representations:
+        ideal = rep.ideal
+        identity_indices = [
+            i
+            for i, op in enumerate(rep.noisy_operations)
+            if op.circuit == ideal
+        ]
+        identity_weight = sum(rep.coeffs[i] for i in identity_indices)
+        if not identity_indices or identity_weight == 0:
+            raise ValueError(
+                "Cannot scale a representation without a non-zero identity "
+                "term (a noisy operation equal to the ideal operation). The "
+                "canonical noise scaling needs it to measure the deviation "
+                "from the identity."
+            )
+
+        scaled_identity_weight = 1.0 - scale_factor * (1.0 - identity_weight)
+
+        new_coeffs = []
+        for i, coeff in enumerate(rep.coeffs):
+            if i in identity_indices:
+                # Split the scaled identity weight across the identity term(s)
+                # in their original proportions (a single term in practice).
+                new_coeffs.append(
+                    float(coeff / identity_weight * scaled_identity_weight)
+                )
+            else:
+                new_coeffs.append(float(scale_factor * coeff))
+
+        scaled.append(
+            OperationRepresentation(
+                rep.ideal,
+                rep.noisy_operations,
+                new_coeffs,
+                rep.is_qubit_dependent,
+            )
+        )
+    return scaled

--- a/mitiq/experimental/pea/tests/test_pea.py
+++ b/mitiq/experimental/pea/tests/test_pea.py
@@ -15,8 +15,10 @@ from mitiq.experimental.pea import (
     execute_with_pea,
 )
 from mitiq.experimental.pea.amplifications.amplify_depolarizing import (
+    amplify_noisy_ops_in_circuit_with_global_depolarizing_noise,
     amplify_noisy_ops_in_circuit_with_local_depolarizing_noise,
 )
+from mitiq.experimental.pea.scale_amplifications import scale_representations
 from mitiq.interface import convert_from_mitiq, convert_to_mitiq
 from mitiq.interface.mitiq_cirq import compute_density_matrix
 from mitiq.pec import (
@@ -222,3 +224,191 @@ def test_pea_data_with_full_output():
     assert np.allclose(
         pea_data["scaled_expectation_values"], scaled_exp_values
     )
+
+
+# Representations interface (issue #2936).
+
+
+def global_depolarizing_representations(circuit, base_noise):
+    """Base (unscaled) global-depolarizing representations for a circuit."""
+    return amplify_noisy_ops_in_circuit_with_global_depolarizing_noise(
+        circuit, base_noise
+    )
+
+
+@pytest.mark.parametrize("scale_factor", [1, 3, 5])
+def test_scale_representations_matches_global_rebuild(scale_factor):
+    """The canonical scaler reproduces the legacy global-depolarizing rebuild
+    at every scale factor, not only at scale_factor=1."""
+    base = global_depolarizing_representations(twoq_circ, BASE_NOISE)
+    scaled = scale_representations(base, scale_factor)
+    rebuilt = amplify_noisy_ops_in_circuit_with_global_depolarizing_noise(
+        twoq_circ, scale_factor * BASE_NOISE
+    )
+    assert scaled == rebuilt
+    for rep in scaled:
+        assert np.isclose(sum(rep.coeffs), 1.0)
+
+
+@pytest.mark.parametrize("scale_factor", [0.5, 1, 3, 5])
+def test_scale_representations_preserves_unit_sum(scale_factor):
+    """Scaling keeps the quasi-probability coefficients summing to one, even
+    for two-qubit local depolarizing where the legacy rebuild is not linear."""
+    base = amplify_noisy_ops_in_circuit_with_local_depolarizing_noise(
+        twoq_circ, BASE_NOISE
+    )
+    for rep in scale_representations(base, scale_factor):
+        assert np.isclose(sum(rep.coeffs), 1.0)
+
+
+def test_scale_representations_requires_identity_term():
+    """A representation with no identity term cannot be scaled."""
+    base = global_depolarizing_representations(oneq_circ, BASE_NOISE)[0]
+    # Drop the identity term (first coeff/op) so the deviation is undefined.
+    broken = OperationRepresentation(
+        base.ideal,
+        base.noisy_operations[1:],
+        [c / sum(base.coeffs[1:]) for c in base.coeffs[1:]],
+        base.is_qubit_dependent,
+    )
+    with pytest.raises(ValueError, match="without a non-zero identity term"):
+        scale_representations([broken], 3)
+
+
+def test_scale_representations_requires_nonzero_identity_weight():
+    """A representation whose identity term has zero weight cannot scale."""
+    base = global_depolarizing_representations(oneq_circ, BASE_NOISE)[0]
+    coeffs = list(base.coeffs)
+    # Move all weight off the identity term while keeping the unit sum.
+    coeffs[1] += coeffs[0]
+    coeffs[0] = 0.0
+    zero_identity = OperationRepresentation(
+        base.ideal,
+        base.noisy_operations,
+        coeffs,
+        base.is_qubit_dependent,
+    )
+    with pytest.raises(ValueError, match="without a non-zero identity term"):
+        scale_representations([zero_identity], 3)
+
+
+def test_construct_circuits_raises_on_empty_representations():
+    with pytest.raises(ValueError, match="'representations' is empty"):
+        construct_circuits(oneq_circ, scale_factors=[1], representations=[])
+
+
+@pytest.mark.parametrize("scale_factors", [[1], [1, 3, 5]])
+def test_construct_circuits_representations_equivalent_to_noise_model(
+    scale_factors,
+):
+    """Passing global-depolarizing representations yields the exact same
+    sampled circuits, signs and norms as the noise_model path, at every scale
+    factor (acceptance criterion of issue #2936)."""
+    reps = global_depolarizing_representations(twoq_circ, BASE_NOISE)
+
+    circuits_reps, signs_reps, norms_reps = construct_circuits(
+        twoq_circ,
+        scale_factors=scale_factors,
+        representations=reps,
+        num_samples=40,
+        random_state=7,
+    )
+    circuits_nm, signs_nm, norms_nm = construct_circuits(
+        twoq_circ,
+        scale_factors=scale_factors,
+        noise_model="global_depolarizing",
+        epsilon=BASE_NOISE,
+        num_samples=40,
+        random_state=7,
+    )
+
+    assert circuits_reps == circuits_nm
+    assert signs_reps == signs_nm
+    assert np.allclose(norms_reps, norms_nm)
+
+
+def test_construct_circuits_with_representations_shape():
+    """construct_circuits accepts representations and returns one entry per
+    scale factor."""
+    reps = global_depolarizing_representations(oneq_circ, BASE_NOISE)
+    scaled_circuits, _, _ = construct_circuits(
+        oneq_circ,
+        scale_factors=[1, 3, 5],
+        representations=reps,
+        num_samples=30,
+        random_state=1,
+    )
+    assert len(scaled_circuits) == 3
+    assert all(len(c) == 30 for c in scaled_circuits)
+
+
+def test_construct_circuits_raises_if_both_provided():
+    reps = global_depolarizing_representations(oneq_circ, BASE_NOISE)
+    with pytest.raises(ValueError, match="not both"):
+        construct_circuits(
+            oneq_circ,
+            scale_factors=[1],
+            representations=reps,
+            noise_model="global_depolarizing",
+            epsilon=BASE_NOISE,
+        )
+
+
+def test_construct_circuits_raises_if_neither_provided():
+    with pytest.raises(ValueError, match="either 'representations'"):
+        construct_circuits(oneq_circ, scale_factors=[1])
+
+
+def test_construct_circuits_raises_if_noise_model_without_epsilon():
+    with pytest.raises(ValueError, match="'epsilon' must be given"):
+        construct_circuits(
+            oneq_circ,
+            scale_factors=[1],
+            noise_model="global_depolarizing",
+        )
+
+
+def test_construct_circuits_noise_model_emits_deprecation_warning():
+    with pytest.warns(DeprecationWarning, match="legacy"):
+        construct_circuits(
+            oneq_circ,
+            scale_factors=[1],
+            noise_model="global_depolarizing",
+            epsilon=BASE_NOISE,
+            num_samples=10,
+            random_state=1,
+        )
+
+
+def test_execute_with_pea_with_representations():
+    """execute_with_pea accepts representations and mitigates noise as well as
+    the equivalent noise_model call."""
+    reps = amplify_noisy_ops_in_circuit_with_local_depolarizing_noise(
+        twoq_circ, BASE_NOISE
+    )
+    true_value = executor(twoq_circ, noise=0.0)
+
+    mitigated = execute_with_pea(
+        twoq_circ,
+        executor,
+        scale_factors=[1, 1.2, 1.6],
+        extrapolation_method=LinearFactory.extrapolate,
+        representations=reps,
+        random_state=101,
+    )
+    assert isinstance(mitigated, float)
+    assert np.isclose(mitigated, true_value, atol=0.1)
+
+
+def test_execute_with_pea_raises_if_both_provided():
+    reps = global_depolarizing_representations(oneq_circ, BASE_NOISE)
+    with pytest.raises(ValueError, match="not both"):
+        execute_with_pea(
+            oneq_circ,
+            executor,
+            scale_factors=[1, 1.2, 1.6],
+            extrapolation_method=LinearFactory.extrapolate,
+            representations=reps,
+            noise_model="global_depolarizing",
+            epsilon=BASE_NOISE,
+        )

--- a/mitiq/experimental/pea/tests/test_pea.py
+++ b/mitiq/experimental/pea/tests/test_pea.py
@@ -412,3 +412,84 @@ def test_execute_with_pea_raises_if_both_provided():
             noise_model="global_depolarizing",
             epsilon=BASE_NOISE,
         )
+
+
+def test_construct_circuits_raises_if_epsilon_with_representations():
+    """epsilon belongs to the legacy noise_model path. Passing it alongside
+    representations is a misuse and is rejected, mirroring the noise_model
+    mutual-exclusion check."""
+    reps = global_depolarizing_representations(oneq_circ, BASE_NOISE)
+    with pytest.raises(ValueError, match="only applies to the legacy"):
+        construct_circuits(
+            oneq_circ,
+            scale_factors=[1],
+            representations=reps,
+            epsilon=BASE_NOISE,
+        )
+
+
+# Signed (PEC-style) representations: canonical sign-partition noise scaling
+# (Mari_2021_PRA, Sec. VI D, Eqs. 38-44). Amplifying these by deviation
+# scaling would amplify error cancellation instead of noise, so they take a
+# separate branch.
+
+
+def signed_pec_representation(noise_level=0.1):
+    """A signed (PEC-style) global-depolarizing representation of an X gate.
+
+    Its quasi-probability coefficients are not all positive (one positive
+    volume term plus negative Pauli terms), so it exercises the canonical
+    sign-partition branch rather than deviation-from-identity scaling.
+    """
+    from mitiq.pec.representations.depolarizing import (
+        represent_operation_with_global_depolarizing_noise,
+    )
+
+    return represent_operation_with_global_depolarizing_noise(
+        cirq.Circuit(cirq.X.on(q0)), noise_level
+    )
+
+
+def _sign_volumes(coeffs):
+    pos = sum(c for c in coeffs if c > 0)
+    neg = -sum(c for c in coeffs if c < 0)
+    return pos, neg
+
+
+@pytest.mark.parametrize("scale_factor", [0.5, 1, 3, 5])
+def test_scale_signed_representation_matches_canonical(scale_factor):
+    """A signed representation is scaled by the canonical sign-partition rule
+    of Eq. (43): the positive volume by (gamma+ - s gamma-)/gamma+ and the
+    negative volume by (1 - s), not by deviation-from-identity scaling."""
+    base = signed_pec_representation()
+    gamma_plus, gamma_minus = _sign_volumes(base.coeffs)
+    pos_scaling = (gamma_plus - scale_factor * gamma_minus) / gamma_plus
+    neg_scaling = 1 - scale_factor
+    expected = [
+        c * pos_scaling if c > 0 else c * neg_scaling for c in base.coeffs
+    ]
+    (scaled,) = scale_representations([base], scale_factor)
+    assert np.allclose(scaled.coeffs, expected)
+    assert np.isclose(sum(scaled.coeffs), 1.0)
+
+
+@pytest.mark.parametrize("scale_factor", [1, 2, 5])
+def test_scale_signed_representation_reduces_negativity(scale_factor):
+    """Amplifying a signed representation (s >= 1) drives its negative volume
+    to zero rather than increasing it. Deviation scaling did the opposite,
+    scaling the signed coefficients by s and amplifying cancellation."""
+    base = signed_pec_representation()
+    _, base_neg = _sign_volumes(base.coeffs)
+    (scaled,) = scale_representations([base], scale_factor)
+    _, scaled_neg = _sign_volumes(scaled.coeffs)
+    assert base_neg > 0
+    assert scaled_neg <= 1e-12
+
+
+def test_scale_signed_representation_above_limit_raises():
+    """Scaling beyond the canonical limit gamma+/gamma- is rejected."""
+    base = signed_pec_representation()
+    gamma_plus, gamma_minus = _sign_volumes(base.coeffs)
+    too_large = gamma_plus / gamma_minus + 1.0
+    with pytest.raises(ValueError, match="canonical limit"):
+        scale_representations([base], too_large)


### PR DESCRIPTION
## Description

PEA could only amplify noise through the `"local_depolarizing"` and `"global_depolarizing"` model strings, which makes it unusable on real hardware where the noise is neither. This adds a `representations` parameter (a list of `OperationRepresentation`) to `pea.construct_circuits` and `pea.execute_with_pea`, as requested in #2936. The representations can be learned from hardware characterization, making PEA hardware-agnostic.

The representations are amplified with the canonical noise scaling of Sec. VI D (Eqs. 38-44) of Mari, Shammah and Zeng, [Phys. Rev. A 104, 052607 (2021)](https://doi.org/10.1103/PhysRevA.104.052607) (arXiv:2108.02237), already in the Mitiq bibliography as `Mari_2021_PRA`. The exact rule applied to each representation depends on its sign structure:

- **All-positive representations** (a genuine probability distribution, e.g. an `amplify_*` decomposition or a noise model learned from hardware) are scaled by deviation from the identity: `a0 -> 1 - s*(1 - a0)`, every other `a_k -> s*a_k`. This reproduces the legacy global-depolarizing rebuild exactly at every scale factor, so passing global-depolarizing representations yields the same sampled circuits, signs and norms as the `noise_model` path. That equivalence is the acceptance-criterion regression test, checked at scale factors `[1, 3, 5]` on a two-qubit circuit (not only at `scale_factor=1`).
- **Signed representations** (containing negative coefficients, e.g. a PEC-style `represent_operation_with_*` decomposition) are scaled by the canonical sign-partition rule of Eq. (43). The positive volume `gamma+` is scaled by `(gamma+ - s*gamma-)/gamma+` and the negative volume `gamma-` by `(1 - s)`, valid up to the canonical limit `s <= gamma+/gamma-`. In the amplification band the negative volume vanishes and the representation becomes a genuine probability distribution, so amplifying it adds real noise. Scaling a signed representation by deviation from the identity instead amplifies the error cancellation, the opposite of what PEA needs. The deviation rule above is the `gamma- = 0` special case of this same construction.

This second branch fixes the case nez0b raised on #3058: a representation with mixed-sign coefficients was being amplified the wrong way. The fix commit credits nez0b as co-author.

`representations` and `noise_model` are mutually exclusive: passing both, or neither, raises a clear `ValueError`. `epsilon` only applies to the legacy `noise_model` path, so passing it together with `representations` is also rejected. `noise_model` keeps working unchanged for backward compatibility and now emits a `DeprecationWarning` pointing at the new interface. An empty `representations` list, a representation whose identity term has zero weight, and a signed representation scaled beyond its canonical limit are all rejected with clear messages.

Limitation, documented in the `_scale_positive_representation` docstring: the two-qubit `local_depolarizing` model has a product (quadratic) dependence on the noise level that flat deviation scaling cannot reproduce exactly. The coefficients still stay normalized; single-qubit local and all global depolarizing are exact, so the equivalence test is scoped to global depolarizing.

New tests cover the scale-factor != 1 equivalence, the signed-rep canonical scaling (closed-form match, negative volume dropping to zero for `s >= 1`, the canonical-limit error), the both/neither/missing-epsilon/empty-list/epsilon-with-representations errors, the deprecation warning and the missing/zero identity-term guard. The PEA user guide documents `representations` as the recommended interface, marks `noise_model` legacy, and now describes the sign-dispatch.

Verified locally: `pytest mitiq/experimental/pea` (56 passed), `ruff check`, `ruff format --check`, and `mypy mitiq` (whole package, 109 files) all clean.

### References

- **Canonical noise scaling (the math used here):** A. Mari, N. Shammah, W. J. Zeng, "Extending quantum probabilistic error cancellation by noise scaling", Phys. Rev. A 104, 052607 (2021). [doi:10.1103/PhysRevA.104.052607](https://doi.org/10.1103/PhysRevA.104.052607) (arXiv:2108.02237). Sec. VI D, Eqs. (38)-(44) split a quasi-probability representation into positive and negative volumes and rescale them; Eq. (43) is the signed rule used here, valid up to `s <= gamma+/gamma-`, with the deviation-from-identity rule as the all-positive special case. Already in the Mitiq bibliography as `Mari_2021_PRA`.
- **PEA technique:** Y. Kim et al., "Evidence for the utility of quantum computing before fault tolerance", Nature 618, 500-505 (2023). [doi:10.1038/s41586-023-06096-3](https://doi.org/10.1038/s41586-023-06096-3). Cited in Mitiq as `Kim_2023_Nature`; motivates learning the noise representation from hardware, which is what this PR lets PEA consume.
- **Quasi-probability foundation (PEC):** K. Temme, S. Bravyi, J. M. Gambetta, "Error Mitigation for Short-Depth Quantum Circuits", Phys. Rev. Lett. 119, 180509 (2017). [doi:10.1103/PhysRevLett.119.180509](https://doi.org/10.1103/PhysRevLett.119.180509). Cited in Mitiq as `Temme_2017_PRL`; the `OperationRepresentation` structure this PR scales.

### AI use

This change was implemented with help from Claude (Anthropic), which drafted the code, the tests and this description. I directed the design and reviewed every line. Before implementing the sign-dispatch I read Sec. VI D of the Mari, Shammah and Zeng paper and verified the signed-scaling rule against Eq. (43) (the `s = lambda` identification, the `s <= gamma+/gamma-` limit, and the sign-free amplification band), and I checked the all-positive branch still reproduces the depolarizing rebuild at several scale factors. The signed-rep handling resolves a case nez0b flagged on #3058 and credits him as commit co-author. I ran the test, lint and type-check suites locally. I understand the change and can answer questions about it during review.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

- [x] I added unit tests for new code.
- [x] I used type hints in function signatures.
- [x] I used Google-style docstrings for functions.
- [x] I updated the documentation where relevant.
