### PR TITLE
Add Calibrator.get_cost_breakdown for per-problem, per-strategy cost

### DIFF
--- a/mitiq/calibration/calibrator.py
+++ b/mitiq/calibration/calibrator.py
@@ -7,7 +7,7 @@ import warnings
 from collections.abc import Callable, Sequence
 from enum import Enum
 from operator import itemgetter
-from typing import cast
+from typing import Any, cast
 
 import cirq
 import numpy as np
@@ -325,22 +325,59 @@ class Calibrator:
         Returns:
             A summary of the number of circuits to be run.
         """
-        num_circuits = len(self.problems)
-        num_options = sum(
-            strategy.num_circuits_required()  # type: ignore
-            for strategy in self.strategies  # type: ignore
-        )
-
-        noisy = num_circuits * (num_options + 1)
-        ideal = (
-            sum(1 for p in self.problems if p.type == "custom")
-            if self.ideal_executor is not None
-            else 0
-        )
+        breakdown = self.get_cost_breakdown()
         return {
-            "noisy_executions": noisy,
-            "ideal_executions": ideal,
+            "noisy_executions": sum(
+                row["noisy_executions"] for row in breakdown
+            ),
+            "ideal_executions": sum(
+                row["ideal_executions"] for row in breakdown
+            ),
         }
+
+    def get_cost_breakdown(self) -> list[dict[str, Any]]:
+        """Returns the breakdown of the total cost reported by
+        :func:`get_cost`, itemized by problem and strategy.
+
+        Each (problem, strategy) pair contributes one row containing the
+        number of noisy executions required by that strategy. Each problem
+        also contributes one baseline row (with ``strategy_id`` set to
+        ``None`` and ``technique`` set to ``"baseline"``) accounting for the
+        single unmitigated noisy execution and, for custom problems run with
+        an ideal executor, the ideal execution.
+
+        Returns:
+            A list of dictionaries, each with keys ``problem_id``,
+            ``problem_type``, ``strategy_id``, ``technique``,
+            ``noisy_executions`` and ``ideal_executions``.
+        """
+        breakdown = []
+        for problem in self.problems:
+            for strategy in self.strategies:
+                breakdown.append(
+                    {
+                        "problem_id": problem.id,
+                        "problem_type": problem.type,
+                        "strategy_id": strategy.id,
+                        "technique": strategy.technique.name,
+                        "noisy_executions": strategy.num_circuits_required(),
+                        "ideal_executions": 0,
+                    }
+                )
+            breakdown.append(
+                {
+                    "problem_id": problem.id,
+                    "problem_type": problem.type,
+                    "strategy_id": None,
+                    "technique": "baseline",
+                    "noisy_executions": 1,
+                    "ideal_executions": int(
+                        problem.type == "custom"
+                        and self.ideal_executor is not None
+                    ),
+                }
+            )
+        return breakdown
 
     def run(self, log: OutputForm | None = None) -> None:
         """Runs all the circuits required for calibration.

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -223,6 +223,80 @@ def test_get_cost():
     assert cost["ideal_executions"] == 0
 
 
+def test_get_cost_breakdown():
+    cal = Calibrator(damping_execute, frontend="cirq", settings=settings)
+    breakdown = cal.get_cost_breakdown()
+
+    # One row per (problem, strategy) pair plus one baseline row per problem.
+    assert len(breakdown) == len(cal.problems) * (len(cal.strategies) + 1)
+    for strategy in cal.strategies:
+        rows = [r for r in breakdown if r["strategy_id"] == strategy.id]
+        assert len(rows) == len(cal.problems)
+        assert all(
+            r["noisy_executions"] == strategy.num_circuits_required()
+            and r["technique"] == strategy.technique.name
+            for r in rows
+        )
+    baseline_rows = [r for r in breakdown if r["strategy_id"] is None]
+    assert len(baseline_rows) == len(cal.problems)
+    assert all(
+        r["noisy_executions"] == 1 and r["technique"] == "baseline"
+        for r in baseline_rows
+    )
+
+    # The breakdown sums to the totals reported by get_cost.
+    cost = cal.get_cost()
+    assert cost["noisy_executions"] == sum(
+        r["noisy_executions"] for r in breakdown
+    )
+    assert cost["ideal_executions"] == 0
+    assert all(r["ideal_executions"] == 0 for r in breakdown)
+
+
+def test_get_cost_breakdown_custom_problem_with_ideal_executor():
+    q = cirq.LineQubit(0)
+    circ = cirq.Circuit(cirq.X(q))
+
+    custom_settings = Settings(
+        benchmarks=[{"circuit_type": "custom", "circuit": circ}],
+        strategies=[
+            {
+                "technique": "zne",
+                "scale_noise": fold_global,
+                "factory": LinearFactory([1.0, 2.0]),
+            }
+        ],
+    )
+    ideal_exec = Executor(partial(damping_execute, noise_level=0))
+    cal = Calibrator(
+        damping_execute,
+        frontend="cirq",
+        settings=custom_settings,
+        ideal_executor=ideal_exec,
+    )
+
+    breakdown = cal.get_cost_breakdown()
+    assert breakdown == [
+        {
+            "problem_id": 0,
+            "problem_type": "custom",
+            "strategy_id": 0,
+            "technique": "ZNE",
+            "noisy_executions": 2,
+            "ideal_executions": 0,
+        },
+        {
+            "problem_id": 0,
+            "problem_type": "custom",
+            "strategy_id": None,
+            "technique": "baseline",
+            "noisy_executions": 1,
+            "ideal_executions": 1,
+        },
+    ]
+    assert cal.get_cost() == {"noisy_executions": 3, "ideal_executions": 1}
+
+
 def test_best_strategy():
     test_strategy_settings = Settings(
         benchmarks=[


### PR DESCRIPTION
Fixes #2972.

`Calibrator.get_cost` only reports total noisy/ideal execution counts. This adds `get_cost_breakdown()`, which itemizes that total by benchmark problem and strategy: one row per (problem, strategy) pair, plus a baseline row per problem covering the unmitigated execution (and the ideal execution for custom problems). `get_cost` now sums the breakdown, so the totals stay consistent by construction; its return value is unchanged.

Verified by running `pytest mitiq/calibration` (60 passed, includes two new tests), `make check-format` and `make check-types` (clean), and by exercising it directly: default ZNE settings still report `{'noisy_executions': 100, 'ideal_executions': 0}` with a 36-row breakdown that sums to those totals, and a custom problem with an ideal executor reports the ideal execution on its baseline row.

AI disclosure: this PR was prepared with the assistance of Claude Code (Anthropic's Claude); I review and test all changes.