### PR TITLE
Document batched circuit execution in the user guide

### DIFF
--- a/docs/source/guide/executors.md
+++ b/docs/source/guide/executors.md
@@ -121,10 +121,18 @@ print("\nQuantum results:\n", *executor.quantum_results, sep="\n")
 
 Notice in the above output that the executor has been called once for each circuit it has executed. This is because `mitiq_cirq.compute_density_matrix` inputs one circuit and outputs one `QuantumResult`.
 
-Several quantum computing services allow running a sequence, or "batch," of circuits at once. This is important for error mitigation when running many circuits to speed up the computation.
+Several quantum computing services allow running a sequence, or "batch," of circuits at once.
+This is especially important for error mitigation: techniques such as ZNE, PEC, and LRE typically generate **many** noise-scaled or sampled circuits, and batching reduces the number of backend round-trips (and often wall-clock time) without changing the quantum resource counts themselves.
+See also [Resource Requirements](resource-requirements.md).
 
-To define a batched executor, annotate it with `Sequence[T]`, `list[T]`, `tuple[T]`, or `Iterable[T]` where `T` is a `QuantumResult`.
-Here is an example:
+To define a batched executor, the function must:
+
+1. Accept a **sequence** of circuits (e.g. `list[QPROGRAM]`), and
+2. Be **annotated** to return a sequence of results (`list[T]`, `Sequence[T]`, `tuple[T]`, or `Iterable[T]` where `T` is a `QuantumResult`).
+
+Mitiq detects batching from that return-type annotation. Functions without a batched annotation are treated as serial even if they could accept a list.
+
+Here is a density-matrix example:
 
 ```{code-cell} ipython3
 import numpy as np
@@ -156,6 +164,57 @@ print("\nExecuted circuits:\n", *batched_executor.executed_circuits, sep="\n")
 print("\nQuantum results:\n", *batched_executor.quantum_results, sep="\n")
 ```
 
+#### Float-valued batched executors
+
+Hardware jobs often return expectation values (floats) rather than density matrices.
+A batched float executor looks like this:
+
+```{code-cell} ipython3
+def serial_float_executor(circuit: cirq.Circuit) -> float:
+    """Serial executor: one circuit → one float."""
+    rho = mitiq_cirq.compute_density_matrix(circuit)
+    # Population of |0⟩ as a simple float-valued result.
+    return float(np.real(rho[0, 0]))
+
+
+def batched_float_executor(circuits: list[cirq.Circuit]) -> list[float]:
+    """Batched executor: many circuits → many floats in one call."""
+    return [serial_float_executor(c) for c in circuits]
+
+
+serial_ex = Executor(serial_float_executor)
+batched_ex = Executor(batched_float_executor, max_batch_size=50)
+
+sample = [cirq.Circuit(pauli.on(q)) for pauli in (cirq.X, cirq.Y, cirq.Z)]
+_ = serial_ex.evaluate(sample)
+_ = batched_ex.evaluate(sample)
+
+print("Serial calls: ", serial_ex.calls_to_executor)   # one call per circuit
+print("Batched calls:", batched_ex.calls_to_executor)  # one call for the batch
+print("can_batch:    ", serial_ex.can_batch, batched_ex.can_batch)
+```
+
+```{tip}
+Replace the body of `batched_float_executor` with your provider's batch/job API
+(for example, submitting a list of circuits in a single QPU job). Mitiq only
+requires that the function accept a list of circuits and return a list of results
+of equal length, in the same order.
+```
+
+#### `max_batch_size`
+
+The optional `max_batch_size` argument caps how many circuits are sent in a single call.
+If you evaluate more circuits than `max_batch_size`, Mitiq splits them into multiple batches:
+
+```{code-cell} ipython3
+small_batch_executor = Executor(batched_float_executor, max_batch_size=2)
+many_circuits = [cirq.Circuit(cirq.X(q)) for _ in range(5)]
+_ = small_batch_executor.evaluate(many_circuits)
+print("Calls with max_batch_size=2:", small_batch_executor.calls_to_executor)
+```
+
+Choose `max_batch_size` based on your backend's limits (job size, payload size, or queue policy).
+
 ## Using `Executor`s in error mitigation techniques
 
 +++
