### PR TITLE
Support representations directly in PEA (closes #2936)

### DIFF
--- a/docs/source/guide/pea-1-intro.md
+++ b/docs/source/guide/pea-1-intro.md
@@ -105,6 +105,13 @@ Here we observe that the application of PEA reduces the estimation error when co
 In the example above, both the noise amplification and extrapolation steps were taken behind the scenes thanks to the default options of {func}`.execute_with_pea`.
 In the following pages, we describe additional options and show how to apply the two steps of PEA independently.
 
+```{note}
+The example above uses the legacy `noise_model` string, which now emits a `DeprecationWarning`. The
+recommended interface is to pass `representations`, a list of {class}`.OperationRepresentation` objects
+that can be learned from hardware characterization, which makes PEA usable on noise that is neither local
+nor global depolarizing. See [What additional options are available in PEA?](pea-3-options.md) for details.
+```
+
 ## Two-stage PEA workflow
 
 If you want more control over the process, you can split PEA into two stages:

--- a/docs/source/guide/pea-3-options.md
+++ b/docs/source/guide/pea-3-options.md
@@ -14,8 +14,59 @@ kernelspec:
 # What additional options are available in PEA?
 
 {func}`.execute_with_pea` exposes several optional arguments beyond the required `circuit`, `executor`,
-`scale_factors`, `noise_model`, `epsilon`, and `extrapolation_method`.
+`scale_factors`, and `extrapolation_method`, together with the noise amplification specified by either
+`representations` or the legacy `noise_model`/`epsilon` pair.
 This page describes each one.
+
+## Choosing how the noise is amplified
+
+PEA needs a quasi-probability representation of each operation in the circuit in order to amplify the
+noise. There are two mutually exclusive ways to provide it.
+
+The recommended way is to pass `representations`, a list of {class}`.OperationRepresentation` objects
+(one per unique operation of the circuit). Because these can be learned from hardware characterization,
+this is the only interface that works on noise that is neither local nor global depolarizing:
+
+```{code} python
+# reps: list[OperationRepresentation], e.g. learned from hardware characterization
+mitigated = pea.execute_with_pea(
+    circuit,
+    executor,
+    scale_factors=[1.0, 1.2, 1.6],
+    extrapolation_method=LinearFactory.extrapolate,
+    representations=reps,
+)
+```
+
+Each representation is amplified with the canonical noise scaling of Section D of {cite}`Mari_2021_PRA`:
+signed (PEC-style) representations use the sign-partition rule, and all-positive representations (such as
+learned noise models) use deviation-from-identity scaling. Both keep the coefficients summing to one.
+
+The legacy alternative is to pass `noise_model` together with `epsilon`; Mitiq then builds the
+depolarizing representations for you. This path still works but emits a `DeprecationWarning`; prefer
+`representations`:
+
+```{code} python
+mitigated = pea.execute_with_pea(
+    circuit,
+    executor,
+    scale_factors=[1.0, 1.2, 1.6],
+    extrapolation_method=LinearFactory.extrapolate,
+    noise_model="local_depolarizing",   # legacy
+    epsilon=0.005,
+)
+```
+
+Passing both `representations` and `noise_model`, or neither, raises a `ValueError`. `epsilon` is used
+only by the `noise_model` path and is ignored when `representations` is given.
+
+```{note}
+For a representation of a *standard depolarizing model*, the two paths agree exactly for global
+depolarizing (any number of qubits) and for single-qubit local depolarizing. For multi-qubit *local*
+depolarizing they differ slightly: the `noise_model` path rebuilds the exact (factorized) amplification,
+whereas a representation is scaled with the single-parameter canonical rule. Prefer `noise_model` when
+the analytic model is known; use `representations` for arbitrary or learned noise.
+```
 
 ## Controlling the sampling budget
 
@@ -105,6 +156,6 @@ If no observable is provided, the executor must return the expectation value dir
 ## Supported noise models
 
 ```{attention}
-The only supported noise models are currently `"local_depolarizing"` and `"global_depolarizing"`.
-Please [open an issue](https://github.com/unitaryfoundation/mitiq/issues/new) to request additional noise models.
+The built-in `noise_model` strings are currently `"local_depolarizing"` and `"global_depolarizing"`.
+To amplify any other noise, pass `representations` directly (see [Choosing how the noise is amplified](#choosing-how-the-noise-is-amplified) above), which is not restricted to these two models.
 ```

--- a/mitiq/experimental/pea/pea.py
+++ b/mitiq/experimental/pea/pea.py
@@ -186,9 +186,7 @@ def execute_with_pea(
     scale_factors: list[float],
     noise_model: str | None = None,
     epsilon: float | None = None,
-    extrapolation_method: Callable[
-        [Sequence[float], Sequence[float]], float
-    ]
+    extrapolation_method: Callable[[Sequence[float], Sequence[float]], float]
     | None = None,
     observable: Observable | None = None,
     random_state: int | np.random.RandomState | None = None,

--- a/mitiq/experimental/pea/pea.py
+++ b/mitiq/experimental/pea/pea.py
@@ -14,8 +14,9 @@ from cirq import Circuit
 
 from mitiq import QPROGRAM, Executor, Observable, QuantumResult
 from mitiq.experimental.pea.scale_amplifications import (
-    scale_circuit_amplifications,
+    _make_scaled_representation_factory,
 )
+from mitiq.pec import OperationRepresentation
 from mitiq.pec.pec import (
     _LARGE_SAMPLE_WARN,
     LargeSampleWarning,
@@ -26,11 +27,12 @@ from mitiq.pec.pec import (
 def construct_circuits(
     circuit: Circuit,
     scale_factors: list[float],
-    noise_model: str,
-    epsilon: float,
+    noise_model: str | None = None,
+    epsilon: float | None = None,
     random_state: int | np.random.RandomState | None = None,
     precision: float = 0.1,
     num_samples: int | None = None,
+    representations: Sequence[OperationRepresentation] | None = None,
 ) -> tuple[list[list[QPROGRAM]], list[list[int]], list[float]]:
     """Samples lists of implementable circuits from the noise-amplified
     representation of the input ideal circuit at each input noise scale
@@ -45,15 +47,20 @@ def construct_circuits(
             sequence is sampled.
         scale_factors: A list of (positive) numbers by which the baseline
             noise level is to be amplified.
-        noise_model: A string describing the noise model to be used for the
-            noise-scaled representations, e.g. "local_depolarizing" or
-            "global_depolarizing".
-        epsilon: Baseline noise level.
+        noise_model: A legacy string describing the noise model to be used for
+            the noise-scaled representations, e.g. "local_depolarizing" or
+            "global_depolarizing". The deprecated alternative to
+            ``representations`` (the two are mutually exclusive).
+        epsilon: Baseline noise level. Used only for the legacy ``noise_model``
+            path; ignored when ``representations`` is provided.
         random_state: The random state or seed for reproducibility.
         precision: The desired precision for the sampling process.
             Default is 0.1.
         num_samples: The number of noisy circuits to be sampled for PEA.
             If not given, this is deduced from the 'precision'.
+        representations: Optional precomputed list of operation
+            representations from which noise-scaled representations
+            are derived.
 
     Returns:
         The scaled circuits, their signs and norms at each scale factor.
@@ -69,15 +76,44 @@ def construct_circuits(
             f" but precision is {precision}."
         )
 
-    # Get the 1-norm of the circuit quasi-probability representation
-    _, _, norm = sample_circuit(
+    if len(scale_factors) == 0:
+        raise ValueError(
+            "``scale_factors`` must be a non-empty list of positive numbers."
+        )
+
+    scaled_representation_factory = _make_scaled_representation_factory(
         circuit,
-        scale_circuit_amplifications(circuit, 1.0, noise_model, epsilon),
-        num_samples=1,
+        noise_model=noise_model,
+        epsilon=epsilon,
+        representations=representations,
     )
 
-    # Deduce the number of samples (if not given by the user)
+    if noise_model is not None:
+        warnings.warn(
+            "noise_model is deprecated and will be removed in a future "
+            "version. Prefer passing ``representations`` directly.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+    scaled_representations = [
+        scaled_representation_factory(s) for s in scale_factors
+    ]
+
+    # Deduce the number of samples (if not given by the user) from the largest
+    # one-norm across the requested scale factors. The sampling variance grows
+    # with the (scaled) one-norm, and sub-unit scale factors (noise reduction)
+    # have a one-norm greater than one, so probing only at scale 1.0 would
+    # under-sample those batches.
     if num_samples is None:
+        norm = max(
+            sample_circuit(
+                circuit,
+                scaled_reps,
+                num_samples=1,
+            )[2]
+            for scaled_reps in scaled_representations
+        )
         num_samples = int((norm / precision) ** 2)
 
     if num_samples > 10**5:
@@ -86,10 +122,10 @@ def construct_circuits(
     scaled_sampled_circuits = []
     scaled_signs = []
     scaled_norms = []
-    for s in scale_factors:
+    for scaled_reps in scaled_representations:
         sampled_circuits, signs, norm = sample_circuit(
             circuit,
-            scale_circuit_amplifications(circuit, s, noise_model, epsilon),
+            scaled_reps,
             num_samples=num_samples,
             random_state=random_state,
         )
@@ -148,15 +184,19 @@ def execute_with_pea(
     circuit: Circuit,
     executor: Executor | Callable[[QPROGRAM], QuantumResult],
     scale_factors: list[float],
-    noise_model: str,
-    epsilon: float,
-    extrapolation_method: Callable[[Sequence[float], Sequence[float]], float],
+    noise_model: str | None = None,
+    epsilon: float | None = None,
+    extrapolation_method: Callable[
+        [Sequence[float], Sequence[float]], float
+    ]
+    | None = None,
     observable: Observable | None = None,
     random_state: int | np.random.RandomState | None = None,
     precision: float = 0.1,
     num_samples: int | None = None,
     full_output: bool = False,
     force_run_all: bool = False,
+    representations: Sequence[OperationRepresentation] | None = None,
 ) -> float | tuple[float, dict[str, Any]]:
     r"""Estimates the error-mitigated expectation value associated to the
     input circuit, via the application of probabilistic error amplification
@@ -180,10 +220,12 @@ def execute_with_pea(
             unmitigated ``QuantumResult`` (e.g. an expectation value).
         scale_factors: A list of (positive) numbers by which the baseline
             noise level is to be amplified.
-        noise_model: A string describing the noise model to be used for the
-            noise-scaled representations, e.g. "local_depolarizing" or
-            "global_depolarizing".
-        epsilon: Baseline noise level.
+        noise_model: A legacy string describing the noise model to be used for
+            the noise-scaled representations, e.g. "local_depolarizing" or
+            "global_depolarizing". The deprecated alternative to
+            ``representations`` (the two are mutually exclusive).
+        epsilon: Baseline noise level. Used only for the legacy ``noise_model``
+            path; ignored when ``representations`` is provided.
         extrapolation_method: The method of extrapolation to use when fitting
             the measured results. A list of built-in functions can be found
             in ``mitiq.zne.inference``.
@@ -200,6 +242,9 @@ def execute_with_pea(
             If True a dictionary containing all PEA data is returned too.
         force_run_all: If True, all sampled circuits are executed regardless of
             uniqueness, else a minimal unique set is executed.
+        representations: Optional precomputed list of operation
+            representations from which noise-scaled representations are
+            derived.
 
     Returns:
         The tuple ``(pea_value, pea_data)`` where ``pea_value`` is the
@@ -208,14 +253,21 @@ def execute_with_pea(
         ``full_output`` is ``False``, only ``pea_value`` is
         returned.
     """
+    if extrapolation_method is None:
+        raise TypeError(
+            "extrapolation_method must be provided when calling "
+            "execute_with_pea."
+        )
+
     scaled_circuits, scaled_signs, scaled_norms = construct_circuits(
         circuit,
         scale_factors,
-        noise_model,
-        epsilon,
-        random_state,
-        precision,
-        num_samples,
+        noise_model=noise_model,
+        epsilon=epsilon,
+        random_state=random_state,
+        precision=precision,
+        num_samples=num_samples,
+        representations=representations,
     )
     # Execute all sampled circuits
     if not isinstance(executor, Executor):

--- a/mitiq/experimental/pea/scale_amplifications.py
+++ b/mitiq/experimental/pea/scale_amplifications.py
@@ -7,7 +7,10 @@
 operations.
 """
 
-from collections.abc import Sequence
+import copy
+import math
+import warnings
+from collections.abc import Callable, Sequence
 
 from cirq import Circuit
 
@@ -16,31 +19,64 @@ from mitiq.experimental.pea.amplifications.amplify_depolarizing import (
     amplify_noisy_ops_in_circuit_with_local_depolarizing_noise,
 )
 from mitiq.pec import OperationRepresentation
+from mitiq.utils import _equal
+
+# Coefficients with magnitude below this are treated as zero when classifying
+# the sign structure of a representation, so floating-point dust does not
+# misroute the scaling rule or perturb the positive/negative volumes.
+_SIGN_TOL = 1e-12
 
 
-def scale_circuit_amplifications(
+def _validate_scale_factor(scale_factor: float) -> None:
+    if not math.isfinite(scale_factor):
+        raise ValueError("Scale factor must be finite.")
+
+    if scale_factor <= 0:
+        raise ValueError("The scale factor must be a positive number.")
+
+
+def _make_scaled_representation_factory(
     ideal_circuit: Circuit,
-    scale_factor: float,
-    noise_model: str,
-    epsilon: float,
-) -> Sequence[OperationRepresentation]:
-    r"""Generates a list of implementable sequences from the noise-amplified
-    representation of the input ideal circuit based on the input noise model
-    and baseline noise level.
+    noise_model: str | None = None,
+    epsilon: float | None = None,
+    representations: Sequence[OperationRepresentation] | None = None,
+) -> Callable[[float], Sequence[OperationRepresentation]]:
+    """Returns a scale-factor-to-representations provider for PEA.
 
-    Args:
-        ideal_circuit: The ideal circuit from which an implementable
-            sequence is sampled.
-        scale_factor: A (positive) number by which the baseline noise
-            level is to be amplified.
-        noise_model: A string describing the noise model to be used for the
-            noise-scaled representations, e.g. "local_depolarizing" or
-            "global_depolarizing".
-        epsilon: Baseline noise level.
+    The legacy ``noise_model`` path still rebuilds analytic depolarizing
+    amplifications at the target noise level. The direct ``representations``
+    path scales the provided operation representations.
+    """
 
-    Returns:
-        A list of noise-amplified circuits, corresponding to each scale
-        factor multiplied by the baseline noise level."""
+    if (noise_model is None) == (representations is None):
+        raise ValueError(
+            "Either ``noise_model`` and ``epsilon`` or ``representations`` "
+            "must be provided."
+        )
+
+    if representations is not None:
+        if len(representations) == 0:
+            raise ValueError(
+                "``representations`` must be a non-empty list of "
+                "``OperationRepresentation`` objects."
+            )
+
+        def scaled_representations(
+            scale_factor: float,
+        ) -> Sequence[OperationRepresentation]:
+            _validate_scale_factor(scale_factor)
+            return [
+                scale_representation(rep, scale_factor)
+                for rep in representations
+            ]
+
+        return scaled_representations
+
+    if epsilon is None:
+        raise ValueError(
+            "``epsilon`` must be provided when using the ``noise_model`` "
+            "path."
+        )
 
     if noise_model == "local_depolarizing":
         amp_fn = amplify_noisy_ops_in_circuit_with_local_depolarizing_noise
@@ -51,4 +87,198 @@ def scale_circuit_amplifications(
         raise ValueError("Noise model not supported")
         # TODO allow use of custom noise model
 
-    return amp_fn(ideal_circuit, scale_factor * epsilon)
+    def scaled_representations(
+        scale_factor: float,
+    ) -> Sequence[OperationRepresentation]:
+        _validate_scale_factor(scale_factor)
+        return amp_fn(ideal_circuit, scale_factor * epsilon)
+
+    return scaled_representations
+
+
+def scale_circuit_amplifications(
+    ideal_circuit: Circuit,
+    scale_factor: float,
+    noise_model: str | None = None,
+    epsilon: float | None = None,
+    representations: Sequence[OperationRepresentation] | None = None,
+) -> Sequence[OperationRepresentation]:
+    r"""Generates a list of implementable sequences from the noise-amplified
+    representation of the input ideal circuit based on the input noise model
+    and baseline noise level.
+
+    Args:
+        ideal_circuit: The ideal circuit from which an implementable
+            sequence is sampled.
+        scale_factor: A (positive) number by which the baseline noise
+            level is to be amplified.
+        noise_model: A legacy string describing the noise model to be used for
+            the noise-scaled representations, e.g. "local_depolarizing" or
+            "global_depolarizing". The deprecated alternative to
+            ``representations`` (the two are mutually exclusive).
+        epsilon: Baseline noise level. Used only for the legacy ``noise_model``
+            path; ignored when ``representations`` is provided.
+        representations: Optional precomputed list of operation representations
+            from which noise-scaled representations are derived.
+
+    Returns:
+        A list of noise-amplified circuits, corresponding to each scale
+        factor multiplied by the baseline noise level."""
+
+    return _make_scaled_representation_factory(
+        ideal_circuit,
+        noise_model=noise_model,
+        epsilon=epsilon,
+        representations=representations,
+    )(scale_factor)
+
+
+def _find_identity_term_index(
+    representation: OperationRepresentation,
+) -> int:
+    identity_term_index = None
+    for idx, (coeff, noisy_op) in enumerate(
+        representation.basis_expansion
+    ):
+        if coeff > 0 and _equal(noisy_op.circuit, representation.ideal):
+            identity_term_index = idx
+            break
+
+    if identity_term_index is None:
+        raise ValueError(
+            "Could not identify the identity (un-noisy) term in this "
+            "all-positive representation."
+        )
+
+    return identity_term_index
+
+
+def _scale_positive_representation(
+    representation: OperationRepresentation,
+    scale_factor: float,
+) -> OperationRepresentation:
+    """Scales an all-positive representation.
+
+    This corresponds to a decomposition
+    ``G = a_0 O_0 + a_1 O_1 + ...``
+    where ``O_0`` is the implementation of the ideal gate.
+    For such representations we use:
+
+    .. math::
+        a_0' = 1 - s(1-a_0)
+        a_i' = s a_i, i > 0
+    """
+
+    coeffs = representation.coeffs
+    identity_term_index = _find_identity_term_index(representation)
+
+    identity_weight = coeffs[identity_term_index]
+    if 1 - identity_weight > 0 and scale_factor > 1 / (1 - identity_weight):
+        warnings.warn(
+            f"scale_factor={scale_factor} drives the identity coefficient "
+            f"negative (deviation-scaling limit {1 / (1 - identity_weight)}); "
+            "the amplified representation is no longer a valid probability "
+            "distribution.",
+            stacklevel=2,
+        )
+
+    scaled_coeffs = copy.copy(coeffs)
+    scaled_coeffs[identity_term_index] = 1 - scale_factor * (
+        1 - scaled_coeffs[identity_term_index]
+    )
+
+    for idx, coeff in enumerate(coeffs):
+        if idx == identity_term_index:
+            continue
+        scaled_coeffs[idx] = scale_factor * coeff
+
+    return OperationRepresentation(
+        representation.ideal,
+        list(representation.noisy_operations),
+        scaled_coeffs,
+        representation.is_qubit_dependent,
+    )
+
+
+def _scale_signed_representation(
+    representation: OperationRepresentation,
+    scale_factor: float,
+) -> OperationRepresentation:
+    r"""Scales a signed representation using canonical noise scaling.
+
+    This implements the canonical two-channel rescaling described in
+    Section D ("Canonical noise scaling") of arXiv:2108.02237. The
+    coefficients are split by sign into positive/negative volumes
+    ``gamma_plus``/``gamma_minus`` (with ``gamma_plus - gamma_minus = 1``)
+    and rescaled by
+
+    .. math::
+        \eta_+ \to \eta_+ (\gamma^+ - s\,\gamma^-)/\gamma^+, \qquad
+        \eta_- \to \eta_- (1 - s),
+
+    which is sign-free with one-norm 1 in the amplification band, up to the
+    canonical limit ``s <= gamma_plus / gamma_minus``.
+    """
+
+    coeffs = representation.coeffs
+    pos_volume = sum(coeff for coeff in coeffs if coeff > _SIGN_TOL)
+    neg_volume = -sum(coeff for coeff in coeffs if coeff < -_SIGN_TOL)
+
+    if pos_volume <= 0:
+        raise ValueError("Canonical scaling requires a representation "
+                         "with positive total mass.")
+    if neg_volume > 0:
+        max_scale = pos_volume / neg_volume
+        if scale_factor > max_scale:
+            raise ValueError(
+                f"scale_factor={scale_factor} is above the canonical limit "
+                f"{max_scale}."
+            )
+
+    pos_scaling = (pos_volume - scale_factor * neg_volume) / pos_volume
+    neg_scaling = 1 - scale_factor
+
+    scaled_coeffs = []
+    for coeff in coeffs:
+        if coeff > _SIGN_TOL:
+            scaled_coeffs.append(coeff * pos_scaling)
+        elif coeff < -_SIGN_TOL:
+            scaled_coeffs.append(coeff * neg_scaling)
+        else:
+            scaled_coeffs.append(0.0)
+
+    return OperationRepresentation(
+        representation.ideal,
+        list(representation.noisy_operations),
+        scaled_coeffs,
+        representation.is_qubit_dependent,
+    )
+
+
+def scale_representation(
+    representation: OperationRepresentation,
+    scale_factor: float,
+) -> OperationRepresentation:
+    """Scales a single representation for a given noise scale factor.
+
+    The scaling rule is selected based on the sign structure of the input
+    representation (see Section D of arXiv:2108.02237):
+
+    * Signed representation (contains negative coefficients, e.g. a PEC-style
+      ``represent_operation_with_*`` decomposition): canonical sign-partition
+      noise scaling, valid up to the limit ``s <= gamma_plus / gamma_minus``.
+    * All-positive representation (e.g. a learned noise model or an
+      ``amplify_*`` decomposition with an explicit identity term):
+      deviation-from-identity scaling ``a_0 -> 1 - s(1 - a_0)``,
+      ``a_k -> s a_k``.
+
+    Both rules preserve the unit sum of the coefficients. This function is
+    designed to be used by ``scale_circuit_amplifications``.
+    """
+
+    _validate_scale_factor(scale_factor)
+
+    if all(coeff >= -_SIGN_TOL for coeff in representation.coeffs):
+        return _scale_positive_representation(representation, scale_factor)
+
+    return _scale_signed_representation(representation, scale_factor)

--- a/mitiq/experimental/pea/scale_amplifications.py
+++ b/mitiq/experimental/pea/scale_amplifications.py
@@ -60,23 +60,21 @@ def _make_scaled_representation_factory(
                 "``representations`` must be a non-empty list of "
                 "``OperationRepresentation`` objects."
             )
+        reps = representations
 
-        def scaled_representations(
+        def scale_supplied_representations(
             scale_factor: float,
         ) -> Sequence[OperationRepresentation]:
             _validate_scale_factor(scale_factor)
-            return [
-                scale_representation(rep, scale_factor)
-                for rep in representations
-            ]
+            return [scale_representation(rep, scale_factor) for rep in reps]
 
-        return scaled_representations
+        return scale_supplied_representations
 
     if epsilon is None:
         raise ValueError(
-            "``epsilon`` must be provided when using the ``noise_model`` "
-            "path."
+            "``epsilon`` must be provided when using the ``noise_model`` path."
         )
+    base_noise = epsilon
 
     if noise_model == "local_depolarizing":
         amp_fn = amplify_noisy_ops_in_circuit_with_local_depolarizing_noise
@@ -87,13 +85,13 @@ def _make_scaled_representation_factory(
         raise ValueError("Noise model not supported")
         # TODO allow use of custom noise model
 
-    def scaled_representations(
+    def rebuild_model_representations(
         scale_factor: float,
     ) -> Sequence[OperationRepresentation]:
         _validate_scale_factor(scale_factor)
-        return amp_fn(ideal_circuit, scale_factor * epsilon)
+        return amp_fn(ideal_circuit, scale_factor * base_noise)
 
-    return scaled_representations
+    return rebuild_model_representations
 
 
 def scale_circuit_amplifications(
@@ -137,9 +135,7 @@ def _find_identity_term_index(
     representation: OperationRepresentation,
 ) -> int:
     identity_term_index = None
-    for idx, (coeff, noisy_op) in enumerate(
-        representation.basis_expansion
-    ):
+    for idx, (coeff, noisy_op) in enumerate(representation.basis_expansion):
         if coeff > 0 and _equal(noisy_op.circuit, representation.ideal):
             identity_term_index = idx
             break
@@ -225,8 +221,10 @@ def _scale_signed_representation(
     neg_volume = -sum(coeff for coeff in coeffs if coeff < -_SIGN_TOL)
 
     if pos_volume <= 0:
-        raise ValueError("Canonical scaling requires a representation "
-                         "with positive total mass.")
+        raise ValueError(
+            "Canonical scaling requires a representation "
+            "with positive total mass."
+        )
     if neg_volume > 0:
         max_scale = pos_volume / neg_volume
         if scale_factor > max_scale:

--- a/mitiq/experimental/pea/tests/test_pea.py
+++ b/mitiq/experimental/pea/tests/test_pea.py
@@ -15,6 +15,7 @@ from mitiq.experimental.pea import (
     execute_with_pea,
 )
 from mitiq.experimental.pea.amplifications.amplify_depolarizing import (
+    amplify_noisy_ops_in_circuit_with_global_depolarizing_noise,
     amplify_noisy_ops_in_circuit_with_local_depolarizing_noise,
 )
 from mitiq.interface import convert_from_mitiq, convert_to_mitiq
@@ -131,6 +132,92 @@ def test_scale_factors(scale_factors):
     assert len(scaled_circuits) == len(scale_factors)
 
 
+@pytest.mark.parametrize(
+    "noise_model, representation_factory",
+    [
+        (
+            "global_depolarizing",
+            amplify_noisy_ops_in_circuit_with_global_depolarizing_noise,
+        ),
+        (
+            "local_depolarizing",
+            amplify_noisy_ops_in_circuit_with_local_depolarizing_noise,
+        ),
+    ],
+)
+def test_construct_circuits_with_representations(
+    noise_model, representation_factory
+):
+    representations = representation_factory(oneq_circ, 0.02)
+    random_state = 0
+    precision = 0.2
+    num_samples = 32
+
+    scaled_by_noise_model = construct_circuits(
+        oneq_circ,
+        scale_factors=[1, 3, 5],
+        noise_model=noise_model,
+        epsilon=0.02,
+        precision=precision,
+        num_samples=num_samples,
+        random_state=random_state,
+    )
+
+    scaled_by_representation = construct_circuits(
+        oneq_circ,
+        scale_factors=[1, 3, 5],
+        representations=representations,
+        precision=precision,
+        num_samples=num_samples,
+        random_state=random_state,
+    )
+
+    assert scaled_by_noise_model[0] == scaled_by_representation[0]
+    assert scaled_by_noise_model[1] == scaled_by_representation[1]
+    assert np.allclose(scaled_by_noise_model[2], scaled_by_representation[2])
+
+
+def test_construct_circuits_requires_input_variant():
+    with pytest.raises(ValueError, match="Either ``noise_model``"):
+        construct_circuits(
+            oneq_circ,
+            scale_factors=[1, 3],
+        )
+
+
+def test_construct_circuits_rejects_both_input_types():
+    representations = (
+        amplify_noisy_ops_in_circuit_with_global_depolarizing_noise(
+            oneq_circ, BASE_NOISE
+        )
+    )
+    with pytest.raises(
+        ValueError,
+        match="Either ``noise_model`` and ``epsilon`` or ``representations``",
+    ):
+        construct_circuits(
+            oneq_circ,
+            scale_factors=[1, 3],
+            noise_model="global_depolarizing",
+            epsilon=BASE_NOISE,
+            representations=representations,
+        )
+
+
+def test_construct_circuits_noise_model_warns_deprecated():
+    with pytest.warns(
+        DeprecationWarning,
+        match="noise_model is deprecated",
+    ):
+        construct_circuits(
+            oneq_circ,
+            scale_factors=[1, 2],
+            noise_model="global_depolarizing",
+            epsilon=BASE_NOISE,
+            num_samples=4,
+        )
+
+
 def test_combining_results():
     """simple arithmetic test"""
     pea_estimate = combine_results(
@@ -156,6 +243,10 @@ def executor(circuit: QPROGRAM, noise: float = BASE_NOISE) -> float:
     return compute_density_matrix(
         circuit, noise_model_function=cirq.depolarize, noise_level=(noise,)
     )[0, 0].real
+
+
+def constant_executor(_: QPROGRAM) -> float:
+    return 0.77
 
 
 @pytest.mark.parametrize("circuit", [oneq_circ, twoq_circ])
@@ -185,6 +276,92 @@ def test_execute_with_pea_mitigates_noise(circuit, circuit_type):
     assert np.isclose(mitigated, true_noiseless_value, atol=0.1)
 
 
+@pytest.mark.parametrize(
+    "noise_model, representation_factory",
+    [
+        (
+            "global_depolarizing",
+            amplify_noisy_ops_in_circuit_with_global_depolarizing_noise,
+        ),
+        (
+            "local_depolarizing",
+            amplify_noisy_ops_in_circuit_with_local_depolarizing_noise,
+        ),
+    ],
+)
+def test_execute_with_pea_with_representations_arg(
+    noise_model,
+    representation_factory,
+):
+    representations = representation_factory(oneq_circ, BASE_NOISE)
+    scale_factors = [1, 1.2, 1.6]
+
+    with_noise_model = execute_with_pea(
+        oneq_circ,
+        constant_executor,
+        scale_factors=scale_factors,
+        noise_model=noise_model,
+        epsilon=BASE_NOISE,
+        extrapolation_method=LinearFactory.extrapolate,
+        random_state=13,
+        num_samples=24,
+        precision=0.5,
+    )
+
+    with_representations = execute_with_pea(
+        oneq_circ,
+        constant_executor,
+        scale_factors=scale_factors,
+        representations=representations,
+        extrapolation_method=LinearFactory.extrapolate,
+        random_state=13,
+        num_samples=24,
+        precision=0.5,
+    )
+
+    assert with_noise_model == with_representations
+
+
+def test_execute_with_pea_rejects_both_input_types():
+    representations = (
+        amplify_noisy_ops_in_circuit_with_global_depolarizing_noise(
+            oneq_circ, BASE_NOISE
+        )
+    )
+    with pytest.raises(
+        ValueError,
+        match="Either ``noise_model`` and ``epsilon`` or ``representations``",
+    ):
+        execute_with_pea(
+            oneq_circ,
+            constant_executor,
+            scale_factors=[1, 3],
+            noise_model="global_depolarizing",
+            epsilon=BASE_NOISE,
+            representations=representations,
+            extrapolation_method=LinearFactory.extrapolate,
+            num_samples=4,
+            precision=0.5,
+        )
+
+
+def test_execute_with_pea_noise_model_warns_deprecated():
+    with pytest.warns(
+        DeprecationWarning,
+        match="noise_model is deprecated",
+    ):
+        execute_with_pea(
+            oneq_circ,
+            constant_executor,
+            scale_factors=[1],
+            noise_model="global_depolarizing",
+            epsilon=BASE_NOISE,
+            extrapolation_method=LinearFactory.extrapolate,
+            num_samples=4,
+            precision=0.5,
+        )
+
+
 def test_pea_data_with_full_output():
     """Tests that execute_with_pea mitigates the error of a noisy
     expectation value.
@@ -201,13 +378,17 @@ def test_pea_data_with_full_output():
         precision=precision,
         full_output=True,
     )
-    # Get num samples from precision
-    _, _, norm = sample_circuit(
-        twoq_circ,
-        amplify_noisy_ops_in_circuit_with_local_depolarizing_noise(
-            twoq_circ, epsilon
-        ),
-        num_samples=1,
+    # Get num samples from precision: the budget is deduced from the largest
+    # one-norm across the requested scale factors (see construct_circuits).
+    norm = max(
+        sample_circuit(
+            twoq_circ,
+            amplify_noisy_ops_in_circuit_with_local_depolarizing_noise(
+                twoq_circ, s * epsilon
+            ),
+            num_samples=1,
+        )[2]
+        for s in [1, 1.2, 1.6]
     )
     num_samples = int((norm / precision) ** 2)
 

--- a/mitiq/experimental/pea/tests/test_representations_pathway.py
+++ b/mitiq/experimental/pea/tests/test_representations_pathway.py
@@ -219,9 +219,7 @@ def test_sign_dispatch_tolerates_floating_point_dust():
         NoisyOperation(Circuit([X(q), Z(q)])),
     ]
     clean = OperationRepresentation(ideal, ops, [0.98, 0.02, 0.0])
-    dusted = OperationRepresentation(
-        ideal, ops, [0.98, 0.02 + 1e-16, -1e-16]
-    )
+    dusted = OperationRepresentation(ideal, ops, [0.98, 0.02 + 1e-16, -1e-16])
     s = 2.0
     assert scale_representation(dusted, s).coeffs == pytest.approx(
         scale_representation(clean, s).coeffs, abs=1e-9

--- a/mitiq/experimental/pea/tests/test_representations_pathway.py
+++ b/mitiq/experimental/pea/tests/test_representations_pathway.py
@@ -1,0 +1,571 @@
+# Copyright (C) Unitary Foundation
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Comprehensive tests for the ``representations`` pathway of PEA (#2936).
+
+These tests scrutinize the convention-aware ``scale_representation`` primitive
+across every quasi-probability representation mitiq can build (depolarizing
+local/global, biased noise, amplitude damping, optimal/tomographic) plus a
+hand-built sparse Pauli-Lindblad representation, and verify the canonical
+noise-scaling math of Section D of arXiv:2108.02237 end to end.
+
+All tests are cirq-only (no ``SUPPORTED_PROGRAM_TYPES`` parametrization) so
+they are deterministic and do not depend on optional frontend extras.
+"""
+
+import cirq
+import numpy as np
+import pytest
+from cirq import (
+    CNOT,
+    Circuit,
+    DepolarizingChannel,
+    H,
+    LineQubit,
+    X,
+    Y,
+    Z,
+)
+
+from mitiq.experimental.pea import construct_circuits, execute_with_pea
+from mitiq.experimental.pea.amplifications.amplify_depolarizing import (
+    amplify_noisy_op_with_global_depolarizing_noise,
+    amplify_noisy_ops_in_circuit_with_global_depolarizing_noise,
+    amplify_noisy_ops_in_circuit_with_local_depolarizing_noise,
+)
+from mitiq.experimental.pea.scale_amplifications import (
+    scale_circuit_amplifications,
+    scale_representation,
+)
+from mitiq.interface import convert_to_mitiq
+from mitiq.interface.mitiq_cirq import compute_density_matrix
+from mitiq.pec import (
+    NoisyOperation,
+    OperationRepresentation,
+    represent_operation_with_global_depolarizing_noise,
+    represent_operation_with_local_depolarizing_noise,
+    represent_operations_in_circuit_with_local_depolarizing_noise,
+)
+from mitiq.pec.channels import _circuit_to_choi, choi_to_super
+from mitiq.pec.representations import (
+    _represent_operation_with_amplitude_damping_noise,
+    find_optimal_representation,
+    represent_operation_with_local_biased_noise,
+)
+from mitiq.zne.inference import LinearFactory, RichardsonFactory
+
+BASE_NOISE = 0.02
+q0, q1 = LineQubit.range(2)
+oneq_circ = Circuit(Z.on(q0), Z.on(q0))  # ideal expectation value 1.0
+twoq_circ = Circuit(Y.on(q1), CNOT.on(q0, q1), Y.on(q1))
+
+
+def depolarizing_executor(circuit, noise=BASE_NOISE):
+    """Ground-state-projector expectation under depolarizing noise."""
+    circuit, _ = convert_to_mitiq(circuit)
+    return compute_density_matrix(
+        circuit, noise_model_function=cirq.depolarize, noise_level=(noise,)
+    )[0, 0].real
+
+
+# --------------------------------------------------------------------------- #
+# Hand-built sparse Pauli-Lindblad reps (mitiq has no SPL builder)            #
+# --------------------------------------------------------------------------- #
+def spl_single_generator_rep(ideal_circuit, qubit, generator, rate):
+    r"""Inverse of a single-generator Pauli-Lindblad channel as a (signed)
+    quasi-probability representation:  N^{-1} = c_I I + c_P P,
+    c_I = (1 + e^{2r})/2,  c_P = (1 - e^{2r})/2 (< 0),  gamma = e^{2r}.
+    """
+    c_I = float((1 + np.exp(2 * rate)) / 2)
+    c_P = float((1 - np.exp(2 * rate)) / 2)
+    noisy_ops = [
+        NoisyOperation(ideal_circuit),
+        NoisyOperation(ideal_circuit + Circuit(generator(qubit))),
+    ]
+    return OperationRepresentation(ideal_circuit, noisy_ops, [c_I, c_P])
+
+
+def spl_two_generator_rep(ideal_circuit, qubit, gen_a, gen_b, rate_a, rate_b):
+    """Product of two single-generator inverses (4 signed terms)."""
+    cIa = (1 + np.exp(2 * rate_a)) / 2
+    cPa = (1 - np.exp(2 * rate_a)) / 2
+    cIb = (1 + np.exp(2 * rate_b)) / 2
+    cPb = (1 - np.exp(2 * rate_b)) / 2
+    noisy_ops = [
+        NoisyOperation(ideal_circuit),
+        NoisyOperation(ideal_circuit + Circuit(gen_b(qubit))),
+        NoisyOperation(ideal_circuit + Circuit(gen_a(qubit))),
+        NoisyOperation(ideal_circuit + Circuit(gen_a(qubit), gen_b(qubit))),
+    ]
+    coeffs = [
+        float(cIa * cIb),
+        float(cIa * cPb),
+        float(cPa * cIb),
+        float(cPa * cPb),
+    ]
+    return OperationRepresentation(ideal_circuit, noisy_ops, coeffs)
+
+
+def optimal_single_qubit_rep(noise_level=0.02):
+    """A tomography-derived (numerically optimized) single-qubit rep."""
+    q = LineQubit(0)
+    ideal_op = Circuit(H(q))
+    implementable = [Circuit(ideal_op)] + [
+        Circuit([ideal_op, g(q)]) for g in (X, Y, Z)
+    ]
+    noisy_circuits = [
+        c + Circuit(DepolarizingChannel(noise_level).on_each(q))
+        for c in implementable
+    ]
+    super_ops = [choi_to_super(_circuit_to_choi(c)) for c in noisy_circuits]
+    noisy_ops = [
+        NoisyOperation(ideal, real)
+        for ideal, real in zip(implementable, super_ops)
+    ]
+    return find_optimal_representation(ideal_op, noisy_ops, tol=1e-8)
+
+
+# =========================================================================== #
+# Group A — scale_representation math correctness                             #
+# =========================================================================== #
+@pytest.mark.parametrize("p", [0.01, 0.05])
+@pytest.mark.parametrize("lam", [1.0, 2.0, 3.0])
+def test_canonical_scaling_reproduces_paper_per_etas(p, lam):
+    """Headline: canonical scaling of a signed depolarizing PEC rep equals the
+    paper's closed-form per_etas eta_j(lambda) (Eq. per_etas / Section D)."""
+    q = LineQubit(0)
+    rep = represent_operation_with_global_depolarizing_noise(Circuit(X(q)), p)
+    scaled = scale_representation(rep, lam)
+
+    eps = 4 / 3 * p
+    f = eps * (1 - lam) / (1 - eps)
+    expected = [1 + 0.75 * f] + 3 * [-0.25 * f]
+    assert scaled.coeffs == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("lam", [0.5, 1.0, 2.0, 3.0])
+def test_scaling_preserves_unit_sum(lam):
+    q = LineQubit(0)
+    reps = [
+        represent_operation_with_global_depolarizing_noise(
+            Circuit(X(q)), 0.05
+        ),
+        represent_operation_with_local_depolarizing_noise(
+            Circuit(CNOT(q0, q1)), 0.05
+        ),
+        represent_operation_with_local_biased_noise(Circuit(X(q)), 0.05, 1.0),
+        _represent_operation_with_amplitude_damping_noise(Circuit(X(q)), 0.05),
+        spl_single_generator_rep(Circuit(H(q)), q, Z, 0.05),
+        spl_two_generator_rep(Circuit(H(q)), q, Z, X, 0.05, 0.03),
+    ]
+    for rep in reps:
+        scaled = scale_representation(rep, lam)
+        assert sum(scaled.coeffs) == pytest.approx(1.0)
+
+
+def test_scale_one_gives_unit_norm_for_signed_rep():
+    """At lambda=1 a signed rep collapses to the base channel Phi+ (norm 1)."""
+    q = LineQubit(0)
+    rep = represent_operation_with_global_depolarizing_noise(
+        Circuit(X(q)), 0.05
+    )
+    assert scale_representation(rep, 1.0).norm == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("lam", [0.5, 1.0, 1.5, 3.0])
+def test_one_norm_law(lam):
+    """gamma(lam) = gamma - lam(gamma-1) on [0,1]; = 1 on [1, lam_max]."""
+    q = LineQubit(0)
+    rep = represent_operation_with_global_depolarizing_noise(
+        Circuit(X(q)), 0.05
+    )
+    gamma = rep.norm
+    scaled = scale_representation(rep, lam)
+    expected = gamma - lam * (gamma - 1) if lam <= 1 else 1.0
+    assert scaled.norm == pytest.approx(expected)
+
+
+def test_canonical_limit_raises_beyond_lambda_max():
+    q = LineQubit(0)
+    rep = represent_operation_with_global_depolarizing_noise(
+        Circuit(X(q)), 0.05
+    )
+    with pytest.raises(ValueError, match="canonical limit"):
+        scale_representation(rep, 100.0)
+
+
+def test_positive_path_warns_past_upper_bound():
+    """Deviation scaling of an all-positive rep can drive the identity coeff
+    negative; we warn past s > 1/(1-a0)."""
+    q = LineQubit(0)
+    rep = amplify_noisy_op_with_global_depolarizing_noise(Circuit(X(q)), 0.05)
+    # a0 = 1 - 0.05 = 0.95  =>  limit = 1/0.05 = 20
+    with pytest.warns(UserWarning, match="no longer a valid probability"):
+        scale_representation(rep, 50.0)
+
+
+def test_sign_dispatch_tolerates_floating_point_dust():
+    """A dust-magnitude negative coefficient (numerical noise for a term that
+    is really zero) must not misroute an otherwise all-positive representation
+    onto the canonical (signed) path; it should scale identically to the clean
+    all-positive representation (deviation-from-identity)."""
+    q = LineQubit(0)
+    ideal = Circuit(X(q))
+    ops = [
+        NoisyOperation(ideal),
+        NoisyOperation(Circuit([X(q), Y(q)])),
+        NoisyOperation(Circuit([X(q), Z(q)])),
+    ]
+    clean = OperationRepresentation(ideal, ops, [0.98, 0.02, 0.0])
+    dusted = OperationRepresentation(
+        ideal, ops, [0.98, 0.02 + 1e-16, -1e-16]
+    )
+    s = 2.0
+    assert scale_representation(dusted, s).coeffs == pytest.approx(
+        scale_representation(clean, s).coeffs, abs=1e-9
+    )
+
+
+def test_two_qubit_local_canonical_differs_from_factorized():
+    """Canonical (single-parameter) scaling cannot reproduce factorized local
+    (tensor) scaling: documented limitation of Section D for local noise."""
+    p, lam = 0.05, 2.0
+    rep2 = represent_operation_with_local_depolarizing_noise(
+        Circuit(CNOT(q0, q1)), p
+    )
+    rep1 = represent_operation_with_global_depolarizing_noise(
+        Circuit(X(LineQubit(0))), p
+    )
+    canon2 = np.array(scale_representation(rep2, lam).coeffs)
+    s1 = np.array(scale_representation(rep1, lam).coeffs)
+    factorized = np.kron(s1, s1)
+
+    assert canon2.sum() == pytest.approx(1.0)
+    assert len(canon2) == len(factorized) == 16
+    assert not np.allclose(np.sort(canon2), np.sort(factorized))
+
+
+# =========================================================================== #
+# Group B — coverage across every representation type                         #
+# =========================================================================== #
+def _rep_catalog():
+    q = LineQubit(0)
+    return {
+        "global_depol_1q": represent_operation_with_global_depolarizing_noise(
+            Circuit(X(q)), BASE_NOISE
+        ),
+        "local_depol_1q": represent_operation_with_local_depolarizing_noise(
+            Circuit(X(q)), BASE_NOISE
+        ),
+        "global_depol_2q": represent_operation_with_global_depolarizing_noise(
+            Circuit(CNOT(q0, q1)), BASE_NOISE
+        ),
+        "local_depol_2q": represent_operation_with_local_depolarizing_noise(
+            Circuit(CNOT(q0, q1)), BASE_NOISE
+        ),
+        "biased_1q": represent_operation_with_local_biased_noise(
+            Circuit(X(q)), BASE_NOISE, 1.0
+        ),
+        "biased_2q": represent_operation_with_local_biased_noise(
+            Circuit(CNOT(q0, q1)), BASE_NOISE, 1.0
+        ),
+        "amp_damping_1q": _represent_operation_with_amplitude_damping_noise(
+            Circuit(X(q)), BASE_NOISE
+        ),
+        "optimal_1q": optimal_single_qubit_rep(BASE_NOISE),
+        "amplify_positive_1q": amplify_noisy_op_with_global_depolarizing_noise(
+            Circuit(X(q)), BASE_NOISE
+        ),
+        "spl_1gen": spl_single_generator_rep(Circuit(H(q)), q, Z, 0.05),
+        "spl_2gen": spl_two_generator_rep(Circuit(H(q)), q, Z, X, 0.05, 0.03),
+    }
+
+
+@pytest.mark.parametrize("name", list(_rep_catalog()))
+@pytest.mark.parametrize("scale_factor", [1.0, 2.0])
+def test_scale_representation_invariants_all_types(name, scale_factor):
+    rep = _rep_catalog()[name]
+    is_signed = any(c < 0 for c in rep.coeffs)
+    scaled = scale_representation(rep, scale_factor)
+
+    assert isinstance(scaled, OperationRepresentation)
+    assert len(scaled.coeffs) == len(rep.coeffs)
+    assert len(scaled.noisy_operations) == len(rep.noisy_operations)
+    assert sum(scaled.coeffs) == pytest.approx(1.0)
+    assert np.isfinite(scaled.norm)
+    if is_signed and scale_factor == 1.0:
+        # signed -> canonical: lambda=1 is the base noisy channel (norm 1)
+        assert scaled.norm == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    "name", ["global_depol_1q", "local_depol_2q", "amp_damping_1q", "spl_1gen"]
+)
+def test_construct_circuits_accepts_each_rep_type(name):
+    rep = _rep_catalog()[name]
+    scaled = construct_circuits(
+        rep.ideal,
+        scale_factors=[1.0, 2.0],
+        representations=[rep],
+        num_samples=8,
+        random_state=0,
+    )
+    sampled_circuits, signs, norms = scaled
+    assert len(sampled_circuits) == 2  # one per scale factor
+    assert all(len(c) == 8 for c in sampled_circuits)
+
+
+# =========================================================================== #
+# Group C — end-to-end mitigation with signed PEC representations             #
+# =========================================================================== #
+@pytest.mark.parametrize("circuit", [oneq_circ, twoq_circ])
+def test_execute_with_pea_signed_reps_mitigate_noise(circuit):
+    """End-to-end mitigation with signed PEC representations fed directly to
+    PEA, against a depolarizing simulator."""
+    reps = represent_operations_in_circuit_with_local_depolarizing_noise(
+        circuit, BASE_NOISE
+    )
+    ideal = depolarizing_executor(circuit, noise=0.0)
+    unmitigated = depolarizing_executor(circuit)
+
+    mitigated = execute_with_pea(
+        circuit,
+        depolarizing_executor,
+        scale_factors=[1.0, 1.5, 2.0],
+        representations=reps,
+        extrapolation_method=RichardsonFactory.extrapolate,
+        random_state=7,
+        num_samples=4000,
+    )
+    assert abs(mitigated - ideal) < abs(unmitigated - ideal)
+    assert np.isclose(mitigated, ideal, atol=0.1)
+
+
+def test_signed_and_noise_model_paths_both_accurate():
+    """The signed-rep interface and the legacy noise_model interface both run
+    end to end and produce accurate estimates (they use different scaling
+    conventions, so need not be numerically identical). Uses the config the
+    existing PEA mitigation test is known to converge with."""
+    circuit = oneq_circ
+    ideal = depolarizing_executor(circuit, noise=0.0)
+
+    reps = represent_operations_in_circuit_with_local_depolarizing_noise(
+        circuit, BASE_NOISE
+    )
+    via_reps = execute_with_pea(
+        circuit,
+        depolarizing_executor,
+        scale_factors=[1.0, 1.2, 1.6],
+        representations=reps,
+        extrapolation_method=LinearFactory.extrapolate,
+        random_state=101,
+    )
+    via_model = execute_with_pea(
+        circuit,
+        depolarizing_executor,
+        scale_factors=[1.0, 1.2, 1.6],
+        noise_model="local_depolarizing",
+        epsilon=BASE_NOISE,
+        extrapolation_method=LinearFactory.extrapolate,
+        random_state=101,
+    )
+    assert np.isclose(via_reps, ideal, atol=0.1)
+    assert np.isclose(via_model, ideal, atol=0.1)
+
+
+def test_pea_with_learned_depolarizing_parameter_mitigates():
+    """Hardware-agnostic workflow: build reps from a (learned-style) epsilon
+    and mitigate, simulating a learned epsilon near the true noise level."""
+    circuit = oneq_circ
+    learned_epsilon = 0.02  # stand-in for learn_depolarizing_noise_parameter
+    reps = represent_operations_in_circuit_with_local_depolarizing_noise(
+        circuit, learned_epsilon
+    )
+    ideal = depolarizing_executor(circuit, noise=0.0)
+    unmitigated = depolarizing_executor(circuit)
+    mitigated = execute_with_pea(
+        circuit,
+        depolarizing_executor,
+        scale_factors=[1.0, 1.5, 2.0],
+        representations=reps,
+        extrapolation_method=LinearFactory.extrapolate,
+        random_state=11,
+        num_samples=4000,
+    )
+    assert abs(mitigated - ideal) < abs(unmitigated - ideal)
+
+
+# =========================================================================== #
+# Group D — validation / robustness                                           #
+# =========================================================================== #
+def test_construct_circuits_empty_representations_raises():
+    with pytest.raises(ValueError, match="non-empty"):
+        construct_circuits(oneq_circ, scale_factors=[1, 2], representations=[])
+
+
+def test_scale_circuit_amplifications_empty_representations_raises():
+    with pytest.raises(ValueError, match="non-empty"):
+        scale_circuit_amplifications(oneq_circ, 2.0, representations=[])
+
+
+def test_scale_representation_rejects_nonpositive_scale():
+    q = LineQubit(0)
+    rep = represent_operation_with_global_depolarizing_noise(
+        Circuit(X(q)), 0.05
+    )
+    with pytest.raises(ValueError, match="positive"):
+        scale_representation(rep, 0.0)
+    with pytest.raises(ValueError, match="positive"):
+        scale_representation(rep, -1.0)
+
+
+def test_scale_representation_rejects_nonfinite_scale():
+    q = LineQubit(0)
+    rep = represent_operation_with_global_depolarizing_noise(
+        Circuit(X(q)), 0.05
+    )
+    with pytest.raises(ValueError, match="finite"):
+        scale_representation(rep, float("inf"))
+
+
+def test_all_positive_without_identity_term_raises():
+    q = LineQubit(0)
+    rep = OperationRepresentation(
+        Circuit(X(q)),
+        [
+            NoisyOperation(Circuit([X(q), Y(q)])),
+            NoisyOperation(Circuit([X(q), Z(q)])),
+        ],
+        [0.5, 0.5],
+    )
+    with pytest.raises(ValueError, match="identity"):
+        scale_representation(rep, 2.0)
+
+
+def test_construct_circuits_rejects_both_inputs():
+    reps = represent_operations_in_circuit_with_local_depolarizing_noise(
+        oneq_circ, BASE_NOISE
+    )
+    with pytest.raises(ValueError, match="Either ``noise_model``"):
+        construct_circuits(
+            oneq_circ,
+            scale_factors=[1, 2],
+            noise_model="local_depolarizing",
+            epsilon=BASE_NOISE,
+            representations=reps,
+        )
+
+
+def test_construct_circuits_requires_some_input():
+    with pytest.raises(ValueError, match="Either ``noise_model``"):
+        construct_circuits(oneq_circ, scale_factors=[1, 2])
+
+
+def test_construct_circuits_rejects_empty_scale_factors():
+    q = LineQubit(0)
+    rep = represent_operation_with_global_depolarizing_noise(
+        Circuit(X(q)), 0.05
+    )
+    with pytest.raises(ValueError, match="scale_factors"):
+        construct_circuits(
+            Circuit(X(q)), scale_factors=[], representations=[rep]
+        )
+
+
+def test_noise_model_path_emits_deprecation_warning():
+    with pytest.warns(DeprecationWarning, match="noise_model is deprecated"):
+        construct_circuits(
+            oneq_circ,
+            scale_factors=[1, 2],
+            noise_model="local_depolarizing",
+            epsilon=BASE_NOISE,
+            num_samples=4,
+        )
+
+
+# =========================================================================== #
+# Group E — multi-qubit noise_model-equivalence scope (criterion 2)
+# =========================================================================== #
+def test_twoqubit_global_depolarizing_representations_equal_noise_model():
+    """2-qubit GLOBAL depolarizing is a single-parameter channel, so the
+    representations path equals the legacy noise_model path EXACTLY at every
+    scale factor."""
+    circ = Circuit(CNOT(q0, q1))
+    eps = 0.05
+    base = amplify_noisy_ops_in_circuit_with_global_depolarizing_noise(
+        circ, eps
+    )
+    for s in (1.0, 2.0, 3.0):
+        via_reps = scale_circuit_amplifications(circ, s, representations=base)
+        via_model = scale_circuit_amplifications(
+            circ, s, noise_model="global_depolarizing", epsilon=eps
+        )
+        assert len(via_reps) == len(via_model) == 1
+        assert via_reps[0].coeffs == pytest.approx(via_model[0].coeffs)
+
+
+def test_twoqubit_local_depolarizing_representations_differ_from_noise_model():
+    """2-qubit LOCAL depolarizing is a tensor product (multi-parameter), so the
+    single-parameter representations path canNOT reproduce the factorized
+    noise_model rebuild. This regression-locks the documented limitation
+    (acceptance criterion 2 holds only for global + single-qubit local)."""
+    circ = Circuit(CNOT(q0, q1))
+    eps, s = 0.05, 2.0
+    base = amplify_noisy_ops_in_circuit_with_local_depolarizing_noise(
+        circ, eps
+    )
+    via_reps = scale_circuit_amplifications(circ, s, representations=base)[
+        0
+    ].coeffs
+    via_model = scale_circuit_amplifications(
+        circ, s, noise_model="local_depolarizing", epsilon=eps
+    )[0].coeffs
+    max_diff = max(abs(a - b) for a, b in zip(via_reps, via_model))
+    assert max_diff == pytest.approx(0.005, abs=5e-4)
+
+
+def test_num_samples_uses_max_scaled_norm():
+    """num_samples is deduced from the largest scaled one-norm across the
+    requested scale factors; a sub-unit (noise-reduction) factor with
+    one-norm > 1 raises the budget above the scale-1.0-only value."""
+    q = LineQubit(0)
+    ideal = Circuit(X(q))
+    rep = represent_operation_with_global_depolarizing_noise(ideal, 0.05)
+    precision = 0.2
+    scale_factors = [0.5, 1.0, 2.0]
+
+    max_norm = max(scale_representation(rep, s).norm for s in scale_factors)
+    expected = int((max_norm / precision) ** 2)
+
+    sampled, _, _ = construct_circuits(
+        ideal,
+        scale_factors=scale_factors,
+        representations=[rep],
+        precision=precision,
+        random_state=0,
+    )
+    assert len(sampled[0]) == expected
+    # strictly more than the (incorrect) scale-1.0-only deduction (norm == 1)
+    assert expected > int((1.0 / precision) ** 2)
+
+
+def test_scale_circuit_amplifications_rejects_nonfinite_scale():
+    q = LineQubit(0)
+    ideal = Circuit(X(q))
+    rep = represent_operation_with_global_depolarizing_noise(ideal, 0.05)
+
+    with pytest.raises(ValueError, match="finite"):
+        scale_circuit_amplifications(
+            ideal,
+            float("inf"),
+            representations=[rep],
+        )
+    with pytest.raises(ValueError, match="finite"):
+        scale_circuit_amplifications(
+            ideal,
+            float("inf"),
+            noise_model="global_depolarizing",
+            epsilon=0.05,
+        )

--- a/mitiq/experimental/pea/tests/test_scale_amplifications.py
+++ b/mitiq/experimental/pea/tests/test_scale_amplifications.py
@@ -11,16 +11,20 @@ from cirq import (
     Circuit,
     H,
     LineQubit,
+    X,
     Y,
 )
 
 from mitiq.experimental.pea.amplifications.amplify_depolarizing import (
+    amplify_noisy_op_with_global_depolarizing_noise,
     amplify_noisy_ops_in_circuit_with_global_depolarizing_noise,
     amplify_noisy_ops_in_circuit_with_local_depolarizing_noise,
 )
 from mitiq.experimental.pea.scale_amplifications import (
     scale_circuit_amplifications,
+    scale_representation,
 )
+from mitiq.pec import NoisyOperation, OperationRepresentation
 
 qreg = LineQubit.range(2)
 circ = Circuit([CNOT(*qreg), H(qreg[0]), Y(qreg[1]), CNOT(*qreg)])
@@ -55,3 +59,82 @@ def test_noise_model_not_implemented_error():
     noise_model = "amplitude_damping"
     with pytest.raises(ValueError, match="Noise model not supported"):
         scale_circuit_amplifications(circ, 1.0, noise_model, 0.01)
+
+
+def test_scale_positive_representation_matches_amplified_depolarizing_path():
+    epsilon = 0.08
+    gate = Circuit(Y(qreg[0]))
+    scaled_factor = 2.5
+    representation = amplify_noisy_op_with_global_depolarizing_noise(
+        gate, epsilon
+    )
+    scaled_representation = scale_representation(representation, scaled_factor)
+    expected = amplify_noisy_op_with_global_depolarizing_noise(
+        gate, scaled_factor * epsilon
+    )
+
+    assert scaled_representation.coeffs == pytest.approx(
+        expected.coeffs
+    )
+
+
+def test_scale_circuit_amplifications_with_representations_path():
+    epsilon = 0.05
+    gate = Circuit(Y(qreg[0]))
+    base_representations = amplify_noisy_op_with_global_depolarizing_noise(
+        gate, epsilon
+    )
+    scaled_factor = 2
+    expected = scale_representation(base_representations, scaled_factor)
+    scaled = scale_circuit_amplifications(
+        gate, scaled_factor, representations=[base_representations]
+    )
+
+    assert len(scaled) == 1
+    assert scaled[0].coeffs == pytest.approx(expected.coeffs)
+
+
+def test_scale_signed_representation_uses_canonical_scaling():
+    # 1.2 * O_+ -0.2 * O_- should become:
+    # a_+ (1 - s*γ^-/γ^+) and a_- (1-s), with γ^+=1.2, γ^-=0.2.
+    q = qreg[0]
+    representation = OperationRepresentation(
+        Circuit(X(q)),
+        [NoisyOperation(Circuit(X(q))), NoisyOperation(Circuit(Y(q)))],
+        [1.2, -0.2],
+    )
+    scale_factor = 2.0
+    scaled = scale_representation(representation, scale_factor)
+
+    assert scaled.coeffs == pytest.approx([0.8, 0.2])
+
+
+def test_scale_signed_representation_enforces_canonical_limit():
+    q = qreg[0]
+    representation = OperationRepresentation(
+        Circuit(X(q)),
+        [NoisyOperation(Circuit(X(q))), NoisyOperation(Circuit(Y(q)))],
+        [1.2, -0.2],
+    )
+    with pytest.raises(ValueError, match="canonical limit"):
+        scale_representation(representation, 7.0)
+
+
+def test_scale_circuit_amplifications_requires_mutually_exclusive_inputs():
+    epsilon = 0.05
+    local_noisy_representations = (
+        amplify_noisy_ops_in_circuit_with_local_depolarizing_noise(
+            circ, epsilon
+        )
+    )
+    with pytest.raises(ValueError, match="Either ``noise_model``"):
+        scale_circuit_amplifications(circ, 2, None, epsilon)
+
+    with pytest.raises(ValueError, match="Either ``noise_model``"):
+        scale_circuit_amplifications(
+            circ,
+            2,
+            "local_depolarizing",
+            epsilon,
+            local_noisy_representations,
+        )

--- a/mitiq/experimental/pea/tests/test_scale_amplifications.py
+++ b/mitiq/experimental/pea/tests/test_scale_amplifications.py
@@ -73,9 +73,7 @@ def test_scale_positive_representation_matches_amplified_depolarizing_path():
         gate, scaled_factor * epsilon
     )
 
-    assert scaled_representation.coeffs == pytest.approx(
-        expected.coeffs
-    )
+    assert scaled_representation.coeffs == pytest.approx(expected.coeffs)
 
 
 def test_scale_circuit_amplifications_with_representations_path():


### PR DESCRIPTION
## Summary

Probabilistic Error Amplification (PEA) currently amplifies noise only through a `noise_model` string
enum (`"local_depolarizing"` / `"global_depolarizing"`), which limits it to analytically tractable
models and makes it unusable on real hardware. This PR adds a `representations` parameter, a
`list[OperationRepresentation]`, to `pea.construct_circuits` and `pea.execute_with_pea`, so PEA can
amplify any quasi-probability representation, including ones learned from hardware characterization.

- `noise_model` becomes optional; `representations` is its alternative. The two are **mutually
  exclusive** (passing both, or neither, raises a clear `ValueError`). `epsilon` is used only by the
  legacy `noise_model` path and is ignored when `representations` is provided.
- `noise_model` keeps working unchanged for backward compatibility, now emitting a `DeprecationWarning`.
- Representations are amplified with the **canonical noise scaling** of Section D of Mari, Shammah &
  Zeng, *Phys. Rev. A* **104**, 052607 (2021), [arXiv:2108.02237](https://arxiv.org/abs/2108.02237),
  implemented as a new helper `scale_representation` that is correct for *both* signed (PEC-style) and
  all-positive (amplification/learned-noise) representations. Internally, both public input modes resolve
  to one `scale_factor -> representations` provider, so the sampling pipeline has a single interface while
  preserving the exact legacy rebuild semantics.

## Background: PEA in brief

A quasi-probability representation writes an ideal gate as a real linear combination of implementable
noisy operations,

$$\mathcal{G} = \sum_\alpha \eta_\alpha\, \mathcal{O}_\alpha, \qquad \sum_\alpha \eta_\alpha = 1, \qquad \gamma = \sum_\alpha |\eta_\alpha| \ge 1 .$$

PEC uses this to *cancel* noise; PEA uses the same object to *amplify* it in a controlled way: each gate
is re-expressed at a series of noise scale factors $\lambda \ge 1$, the expectation values are estimated
at each $\lambda$, and the results are extrapolated to $\lambda = 0$ (zero-noise), i.e. PEA is the
principled, quasi-probability front end of ZNE.

The math for scaling an arbitrary representation is the **canonical noise scaling** of Section D. Split the
coefficients by sign into positive/negative volumes $\gamma^{+} = \sum_{\eta>0}\eta$ and
$\gamma^{-} = \sum_{\eta<0}|\eta|$ (so $\gamma^{+} - \gamma^{-} = 1$), and rescale:

$$\eta_{+} \;\to\; \eta_{+}\,\frac{\gamma^{+} - \lambda\,\gamma^{-}}{\gamma^{+}}, \qquad \eta_{-} \;\to\; \eta_{-}\,(1 - \lambda),$$

valid up to $\lambda_{\max} = \gamma^{+}/\gamma^{-}$. This preserves $\sum_\alpha \eta_\alpha = 1$ for
every $\lambda$; at $\lambda = 1$ it yields the base noisy channel (one-norm $\gamma = 1$), and for
$1 \le \lambda \le \lambda_{\max}$ the rescaled coefficients are **all non-negative**, a genuine
probability distribution, so amplification is sign-problem-free ($\gamma = 1$, negligible sampling
overhead). For an all-positive representation ($\gamma^{-} = 0$, e.g. a learned noise model) the
canonical map degenerates, and the natural rule is **deviation-from-identity** scaling
$a_0 \to 1 - \lambda(1 - a_0)$, $a_k \to \lambda\, a_k$, which reproduces the analytic depolarizing
rebuild.

## Why the existing approaches are incomplete (#3027, #3041)

Two open PRs each implement only one of the two scaling rules above, and so each fails on half of the
realistic inputs. Numerical evidence for single-qubit depolarizing, base $p = 0.01$, amplification factor
$s = 2$ (only the failing cases are shown):

| PR | Input it mishandles | Result of scaling | Issue |
|---|---|---|---|
| **#3041** (deviation-only) | signed PEC rep $[1.0101,\,-0.00338,\,-0.00338,\,-0.00338]$ ($\gamma=1.0203$) | $[1.0203,\,-0.00676,\,-0.00676,\,-0.00676]$, $\gamma = 1.041$ | **still signed; $\gamma$ grew** $\to$ amplifies error *cancellation*, not noise. Silently wrong (no error raised). |
| **#3027** (canonical-only) | all-positive `amplify`/learned rep $[0.98,\,0.0067,\,0.0067,\,0.0067]$ | raises `ValueError` ($\gamma^{-} = 0$) | **cannot scale all-positive reps** $\to$ rejects learned- and `noise_model`-style representations. |

- **#3041** uses deviation-from-identity scaling: on a signed PEC representation it scales every error
  term by $s$ and pushes the identity term *away* from 1, *increasing* the negativity
  ($\gamma:\ 1.020 \to 1.041$), amplifying the error-cancellation rather than the noise, without
  raising.
- **#3027** uses canonical sign-partition scaling: exact on signed PEC reps, but raises on any
  all-positive representation ($\gamma^{-} = 0$), which breaks the depolarizing-`noise_model` equivalence
  path and rejects learned all-positive noise models.

Both PRs are still open/unmerged, and their scaling rules were re-verified against their current heads:
#3041's `scale_representations` applies deviation-from-identity to every representation (no sign
dispatch), and #3027's `_canonical_scaled_representations` raises `ValueError` on any all-positive
representation away from scale factor 1. The gaps above are therefore unfixed. This PR keeps the
strengths of each.

## Our approach: one interface, two providers (fidelity vs generality)

`scale_representation(representation, scale_factor)` is **convention-aware**: it dispatches on the sign
structure of the representation (with a small tolerance so floating-point dust does not misroute it):

- contains negative coefficients (PEC-style) $\to$ **canonical sign-partition** scaling (Section D), with a
  $\lambda_{\max} = \gamma^{+}/\gamma^{-}$ physicality guard;
- all non-negative (learned-noise / `amplify_*` style) $\to$ **deviation-from-identity** scaling.

This single helper supports signed PEC-style representations (depolarizing, biased, amplitude-damping,
optimal/tomographic) and all-positive amplification/learned-noise representations that include an
explicit identity (bare-ideal) term. (All-positive representations *without* an identity term are
rejected with a clear error.)

`num_samples` (when not given) is deduced from the largest scaled one-norm across the requested
scale factors, so noise-reduction factors below 1 (whose one-norm exceeds 1) are not under-sampled.

**Design choice: two providers behind one interface.** The public API keeps two ways to specify the
amplification (`noise_model` and `representations`); internally both resolve through one
`_make_scaled_representation_factory(...)`, so input validation and the sampling interface live in a
single place. What we deliberately do **not** do is the *literal math merge* (routing `noise_model`
through the `representations` scaling rule), because the two providers compute genuinely different, and
both correct, scaling families:

- **`noise_model` provider**: exact analytic rebuild at the target noise $s\,\epsilon$, a regenerable
  family that retains the model's structure (preserves the precise multi-qubit-local behavior; unchanged,
  so byte-for-byte backward compatible);
- **`representations` provider**: canonical/deviation scaling of a single supplied snapshot, the only
  option for arbitrary/learned reps where no regenerable model exists.

These coincide for global depolarizing (any size) and single-qubit local depolarizing but differ for
multi-qubit *local* noise; the precise reason and the math are in **Known limitation** below. Choosing
between the providers is choosing *factorized exactness* (when the analytic model is known) vs
*generality* (any representation).

## What we test

A new `tests/test_representations_pathway.py` (cirq-only, deterministic) exercises every representation
family and the canonical-scaling math:

- **Noise models / representation types**: depolarizing **local & global** (1- and 2-qubit), local
  **biased noise** (1- and 2-qubit), **amplitude damping** (1-qubit), **optimal/tomographic** (1-qubit,
  via `find_optimal_representation`), all-positive **`amplify_*`** reps, and a hand-built **sparse
  Pauli–Lindblad** representation (later could cross validate with ibm-q). For each: scaling preserves
  $\sum_\alpha \eta_\alpha = 1$, preserves the operation count, dispatches to the correct rule, and
  round-trips through `construct_circuits`.
- **Canonical-scaling correctness**: the headline test is that canonically scaling a signed depolarizing
  PEC rep reproduces the paper's closed-form $\eta_j(\lambda)$ to machine precision; the one-norm law
  $\gamma^{(\lambda)} = \gamma - \lambda(\gamma-1)$ on $[0,1]$ and $\gamma^{(\lambda)} = 1$ on
  $[1, \lambda_{\max}]$; $\lambda = 1 \Rightarrow$ one-norm 1; the $\lambda_{\max}$ physicality guard
  raises; the deviation-path upper bound warns; the sign dispatch tolerates floating-point dust.
- **End-to-end mitigation**: `execute_with_pea(..., representations=…)` with signed PEC reps against a
  depolarizing simulator reduces the error and lands within `atol = 0.1`; plus a learned-$\epsilon$
  workflow and a signed-vs-`noise_model` accuracy comparison.
- **Multi-qubit `noise_model` scope**: a 2-qubit *global* depolarizing test asserts the
  `representations` path equals the `noise_model` path exactly, and a 2-qubit *local* test asserts they
  differ (regression-locking the single-parameter limitation); the signed canonical-vs-factorized
  difference is also regression-tested.
- **Sampling budget**: a test asserting `num_samples` is deduced from the max scaled one-norm across the
  requested scale factors (so sub-unit factors are not under-sampled).
- **Validation**: both / neither / empty `representations` $\to$ `ValueError`; non-positive and non-finite
  scale factors $\to$ `ValueError`; empty `scale_factors` $\to$ `ValueError`; an all-positive rep without
  an identity term $\to$ `ValueError`; floating-point dust in the sign dispatch is tolerated; the
  `noise_model` deprecation warning.

## Known limitation

Both representation-scaling rules produce a family that is **affine (degree 1) in the scale factor**
$s$: every coefficient is a degree-1 polynomial in $s$ (canonical:
$\eta_+ \to \eta_+(1 - s\,\gamma^-/\gamma^+)$ and $\eta_- \to \eta_-(1 - s)$; deviation:
$a_0 \to 1 - s(1 - a_0)$ and $a_k \to s\,a_k$). A named `noise_model`, in contrast, is a *regenerable
family*: it rebuilds the representation at any noise level, retaining the model's structure. A
**factorized $k$-qubit local** channel is a tensor product, so its coefficients are *products* of
per-qubit terms and the family is **degree $k$** in $s$. For 2-qubit local depolarizing the two-Pauli
coefficient is

$$c_{\text{true}}(s) = \Big(\tfrac{s\,\epsilon}{3}\Big)^{2} = s^{2}\Big(\tfrac{\epsilon}{3}\Big)^{2}\ \ (\text{degree }2), \qquad c_{\text{aff}}(s) = s\,\Big(\tfrac{\epsilon}{3}\Big)^{2}\ \ (\text{degree }1).$$

They agree at the pinned points $s = 0$ (ideal) and $s = 1$ (base noise) but diverge for any other $s$
once $k \ge 2$: at $\epsilon = 0.05,\ s = 2$ they are $c_{\text{true}} = 0.001111$ vs
$c_{\text{aff}} = 0.000556$ (ratio $s$), the source of the observed $\max|\Delta| \approx 5\times10^{-3}$.
For $k = 1$ (single-qubit local, and global depolarizing, which is one channel for any qubit count) the
true family is itself degree 1, so the affine scaling is **exact**. Equivalence with `noise_model` is
therefore exact only for **global depolarizing (any size)** and **single-qubit local** depolarizing.

**This is not "the representation has no model."** It is tempting to say a representation has "lost the
noise model," but 2-qubit `local_depolarizing` *has* a named model and is *exactly* where the paths
diverge, so that cannot be the cause. In fact every signed representation *induces* a noise model: by
Section D it defines a canonical noise channel $\Lambda_p = (1 - p)\,\mathcal{G} + p\,\Phi^{-}$, and an
all-positive representation is extended by the deviation-from-identity rule. The point is finer: the
**induced model is single-parameter (affine), hence lossy.** A bare representation fixes only one point
($s = 1$); extending it to a family forces the affine rule, whereas a named model carries enough
structure to define the exact, higher-degree family. The representation-to-model map always exists; it
simply need not equal the true physical noise when that noise scales nonlinearly (degree $> 1$), as
factorized multi-qubit local noise does.

**Practical consequence.** When the analytic model is known, prefer `noise_model` (exact). The
`representations` path is the general fallback for arbitrary/learned noise, where no regenerable model
exists and the Section-D single-parameter scaling is the principled choice. Recovering the higher-degree
behavior from a representation would require carrying factorization / noise-model metadata, which would
change the `OperationRepresentation` contract and defeat #2936's goal of accepting arbitrary learned
representations; we deliberately do not do that.

## Files changed

- `mitiq/experimental/pea/pea.py`: `representations` parameter on `construct_circuits` /
  `execute_with_pea`, mutual-exclusion + empty-list validation, deprecation warning.
- `mitiq/experimental/pea/scale_amplifications.py`: new `scale_representation` (sign-dispatch:
  canonical / deviation, dust-tolerant) plus a resolver that maps either public input mode to
  `scale_factor -> representations`.
- `mitiq/experimental/pea/tests/test_pea.py`,
  `mitiq/experimental/pea/tests/test_scale_amplifications.py`: pathway + validation tests.
- `mitiq/experimental/pea/tests/test_representations_pathway.py`: new comprehensive suite.

Closes #2936
