### PR TITLE
Add closest_clifford equidistant regression test

### DIFF
--- a/mitiq/cdr/tests/test_clifford_utils.py
+++ b/mitiq/cdr/tests/test_clifford_utils.py
@@ -75,6 +75,30 @@ def test_closest_clifford():
             assert closest_clifford(a) == ang
 
 
+@pytest.mark.parametrize(
+    ("angle", "neighbor_indices"),
+    [
+        (np.pi / 4, (0, 1)),
+        (3 * np.pi / 4, (1, 2)),
+        (5 * np.pi / 4, (2, 3)),
+    ],
+)
+def test_closest_clifford_equidistant(angle, neighbor_indices):
+    """Cover the equidistant branch of ``closest_clifford`` (see #2365).
+
+    Midpoints between neighboring Clifford angles are handled by randomly
+    choosing one of the two closest Clifford angles.
+    """
+    expected = {_CLIFFORD_ANGLES[i] for i in neighbor_indices}
+    results: set[float] = set()
+    for seed in range(200):
+        np.random.seed(seed)
+        results.add(float(closest_clifford(angle)))
+        if results == expected:
+            break
+    assert results == expected
+
+
 def test_random_clifford():
     assert set(random_clifford(20, np.random.RandomState(1))).issubset(
         _CLIFFORD_ANGLES

--- a/mitiq/cdr/tests/test_clifford_utils.py
+++ b/mitiq/cdr/tests/test_clifford_utils.py
@@ -84,19 +84,9 @@ def test_closest_clifford():
     ],
 )
 def test_closest_clifford_equidistant(angle, neighbor_indices):
-    """Cover the equidistant branch of ``closest_clifford`` (see #2365).
-
-    Midpoints between neighboring Clifford angles are handled by randomly
-    choosing one of the two closest Clifford angles.
-    """
+    """Equidistant inputs map to one of the two neighboring angles."""
     expected = {_CLIFFORD_ANGLES[i] for i in neighbor_indices}
-    results: set[float] = set()
-    for seed in range(200):
-        np.random.seed(seed)
-        results.add(float(closest_clifford(angle)))
-        if results == expected:
-            break
-    assert results == expected
+    assert float(closest_clifford(angle)) in expected
 
 
 def test_random_clifford():


### PR DESCRIPTION
Fixes #2365 partially.

## Summary

Adds focused coverage for the equidistant branch of `closest_clifford`. Midpoints between neighboring Clifford angles must randomly select one of the two closest angles.

The earlier synthetic Qiskit multi-measure test was removed after review because modern Qiskit normalizes measurement operations and no real circuit reproducer exists.

## Validation

The regression covers the midpoint branch without changing production code.

## License

- [x] I license this contribution under GPLv3 and grant Unitary Foundation the additional permissions described in section 7.

Assisted-by: Codex (OpenAI)