### PR TITLE
Fix nightly docs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If you are using an experimental technique and would like to help it graduate, p
 | Probabilistic Error Amplification  | [PEA](https://mitiq.readthedocs.io/en/stable/guide/pea.html) |  [`mitiq.experimental.pea`](https://github.com/unitaryfoundation/mitiq/tree/main/mitiq/experimental/pea) | [Nature](https://www.nature.com/articles/s41586-023-06096-3) |
 | Virtual Distillation  | [VD](https://mitiq.readthedocs.io/en/stable/guide/vd.html) |  [`mitiq.experimental.vd`](https://github.com/unitaryfoundation/mitiq/tree/main/mitiq/experimental/vd) | [APS](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.11.041036) |
 | Twirled Readout Error eXtinction | [TREX](https://mitiq.readthedocs.io/en/latest/guide/trex.html) | [`mitiq.experimental.trex`](https://github.com/unitaryfoundation/mitiq/tree/main/mitiq/experimental/trex) | [2012.09738](https://arxiv.org/abs/2012.09738) |
-| Debiasing | [DEB](https://mitiq.readthedocs.io/en/stable/guide/deb.html) | [`mitiq.experimental.deb`](https://github.com/unitaryfoundation/mitiq/tree/main/mitiq/experimental/deb) | [2301.07233](https://arxiv.org/abs/2301.07233) |
+| Debiasing | [DEB](https://mitiq.readthedocs.io/en/latest/guide/deb.html) | [`mitiq.experimental.deb`](https://github.com/unitaryfoundation/mitiq/tree/main/mitiq/experimental/deb) | [2301.07233](https://arxiv.org/abs/2301.07233) |
 
 
 In addition, we also have Pauli Twirling which is a noise tailoring technique:

--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -150,7 +150,7 @@ Jupyter notebooks (`.ipynb`) or MyST markdown notebooks, but MyST formatting wil
 If you have a notebook you want to add, and want to automatically convert it from the `.ipynb` to `.md`, you can use a great Python command line tool called [jupytext](https://jupytext.readthedocs.io/en/latest/index.html).
 To convert from an IPython notebook to markdown file, run `jupytext your_filename.ipynb --to myst` and find the converted file at `your_filename.md`.
 
-Further, not only can `jupytext` convert between the formats on demand, but once you install it, you can configure it to manage _both_ a Jupyter and Markdown version of your file, so you don't have to remember to do conversions (for more details, see the `jupytext` docs on [paired notebooks](https://jupytext.readthedocs.io/en/latest/index.html#paired-notebooks)).
+Further, not only can `jupytext` convert between the formats on demand, but once you install it, you can configure it to manage _both_ a Jupyter and Markdown version of your file, so you don't have to remember to do conversions (for more details, see the `jupytext` docs on [paired notebooks](https://jupytext.org/using/paired-notebooks/)).
 Using the paired notebooks you can continue your development in the notebooks as normal, and just commit to git the markdown serialized version when you want to add to the docs.
 You can even add this tool as a [git pre-commit hook](https://jupytext.readthedocs.io/en/latest/using-pre-commit.html) if you want!
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -241,6 +241,7 @@ linkcheck_ignore = [
     r"https://github.com/unitaryfoundation/mitiq/compare/.*",
     r"https://github.com/unitaryfoundation/mitiq/compare/.*",
     r"https://github.com/unitaryfoundation/mitiq/projects/7",
+    r"https://scholar\.google\.com/.*",
 ]
 
 linkcheck_retries = 3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -239,7 +239,6 @@ linkcheck_ignore = [
     r"https://www\.contributor-covenant\.org/.*",
     r"https://www\.sciencedirect\.com/science/article/.*",
     r"https://github.com/unitaryfoundation/mitiq/compare/.*",
-    r"https://github.com/unitaryfoundation/mitiq/compare/.*",
     r"https://github.com/unitaryfoundation/mitiq/projects/7",
     r"https://scholar\.google\.com/.*",
 ]

--- a/docs/source/guide/deb.md
+++ b/docs/source/guide/deb.md
@@ -55,7 +55,7 @@ probability. To apply the sharpening step instead, pass
 
 Bitstrings are ordered to match `sorted(circuit.all_qubits())`: the first
 character corresponds to the first qubit in that sorted order, and so on. The
-same ordering is used by {func}`.construct_circuits` and
-{func}`.combine_results`, which is why the permutation returned by
+same ordering is used by {func}`~mitiq.experimental.deb.symmetrization.construct_circuits` and
+{func}`~mitiq.experimental.deb.deb.combine_results`, which is why the permutation returned by
 `construct_circuits` must be passed to `combine_results` so it can be undone on
 the measured bitstrings.

--- a/mitiq/experimental/deb/deb.py
+++ b/mitiq/experimental/deb/deb.py
@@ -75,10 +75,11 @@ def combine_results(
 
     Args:
         results: One ``MeasurementResult`` per variant, in the same order as
-            the variants returned by :func:`.construct_circuits`.
+            the variants returned by
+            :func:`~mitiq.experimental.deb.symmetrization.construct_circuits`.
         permutations: The permutation applied to each variant, in the same
             order as ``results`` (the second element returned by
-            :func:`.construct_circuits`).
+            :func:`~mitiq.experimental.deb.symmetrization.construct_circuits`).
         method: Either ``"averaging"`` or ``"sharpening"``.
 
     Returns:

--- a/mitiq/experimental/deb/symmetrization.py
+++ b/mitiq/experimental/deb/symmetrization.py
@@ -53,7 +53,7 @@ def construct_circuits(
     measurement is expected to be handled by the executor.
 
     The permutations are returned alongside the circuits so that they can be
-    passed to :func:`.combine_results`, which undoes them on the measured
+    passed to :func:`~mitiq.experimental.deb.deb.combine_results`, which undoes them on the measured
     bitstrings. ``permutations[k][i]`` is the index (into
     ``sorted(circuit.all_qubits())``) of the qubit that logical qubit ``i`` is
     mapped onto in variant ``k``.

--- a/mitiq/experimental/deb/symmetrization.py
+++ b/mitiq/experimental/deb/symmetrization.py
@@ -53,8 +53,9 @@ def construct_circuits(
     measurement is expected to be handled by the executor.
 
     The permutations are returned alongside the circuits so that they can be
-    passed to :func:`~mitiq.experimental.deb.deb.combine_results`, which undoes them on the measured
-    bitstrings. ``permutations[k][i]`` is the index (into
+    passed to :func:`~mitiq.experimental.deb.deb.combine_results`, which
+    undoes them on the measured bitstrings. ``permutations[k][i]`` is the
+    index (into
     ``sorted(circuit.all_qubits())``) of the qubit that logical qubit ``i`` is
     mapped onto in variant ``k``.
 


### PR DESCRIPTION
## Summary
- Disambiguate `construct_circuits` / `combine_results` cross-references in the new deb module (#3044) — Sphinx finds 8+ matches and treats the warnings as errors
- Fix stale jupytext link, use `/latest/` for deb guide (not on `/stable/` yet), and ignore `scholar.google.com` in linkcheck (403s from bot detection)

## Test plan
- [x] `make docs` passes locally
- [x] `make linkcheck` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)