### PR TITLE
Allow inserting DD sequences with non-Cirq rules

### DIFF
--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -9,10 +9,12 @@ from collections.abc import Callable
 
 import numpy as np
 import numpy.typing as npt
+import cirq
 from cirq import Circuit, I, LineQubit, synchronize_terminal_measurements
 
 from mitiq import QPROGRAM
 from mitiq.interface import accept_qprogram_and_validate
+from mitiq.interface.conversions import convert_to_mitiq
 
 
 def _get_circuit_mask(circuit: Circuit) -> npt.NDArray[np.int64]:
@@ -88,7 +90,7 @@ def get_slack_matrix_from_circuit_mask(
 
 def insert_ddd_sequences(
     circuit: QPROGRAM,
-    rule: Callable[[int], Circuit],
+    rule: Callable[[int], QPROGRAM],
 ) -> QPROGRAM:
     """Returns the circuit with DDD sequences applied according to the input
     rule.
@@ -109,7 +111,7 @@ def insert_ddd_sequences(
 @accept_qprogram_and_validate
 def _insert_ddd_sequences(
     circuit: Circuit,
-    rule: Callable[[int], Circuit],
+    rule: Callable[[int], QPROGRAM],
 ) -> Circuit:
     """Returns the circuit with DDD sequences applied according to the input
     rule.
@@ -130,6 +132,14 @@ def _insert_ddd_sequences(
             "are not currently supported by DDD."
         )
 
+    def cirq_rule(slack_length: int) -> Circuit:
+        cirq_circuit, _ = convert_to_mitiq(rule(slack_length))
+        qubit_map: dict[cirq.Qid, cirq.Qid] = {
+            q: LineQubit(i)
+            for i, q in enumerate(sorted(cirq_circuit.all_qubits()))
+        }
+        return cirq_circuit.transform_qubits(qubit_map)
+
     slack_matrix = get_slack_matrix_from_circuit_mask(
         _get_circuit_mask(circuit)
     )
@@ -140,7 +150,7 @@ def _insert_ddd_sequences(
         slack_column = slack_matrix[:, moment_idx]
         for row_index, slack_length in enumerate(slack_column):
             if slack_length > 1:
-                ddd_sequence = rule(slack_length).transform_qubits(
+                ddd_sequence = cirq_rule(slack_length).transform_qubits(
                     {LineQubit(0): qubits[row_index]}
                 )
                 for idx, op in enumerate(ddd_sequence.all_operations()):

--- a/mitiq/ddd/insertion.py
+++ b/mitiq/ddd/insertion.py
@@ -7,9 +7,9 @@
 
 from collections.abc import Callable
 
+import cirq
 import numpy as np
 import numpy.typing as npt
-import cirq
 from cirq import Circuit, I, LineQubit, synchronize_terminal_measurements
 
 from mitiq import QPROGRAM

--- a/mitiq/ddd/tests/test_insertion.py
+++ b/mitiq/ddd/tests/test_insertion.py
@@ -291,3 +291,29 @@ def test_insert_sequence_over_identity_gates():
     ddd_circuit = insert_ddd_sequences(circuit, rule=xx)
 
     assert ddd_circuit == circuit_expected
+
+
+def test_insert_sequences_with_qiskit_rule():
+    """DDD rules that return non-Cirq circuits (e.g. Qiskit) should work."""
+    from mitiq.interface.mitiq_qiskit.conversions import to_qiskit
+
+    def qiskit_xx(slack_length: int) -> qiskit.QuantumCircuit:
+        cirq_seq = xx(slack_length)
+        return to_qiskit(cirq_seq)
+
+    qubits = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.ops.H.on_each(*qubits),
+        cirq.ops.I.on_each(*qubits),
+        cirq.ops.I.on_each(*qubits),
+        cirq.ops.H.on_each(*qubits),
+    )
+    expected = cirq.Circuit(
+        cirq.ops.H.on_each(*qubits),
+        cirq.ops.X.on_each(*qubits),
+        cirq.ops.X.on_each(*qubits),
+        cirq.ops.H.on_each(*qubits),
+    )
+
+    result = insert_ddd_sequences(circuit, rule=qiskit_xx)
+    assert result == expected


### PR DESCRIPTION
## Summary

The DDD rule functions (e.g. `xx`, `xyxy`) are typed as returning `QPROGRAM`, and the public API (`insert_ddd_sequences`, `execute_with_ddd`, etc.) accepts `Callable[[int], QPROGRAM]`. However, the internal implementation of `insert_ddd_sequences` called Cirq-specific methods directly on the rule's return value, so any rule returning a non-Cirq circuit would fail at runtime:

```python
from qiskit import QuantumCircuit
from mitiq.ddd.insertion import insert_ddd_sequences
from mitiq.interface.mitiq_qiskit import to_qiskit
from mitiq.ddd.rules import xx

def qiskit_xx(slack_length: int) -> QuantumCircuit:
    return to_qiskit(xx(slack_length))

qreg = QuantumCircuit(2)
qreg.h([0, 1])
qreg.id([0, 1])
qreg.id([0, 1])
qreg.h([0, 1])

# Raises AttributeError: 'QuantumCircuit' has no attribute 'transform_qubits'
insert_ddd_sequences(qreg, rule=qiskit_xx)
```

- Widen the `rule` parameter type from `Callable[[int], Circuit]` to `Callable[[int], QPROGRAM]` in `insert_ddd_sequences` / `_insert_ddd_sequences`
- Add an internal `cirq_rule` wrapper that converts the rule output to a Cirq `Circuit` (via `convert_to_mitiq`) and normalizes qubit indexing to `LineQubit`s before the Cirq-specific DDD insertion logic runs

## Test plan

- [x] New test `test_insert_sequences_with_qiskit_rule` verifies a Qiskit-returning rule produces the same result as the equivalent Cirq rule
- [x] All 170 existing DDD tests continue to pass

AI was used in helping create this PR.