@@ -182,6 +241,11 @@ print("Calls to executor:", batched_executor.calls_to_executor)
 print("\nExecuted circuits:\n", *batched_executor.executed_circuits, sep="\n")
 print("\nQuantum results:\n", *batched_executor.quantum_results, sep="\n")
 ```
+
+With a batched executor, all noise-scaled circuits for a non-adaptive method
+(for example a fixed set of ZNE scale factors) can be submitted together,
+which is the usual way to use Mitiq efficiently on cloud hardware
+{cite}`Russo_2022_Testing`.
 
 ## Defining an `Executor` that returns measurement outcomes (bitstrings)
 

--- a/docs/source/guide/executors.md
+++ b/docs/source/guide/executors.md
@@ -179,6 +179,9 @@ def serial_float_executor(circuit: cirq.Circuit) -> float:
 
 def batched_float_executor(circuits: list[cirq.Circuit]) -> list[float]:
     """Batched executor: many circuits → many floats in one call."""
+    # For demonstration only: this just loops the serial call under the
+    # hood, so it isn't actually batched. Replace the body with your
+    # provider's batch/job API to get real batching.
     return [serial_float_executor(c) for c in circuits]
 
 

--- a/docs/source/guide/frontends-backends.md
+++ b/docs/source/guide/frontends-backends.md
@@ -73,6 +73,22 @@ For more information on executors, see the {doc}`executors` section of this guid
 ### Batch execution of programs
 
 You can also use the {class}`.Executor` class to execute a batch of quantum programs all in one go.
-To perform batched execution, you can use the same mitiq.Executor class constructor and pass a function with the following signature: `T[mitiq.QPROGRAM] -> T[{class}".QuantumResult"]` where T is `Sequence`, `List`, `Tuple`, or `Iterable`.
+Error mitigation techniques often produce many circuits; a batched executor submits them with fewer backend calls.
 
-For more information on batched executors and example code, see the {doc}`executors` section of this guide.
+To perform batched execution, pass a function with signature
+`Sequence[mitiq.QPROGRAM] -> Sequence[mitiq.QuantumResult]`
+(or `list` / `tuple` / `Iterable` in place of `Sequence`).
+**Return-type annotations are required** so Mitiq can detect batching.
+
+```python
+from mitiq import Executor, QPROGRAM
+
+def run_batch(circuits: list[QPROGRAM]) -> list[float]:
+    # Submit all circuits to your backend in one job when possible.
+    return [run_one(c) for c in circuits]
+
+batched_executor = Executor(run_batch, max_batch_size=75)
+assert batched_executor.can_batch
+```
+
+For a full walkthrough (serial vs. batched call counts, `max_batch_size`, and use with ZNE), see {doc}`executors`.

--- a/docs/source/guide/resource-requirements.md
+++ b/docs/source/guide/resource-requirements.md
@@ -85,6 +85,17 @@ for i, folded in enumerate(folded_circuits, start=1):
     print(f"Folded Circuit {i}: {gate_count} extra gates")
 ```
 
+## Wall-clock cost and batched execution
+
+The counts above measure **how many circuits and gates** a technique needs.
+They do not automatically measure how long an experiment takes on a queue-based QPU.
+
+If your backend accepts multiple circuits in one job, define a [batched executor](executors.md)
+so Mitiq can send those circuits in fewer API calls.
+Batching does not reduce the number of circuits or gates—only the number of round-trips—so the resource counts in this guide stay the same while wall-clock time and queue overhead often drop.
+
 ## Further Reading
 
 More information on simulating and executing our GHZ circuit with LRE can be found [here](./lre-1-intro.md).
+
+For batching circuits on hardware backends, see the [Executors](executors.md) guide.


### PR DESCRIPTION
Fixes #2537

## Summary
Adds a clear, practical treatment of **batched quantum circuit execution** in the user guide. Error mitigation generates many circuits; batching is how those circuits are submitted efficiently on hardware.

### Changes
- **`executors.md`**: Expand the batched-execution section with
  - why batching matters for QEM (round-trips vs quantum resource counts)
  - detection via return-type annotations
  - float-valued serial vs batched comparison (`calls_to_executor`)
  - `max_batch_size` splitting example
  - tip for wiring provider batch/job APIs
  - cite to Russo et al. arXiv:2210.07194 (same ref as the issue)
- **`frontends-backends.md`**: Replace pointer-only note with a minimal batch snippet and link to the full guide
- **`resource-requirements.md`**: Clarify that batching reduces wall-clock/API cost, not circuit/gate counts

Docs-only; no code changes.

## Why this matters

Error-mitigation workflows routinely expand one logical circuit into many sampled variants. Without batching guidance, users pay unnecessary API round-trips and wall-clock time even when gate counts are unchanged. Batching is the main lever for making QEM practical on real hardware backends.

## Related

- Request: #2537
- Reference cited in issue: Russo et al. [arXiv:2210.07194](https://arxiv.org/abs/2210.07194)

---

Assisted-by: Codex (OpenAI)