### PR TITLE
Fix executor return-type detection under `from __future__ import annotations` (closes #3061)

### DIFF
--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -78,11 +78,14 @@ class Executor:
         # evaluates stringized (PEP 563) annotations back into concrete types,
         # so executors defined in modules using
         # ``from __future__ import annotations`` are still detected correctly.
-        # Fall back to the raw annotations if a hint cannot be resolved (e.g.
-        # an unresolvable forward reference).
+        # It evaluates *all* annotations, so it raises ``NameError`` when any
+        # of them is an unresolvable forward reference (e.g. a name imported
+        # only under ``typing.TYPE_CHECKING``) and ``TypeError`` on some
+        # callables it cannot introspect. In those cases fall back to the raw
+        # (possibly stringized) annotations, preserving the previous behavior.
         try:
             executor_annotation = typing.get_type_hints(executor)
-        except Exception:
+        except (NameError, TypeError):
             executor_annotation = inspect.getfullargspec(executor).annotations
         self._executor_return_type = executor_annotation.get("return")
         self._max_batch_size = max_batch_size

--- a/mitiq/executor/executor.py
+++ b/mitiq/executor/executor.py
@@ -74,7 +74,16 @@ class Executor:
     ) -> None:
         self._executor = executor
 
-        executor_annotation = inspect.getfullargspec(executor).annotations
+        # Resolve the executor's return-type annotation. ``get_type_hints``
+        # evaluates stringized (PEP 563) annotations back into concrete types,
+        # so executors defined in modules using
+        # ``from __future__ import annotations`` are still detected correctly.
+        # Fall back to the raw annotations if a hint cannot be resolved (e.g.
+        # an unresolvable forward reference).
+        try:
+            executor_annotation = typing.get_type_hints(executor)
+        except Exception:
+            executor_annotation = inspect.getfullargspec(executor).annotations
         self._executor_return_type = executor_annotation.get("return")
         self._max_batch_size = max_batch_size
 

--- a/mitiq/executor/tests/test_executor_pep563.py
+++ b/mitiq/executor/tests/test_executor_pep563.py
@@ -11,7 +11,8 @@ an executor is defined, every annotation is stored as a string.
 (e.g. ``"float"`` -> ``float``) so that float / measurement /
 density-matrix executors are detected correctly.
 
-See https://github.com/unitaryfoundation/mitiq/issues/3061 for the originating issue.
+See https://github.com/unitaryfoundation/mitiq/issues/3061 for the
+originating issue.
 """
 
 from __future__ import annotations

--- a/mitiq/executor/tests/test_executor_pep563.py
+++ b/mitiq/executor/tests/test_executor_pep563.py
@@ -1,0 +1,60 @@
+# Copyright (C) Unitary Foundation
+#
+# This source code is licensed under the GPL license (v3) found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Regression tests for executors defined under PEP 563.
+
+When ``from __future__ import annotations`` is active in the module where
+an executor is defined, every annotation is stored as a string.
+``Executor`` must still resolve the return-type annotation
+(e.g. ``"float"`` -> ``float``) so that float / measurement /
+density-matrix executors are detected correctly.
+
+See https://github.com/unitaryfoundation/mitiq for the originating issue.
+"""
+
+from __future__ import annotations
+
+import cirq
+import numpy as np
+
+from mitiq.executor.executor import Executor
+from mitiq.observable import Observable, PauliString
+
+
+# Defined in a module using PEP 563, so this annotation is the string "float".
+def float_executor(circuit) -> float:
+    return 1.0
+
+
+def test_return_annotation_resolved_to_type():
+    """The stringized "float" annotation should resolve to the float type."""
+    executor = Executor(float_executor)
+    assert executor._executor_return_type is float
+
+
+def test_evaluate_float_executor_under_pep563():
+    """A float executor defined under PEP 563 must evaluate without error."""
+    q = cirq.LineQubit(0)
+    circuit = cirq.Circuit(cirq.X(q))
+
+    results = Executor(float_executor).evaluate(circuit)
+
+    assert np.allclose(results, [1.0])
+    assert not Executor(float_executor).can_batch
+
+
+def test_evaluate_with_observable_under_pep563():
+    """An observable-based evaluation should also work under PEP 563."""
+
+    def density_matrix_executor(circuit) -> np.ndarray:
+        return cirq.final_density_matrix(circuit)
+
+    obs = Observable(PauliString("Z"))
+    q = cirq.LineQubit(0)
+    circuit = cirq.Circuit(cirq.I(q))
+
+    results = Executor(density_matrix_executor).evaluate(circuit, obs)
+
+    assert np.allclose(results, [1.0])

--- a/mitiq/executor/tests/test_executor_pep563.py
+++ b/mitiq/executor/tests/test_executor_pep563.py
@@ -11,7 +11,7 @@ an executor is defined, every annotation is stored as a string.
 (e.g. ``"float"`` -> ``float``) so that float / measurement /
 density-matrix executors are detected correctly.
 
-See https://github.com/unitaryfoundation/mitiq for the originating issue.
+See https://github.com/unitaryfoundation/mitiq/issues/3061 for the originating issue.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Fixes #3061 

`Executor` read the executor's return type via
`inspect.getfullargspec(executor).annotations`, which returns the raw `__annotations__` dict. When the executor is defined in a module using `from __future__ import annotations`, annotations are strings, so the return type became the string `"float"` instead of the `float` type. The membership checks in `evaluate()` then matched nothing and raised `ValueError: Could not parse executed results from executor with type float`, even though the executor returned a valid float. This also affected measurement/density-matrix executors and any technique that builds an `Executor` internally (PEC, ZNE, ...).

Resolve the annotation with `typing.get_type_hints()`, which evaluates stringized (PEP 563) annotations back into concrete types, with a fallback to the raw annotations when a hint cannot be resolved.

Add regression tests in a module that uses
`from __future__ import annotations`.

## Description

`Executor.__init__` reads the executor's return type via `inspect.getfullargspec(executor).annotations`, which returns the raw `__annotations__` dict. When the executor is defined in a module using `from __future__ import annotations` ([PEP 563](https://peps.python.org/pep-0563/)), all annotations are strings, so `_executor_return_type` becomes the string `"float"` instead of the `float` type. The membership checks in `evaluate()` (`... in FloatLike`, etc.) compare against concrete type objects, match nothing, and the method raises:

```python
ValueError: Could not parse executed results from executor with type float.
```

…even though the executor returns a valid float. This also affects measurement/density-matrix executors and any technique that builds an `Executor` internally (PEC, ZNE, …).

## Reproducer

```python
from __future__ import annotations  # the only thing that matters

import cirq
from mitiq import Executor

def executor(circuit) -> float:
    return 1.0

q = cirq.LineQubit(0)
circuit = cirq.Circuit(cirq.X(q))
print(Executor(executor).evaluate(circuit))  # raises ValueError
```

## Fix

Resolve the annotation with `typing.get_type_hints()`, which evaluates stringized annotations back into concrete types using the executor's `__globals__`, with a fallback to the raw annotations if a hint can't be resolved (e.g. an unresolvable forward reference).

## Tests

Adds `mitiq/executor/tests/test_executor_pep563.py` with regression tests in a module that uses `from __future__ import annotations`. They fail on `main` and pass with this change.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
