### PR TITLE
Remove duplicated `custom` branch in `Settings.make_problems`; cover remaining calibration lines (#2365)

### DIFF
--- a/mitiq/calibration/settings.py
+++ b/mitiq/calibration/settings.py
@@ -380,15 +380,11 @@ class Settings:
             elif circuit_type == "custom":
                 # ideal distribution already set above (may be empty)
                 pass
-            elif circuit_type == "custom":
-                # ideal distribution already set above (may be empty)
-                pass
             else:
                 raise ValueError(
                     "invalid value passed for `circuit_types`. Must be "
-                    "one of `ghz`, `rb`, `mirror`, `w`, `qv`, or `custom`, "
-                    "one of `ghz`, `rb`, `mirror`, `w`, `qv`, or `custom`, "
-                    f"but got {circuit_type}."
+                    "one of `ghz`, `rb`, `rotated_rb`, `mirror`, `w`, `qv`, "
+                    f"or `custom`, but got {circuit_type}."
                 )
 
             circuit = cast(cirq.Circuit, circuit)

--- a/mitiq/calibration/tests/test_calibration.py
+++ b/mitiq/calibration/tests/test_calibration.py
@@ -356,6 +356,31 @@ def test_convert_to_expval_executor():
     assert np.isclose(rb_circuit_expval, 1.0)
 
 
+def test_convert_to_expval_executor_appends_measurements():
+    noiseless_bitstring_executor = Executor(
+        partial(damping_execute, noise_level=0)
+    )
+    noiseless_expval_executor = convert_to_expval_executor(
+        noiseless_bitstring_executor, bitstring="00"
+    )
+    rb_circuit = generate_rb_circuits(2, 10)[0]
+
+    rb_circuit_expval = noiseless_expval_executor.evaluate(rb_circuit)
+    assert np.isclose(rb_circuit_expval, 1.0)
+
+
+def test_ideal_cirq_executor():
+    cal = Calibrator(damping_execute, frontend="cirq")
+    assert cal.ideal_cirq_executor is None
+
+    cal_with_ideal = Calibrator(
+        damping_execute,
+        frontend="cirq",
+        ideal_executor=partial(damping_execute, noise_level=0),
+    )
+    assert cal_with_ideal.ideal_cirq_executor is not None
+
+
 def test_execute_with_mitigation(monkeypatch):
     cal = Calibrator(damping_execute, frontend="cirq")
 
@@ -372,6 +397,23 @@ def test_execute_with_mitigation(monkeypatch):
     )
     assert isinstance(expval, float)
     assert 0 <= expval <= 1.5
+
+
+def test_execute_with_mitigation_declined(monkeypatch):
+    cal = Calibrator(damping_execute, frontend="cirq")
+
+    expval_executor = convert_to_expval_executor(
+        Executor(damping_execute), bitstring="00"
+    )
+    rb_circuit = generate_rb_circuits(2, 10)[0]
+    rb_circuit.append(cirq.measure(rb_circuit.all_qubits()))
+
+    # override the def of `input` so that it returns "no"
+    monkeypatch.setattr("builtins.input", lambda _: "no")
+    assert (
+        execute_with_mitigation(rb_circuit, expval_executor, calibrator=cal)
+        is None
+    )
 
 
 def test_cal_execute_w_mitigation():

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -186,6 +186,39 @@ def test_Strategy_pretty_dict():
         )
 
 
+def test_Strategy_pretty_dict_pec():
+    strategy = light_pec_settings.make_strategies()[0]
+    strategy_dict = strategy.to_dict()
+    strategy_pretty_dict = strategy.to_pretty_dict()
+    assert strategy_pretty_dict["technique"] == "PEC"
+    assert strategy_pretty_dict["noise_bias"] == strategy_dict.get(
+        "noise_bias", "N/A"
+    )
+    assert (
+        strategy_pretty_dict["representation_function"]
+        == strategy_dict["representation_function"][25:]
+    )
+
+
+def test_pec_mitigation_function_unbiased_representation():
+    def constant_executor(circuit: cirq.Circuit) -> float:
+        return 1.0
+
+    strategy = light_pec_settings.make_strategies()[0]
+    q0, q1 = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(cirq.H(q0), cirq.CNOT(q0, q1))
+
+    expval = strategy.mitigation_function(circuit, constant_executor)
+    assert np.isclose(expval, 1.0, atol=0.5)
+
+
+def test_get_problem():
+    settings = basic_settings
+    problems = settings.make_problems()
+    problem = problems[0]
+    assert settings.get_problem(problem.id) is problem
+
+
 def test_make_circuits_rotated_rb_circuits():
     settings = Settings(
         benchmarks=[
@@ -264,7 +297,8 @@ def test_make_circuits_invalid_circuit_type():
         ],
     )
     with pytest.raises(
-        ValueError, match="invalid value passed for `circuit_types`"
+        ValueError,
+        match="invalid value passed for `circuit_types`.*but got foobar",
     ):
         settings.make_problems()
 

--- a/mitiq/calibration/tests/test_settings.py
+++ b/mitiq/calibration/tests/test_settings.py
@@ -297,8 +297,7 @@ def test_make_circuits_invalid_circuit_type():
         ],
     )
     with pytest.raises(
-        ValueError,
-        match="invalid value passed for `circuit_types`.*but got foobar",
+        ValueError, match="invalid value passed for `circuit_types`"
     ):
         settings.make_problems()
 


### PR DESCRIPTION
## Description

A merge in #2775 accidentally duplicated the `elif circuit_type == "custom"` branch that #2779 added to `Settings.make_problems` (the second copy is unreachable, which is why it shows as uncovered in #2365), and duplicated one line of the invalid-circuit-type `ValueError` so the message listed the valid types twice. This PR removes both duplicates and includes `rotated_rb` in the message, since it is an accepted circuit type.

It also adds unit tests for the remaining uncovered `mitiq/calibration` lines tracked in #2365 (calibrator.py 478/525 and settings.py 186/245-247/319 on current `main`): the unbiased-representation PEC branch of `Strategy.mitigation_function`, `Strategy.to_pretty_dict` for PEC, `Settings.get_problem`, `Calibrator.ideal_cirq_executor`, measurement insertion in `convert_to_expval_executor`, and answering "no" to the `execute_with_mitigation` prompt.

After this, `calibrator.py` is at 100% and `settings.py`'s only uncovered line is the defensive `return None` in `num_circuits_required`, which is unreachable with the current `MitigationTechnique` members.

Verified with `pytest mitiq/calibration/tests --cov=mitiq/calibration` (66 passed), plus `ruff check`, `ruff format --check`, and `mypy` on the touched files; also exercised the corrected error message and the `custom` branch manually.

Addresses #2365 (checks off the `calibrator.py` and `settings.py` items).

AI disclosure: this PR was prepared with the assistance of Claude Code (Anthropic's Claude); I review and test all changes.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [ ] I [updated the documentation](https://mitiq.readthedocs.io/en/latest/contributing_docs.html) where relevant.
- [ ] Added no-op meta tag if this change does not warrant a changelog entry.