### PR TITLE
Replace deprecated QuantumTape.expand with qml.decompose for PennyLane 0.45+ compatibility

### DIFF
--- a/mitiq/interface/mitiq_pennylane/conversions.py
+++ b/mitiq/interface/mitiq_pennylane/conversions.py
@@ -56,7 +56,9 @@ def from_pennylane(tape: QuantumTape) -> Circuit:
             "They should be subsequently added by the executor."
         )
 
-    tape = tape.expand(stop_at=lambda obj: obj.name in SUPPORTED)
+    (tape,), _ = qml.decompose(
+        tape, stopping_condition=lambda obj: obj.name in SUPPORTED
+    )
     qasm = qml.to_openqasm(
         tape,
         rotations=False,

--- a/mitiq/interface/mitiq_pennylane/tests/test_conversions_pennylane.py
+++ b/mitiq/interface/mitiq_pennylane/tests/test_conversions_pennylane.py
@@ -37,7 +37,7 @@ def test_from_pennylane_strips_gphase():
         qml.SX(wires=0)
 
     # Confirm the QASM contains gphase before conversion.
-    expanded = tape.expand()
+    (expanded,), _ = qml.decompose(tape)
     qasm = qml.to_openqasm(
         expanded,
         rotations=False,


### PR DESCRIPTION
PennyLane deprecated and removed `QuantumTape.expand()`, which broke the PennyLane → Mitiq conversion path (`from_pennylane`) on PennyLane 0.45 and later. This PR migrates the tape expansion to the supported `qml.decompose` API, keeping the same stopping condition (only decompose gates not in `SUPPORTED`).
  Changes:
  - `mitiq/interface/mitiq_pennylane/conversions.py`: replace
    `tape.expand(stop_at=...)` with
    `qml.decompose(tape, stopping_condition=...)`.
  - `mitiq/interface/mitiq_pennylane/tests/test_conversions_pennylane.py`:
    update the test helper to use `qml.decompose(tape)` instead of
    `tape.expand()`.
  Verification (locally):
  - `uv run pytest mitiq/interface/mitiq_pennylane` — 18 passed
  - `make check-format` — passed
  - `make check-types` — passed
  > **AI use disclosure:** Portions of this change were prepared with the
  > assistance of an AI coding tool (Cursor). All code was reviewed and is
  > understood by the author.
  ---
  ### License
  - [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described
  in section 7 of the GNU GPL, version 3.
  Before opening the PR, please ensure you have completed the following where appropriate.
  - [x] I added unit tests for new code.
  - [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
  - [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
  - [ ] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.