### PR TITLE
Fix nightly linkcheck failures

### DIFF
--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -150,7 +150,7 @@ Jupyter notebooks (`.ipynb`) or MyST markdown notebooks, but MyST formatting wil
 If you have a notebook you want to add, and want to automatically convert it from the `.ipynb` to `.md`, you can use a great Python command line tool called [jupytext](https://jupytext.readthedocs.io/en/latest/index.html).
 To convert from an IPython notebook to markdown file, run `jupytext your_filename.ipynb --to myst` and find the converted file at `your_filename.md`.
 
-Further, not only can `jupytext` convert between the formats on demand, but once you install it, you can configure it to manage _both_ a Jupyter and Markdown version of your file, so you don't have to remember to do conversions (for more details, see the `jupytext` docs on [paired notebooks](https://jupytext.org/using/paired-notebooks/)).
+Further, not only can `jupytext` convert between the formats on demand, but once you install it, you can configure it to manage _both_ a Jupyter and Markdown version of your file, so you don't have to remember to do conversions (for more details, see the `jupytext` docs on [paired notebooks](https://jupytext.readthedocs.io/en/latest/paired-notebooks.html)).
 Using the paired notebooks you can continue your development in the notebooks as normal, and just commit to git the markdown serialized version when you want to add to the docs.
 You can even add this tool as a [git pre-commit hook](https://jupytext.readthedocs.io/en/latest/using-pre-commit.html) if you want!
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -241,6 +241,7 @@ linkcheck_ignore = [
     r"https://github.com/unitaryfoundation/mitiq/compare/.*",
     r"https://github.com/unitaryfoundation/mitiq/projects/7",
     r"https://scholar\.google\.com/.*",
+    r"https://ora\.ox\.ac\.uk/objects/.*",
 ]
 
 linkcheck_retries = 3


### PR DESCRIPTION
The nightly linkcheck has been failing on two links. Neither is actually broken — both return 200 from a browser, but 403 to CI traffic, since both sites sit behind bot protection that blocks requests from GitHub Actions IPs.

Two different fixes:

The jupytext link now points to `jupytext.readthedocs.io` instead of `jupytext.org` (which is fronted by Cloudflare). The readthedocs URL serves link checkers without complaint, so we keep actually checking this link — and it matches the two other jupytext links in the same paragraph.

The `ora.ox.ac.uk` link is a stable UUID permalink with no checker-friendly alternative, so it's added to `linkcheck_ignore` alongside the other WAF-blocked hosts already there (arxiv, doi.org, sciencedirect, …).

Note the linkcheck step only runs on the nightly schedule, so the real confirmation comes from the next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)