### PR TITLE
Fix nightly docs build: apply SKIP_PYQUIL to linkcheck step

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -20,6 +20,10 @@ jobs:
     permissions:
       contents: read
       actions: write
+    env:
+      # Skip pyquil notebook execution everywhere (including linkcheck, which
+      # also executes notebooks) since no QVM/quilc servers run in CI.
+      SKIP_PYQUIL: 1
     steps:
       - name: Check out mitiq
         uses: actions/checkout@v7
@@ -56,7 +60,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install ocl-icd-opencl-dev
-          export SKIP_PYQUIL=1
           make docs
 
       - name: Run nightly linkcheck


### PR DESCRIPTION
## Problem

The nightly docs builds are still failing even after many "broken" links are ignored. The root cause is that `make linkcheck` is trying to build the pyquil docs instead of using the pre-run notebooks like we do on readthedocs, and the rest of CI. This PR brings the process into alignment, skipping pyquil everywhere.

---
Claude's summary:

## Root cause

The nightly-only `make linkcheck` step runs in a separate shell from the docs build step, so the `export SKIP_PYQUIL=1` in the build step never reaches it. The `linkcheck` builder parses all sources during Sphinx's reading phase, which means myst-nb executes notebooks there too. Without `SKIP_PYQUIL`, `nb_execution_excludepatterns` is unset (see `docs/source/conf.py`), so linkcheck executes the two pyquil notebooks from scratch (they were excluded from the main build, so they have no jupyter-cache entry). They fail because no QVM/quilc servers run in CI, and with `-W` those warnings fail the build.

The run logs confirm the config mismatch: the docs build step runs with `execution_excludepatterns=['*pyquil*.ipynb']`, the linkcheck step with `execution_excludepatterns=()`.

Push builds never hit this because linkcheck only runs on `schedule`.

## Fix

Hoist `SKIP_PYQUIL: 1` to job-level `env` so every step sees it. A side benefit: since the effective myst-nb config no longer differs between the two sphinx-build invocations, linkcheck can reuse the cached Sphinx environment from the html build instead of re-reading all sources, which should shave several minutes off the nightly job.

No other issues found: recent nightly logs show zero broken links and no other warnings, and linkcheck is the only step gated on `schedule`, so the nightly is now identical to the passing push build plus link checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)