### PR TITLE
Extend the amplitude damping representation beyond Cirq circuits

### DIFF
--- a/docs/source/guide/pec-3-options.md
+++ b/docs/source/guide/pec-3-options.md
@@ -192,6 +192,23 @@ depolarizing_h_rep = represent_operation_with_local_depolarizing_noise(
 assert depolarizing_h_rep == h_rep
 ```
 
+Amplitude damping noise has an analytical representation too, given in
+{cite}`Takagi_2020_PRR`.
+
+```{code-cell} ipython3
+from mitiq.pec.representations.damping import represent_operation_with_amplitude_damping_noise
+
+damping_h_rep = represent_operation_with_amplitude_damping_noise(
+    ideal_operation,
+    noise_level=BASE_NOISE,
+)
+
+print(f"Amplitude damping representation:\n{damping_h_rep}")
+```
+
+Its basis contains a reset of the qubit, so it is only defined for frontends which can express one
+(Cirq, Qiskit and OpenQASM circuits). For the others, Mitiq raises an `UnsupportedCircuitError`.
+
 ### Qubit-independent representations
 
 It is possible to define a qubit-independent {class}`.OperationRepresentation` by setting the option `is_qubit_dependent` to `False`.

--- a/mitiq/pec/representations/__init__.py
+++ b/mitiq/pec/representations/__init__.py
@@ -14,7 +14,7 @@ from mitiq.pec.representations.depolarizing import (
 )
 
 from mitiq.pec.representations.damping import (
-    _represent_operation_with_amplitude_damping_noise,
+    represent_operation_with_amplitude_damping_noise,
     amplitude_damping_kraus,
 )
 

--- a/mitiq/pec/representations/damping.py
+++ b/mitiq/pec/representations/damping.py
@@ -4,19 +4,83 @@
 # LICENSE file in the root directory of this source tree.
 """Functions related to representations with amplitude damping noise."""
 
+import copy
 from itertools import product
 
 import numpy as np
 import numpy.typing as npt
-from cirq import AmplitudeDampingChannel, Circuit, Z, kraus, reset
+from cirq import (
+    AmplitudeDampingChannel,
+    Circuit,
+    Operation,
+    Qid,
+    ResetChannel,
+    Z,
+    kraus,
+    reset,
+)
 
+from mitiq import QPROGRAM
+from mitiq.interface.conversions import (
+    CircuitConversionError,
+    UnsupportedCircuitError,
+    append_cirq_circuit_to_qprogram,
+    convert_to_mitiq,
+)
 from mitiq.pec.types import NoisyOperation, OperationRepresentation
 from mitiq.utils import arbitrary_tensor_product
 
+_RESET_NOT_SUPPORTED_ERROR = (
+    "The quasi-probability representation of amplitude damping noise needs a "
+    "reset operation, which cannot be expressed in a {} circuit. Convert "
+    "`ideal_operation` to a circuit type which supports reset (Cirq, Qiskit "
+    "or OpenQASM) before calling this function."
+)
 
-# TODO: this may be extended to an arbitrary QPROGRAM (GitHub issue gh-702).
-def _represent_operation_with_amplitude_damping_noise(
-    ideal_operation: Circuit,
+
+def _append_reset_to_qprogram(
+    ideal_operation: QPROGRAM, qubit: Qid, circuit_type: str
+) -> QPROGRAM:
+    """Returns ``ideal_operation`` with a reset of ``qubit`` appended to it.
+
+    Frontends which do not support reset behave in two different ways: some
+    fail the conversion, others drop the instruction and return a circuit
+    which no longer implements what was asked for. Both cases are turned into
+    an ``UnsupportedCircuitError`` here, since a silently dropped reset would
+    give a representation which does not sum to the ideal operation.
+
+    Args:
+        ideal_operation: The ideal operation (as a QPROGRAM) to append to.
+        qubit: The qubit to reset.
+        circuit_type: The frontend of ``ideal_operation``, used in the error
+            message.
+
+    Returns:
+        The input operation followed by a reset, in the input circuit type.
+    """
+    try:
+        circuit_with_reset = append_cirq_circuit_to_qprogram(
+            ideal_operation, Circuit(reset(qubit))
+        )
+    except CircuitConversionError as error:
+        raise UnsupportedCircuitError(
+            _RESET_NOT_SUPPORTED_ERROR.format(circuit_type)
+        ) from error
+
+    converted_circuit, _ = convert_to_mitiq(circuit_with_reset)
+    if not any(
+        isinstance(operation.gate, ResetChannel)
+        for operation in converted_circuit.all_operations()
+    ):
+        raise UnsupportedCircuitError(
+            _RESET_NOT_SUPPORTED_ERROR.format(circuit_type)
+        )
+
+    return circuit_with_reset
+
+
+def represent_operation_with_amplitude_damping_noise(
+    ideal_operation: QPROGRAM,
     noise_level: float,
     is_qubit_dependent: bool = True,
 ) -> OperationRepresentation:
@@ -28,8 +92,14 @@ def _represent_operation_with_amplitude_damping_noise(
     of equal ``noise_level`` is assumed to be in the basis of implementable
     operations.
 
-    The representation is based on the analytical result presented
-    in :cite:`Takagi2020`.
+    The representation is based on the analytical result presented in
+    Theorem 3 of :cite:`Takagi_2020_PRR`. The basis is the noisy operation
+    itself, the noisy operation followed by a ``Z`` gate and a reset of the
+    qubit to :math:`|0\rangle`. Its one-norm is
+    :math:`(1 + \epsilon) / (1 - \epsilon)` for a noise level
+    :math:`\epsilon`, a cost which that work shows is achievable and bounds
+    from below by :math:`(\sqrt{1 - \epsilon} + \epsilon / 2) / (1 -
+    \epsilon)`.
 
     Args:
         ideal_operation: The ideal operation (as a QPROGRAM) to represent.
@@ -43,6 +113,13 @@ def _represent_operation_with_amplitude_damping_noise(
     Returns:
         The quasi-probability representation of the ``ideal_operation``.
 
+    Raises:
+        ValueError: If ``ideal_operation`` acts on more than one qubit.
+        UnsupportedCircuitError: If the frontend of ``ideal_operation``
+            cannot express the reset which the representation needs. Cirq,
+            Qiskit and OpenQASM circuits support it. Braket, PennyLane,
+            pyQuil and Qibo circuits do not.
+
     .. note::
         The input ``ideal_operation`` is typically a QPROGRAM with a single
         gate but could also correspond to a sequence of more gates.
@@ -51,32 +128,33 @@ def _represent_operation_with_amplitude_damping_noise(
         physically implementable.
 
     .. note::
-        The input ``ideal_operation`` must be a ``cirq.Circuit``.
+        The noisy operations of the returned representation have the same
+        circuit type as ``ideal_operation``.
     """
+    circuit_copy = copy.deepcopy(ideal_operation)
+    converted_circ, circuit_type = convert_to_mitiq(circuit_copy)
 
-    if not isinstance(ideal_operation, Circuit):
-        raise NotImplementedError(
-            "The input ideal_operation must be a cirq.Circuit.",
-        )
+    qubits = converted_circ.all_qubits()
 
-    qubits = ideal_operation.all_qubits()
+    if len(qubits) != 1:
+        raise ValueError("Only single-qubit operations are supported.")
 
-    if len(qubits) == 1:
-        q = tuple(qubits)[0]
+    q = tuple(qubits)[0]
 
-        eta_0 = (1 + np.sqrt(1 - noise_level)) / (2 * (1 - noise_level))
-        eta_1 = (1 - np.sqrt(1 - noise_level)) / (2 * (1 - noise_level))
-        eta_2 = -noise_level / (1 - noise_level)
-        etas = [eta_0, eta_1, eta_2]
-        post_ops = [[], Z(q), reset(q)]
-
-    else:
-        raise ValueError(  # pragma: no cover
-            "Only single-qubit operations are supported."  # pragma: no cover
-        )  # pragma: no cover
+    eta_0 = (1 + np.sqrt(1 - noise_level)) / (2 * (1 - noise_level))
+    eta_1 = (1 - np.sqrt(1 - noise_level)) / (2 * (1 - noise_level))
+    eta_2 = -noise_level / (1 - noise_level)
+    etas = [eta_0, eta_1, eta_2]
+    post_ops: list[list[Operation]] = [[], [Z(q)]]
 
     # Basis of implementable operations as circuits
-    imp_op_circuits = [ideal_operation + Circuit(op) for op in post_ops]
+    imp_op_circuits = [
+        append_cirq_circuit_to_qprogram(ideal_operation, Circuit(op))
+        for op in post_ops
+    ]
+    imp_op_circuits.append(
+        _append_reset_to_qprogram(ideal_operation, q, circuit_type)
+    )
     noisy_operations = [NoisyOperation(c) for c in imp_op_circuits]
 
     return OperationRepresentation(

--- a/mitiq/pec/representations/tests/test_damping.py
+++ b/mitiq/pec/representations/tests/test_damping.py
@@ -7,29 +7,46 @@ import numpy as np
 import pytest
 from cirq import AmplitudeDampingChannel, Circuit, Gate, H, LineQubit, X, Y, Z
 
-from mitiq.interface import convert_from_mitiq
+from mitiq import SUPPORTED_PROGRAM_TYPES
+from mitiq.interface import UnsupportedCircuitError, convert_from_mitiq
 from mitiq.pec.channels import _circuit_to_choi, _operation_to_choi
 from mitiq.pec.representations.damping import (
-    _represent_operation_with_amplitude_damping_noise,
     amplitude_damping_kraus,
+    represent_operation_with_amplitude_damping_noise,
 )
 
+# Frontends which can express the reset operation used by the representation.
+RESET_SUPPORTED_TYPES = ["cirq", "qiskit", "openqasm"]
+# Frontends which cannot: they either fail the conversion or drop the reset.
+RESET_UNSUPPORTED_TYPES = ["braket", "pennylane", "pyquil", "qibo"]
 
+
+def test_all_frontends_are_covered():
+    """Every supported frontend either expresses a reset or does not, so a new
+    frontend has to be added to one of the two lists above.
+    """
+    assert set(RESET_SUPPORTED_TYPES) | set(RESET_UNSUPPORTED_TYPES) == set(
+        SUPPORTED_PROGRAM_TYPES.keys()
+    )
+
+
+@pytest.mark.parametrize("circuit_type", RESET_SUPPORTED_TYPES)
 @pytest.mark.parametrize("noise", [0, 0.1, 0.7])
 @pytest.mark.parametrize("gate", [X, Y, Z, H])
-def test_single_qubit_representation_norm(gate: Gate, noise: float):
+def test_single_qubit_representation_norm(
+    gate: Gate, noise: float, circuit_type: str
+):
     q = LineQubit(0)
     optimal_norm = (1 + noise) / (1 - noise)
-    norm = _represent_operation_with_amplitude_damping_noise(
-        Circuit(gate(q)),
+    circuit = convert_from_mitiq(Circuit(gate(q)), circuit_type)
+    norm = represent_operation_with_amplitude_damping_noise(
+        circuit,
         noise,
     ).norm
     assert np.isclose(optimal_norm, norm)
 
 
-# When _represent_operation_with_amplitude_damping_noise will
-# support more circuit types we can add them below.
-@pytest.mark.parametrize("circuit_type", ["cirq"])
+@pytest.mark.parametrize("circuit_type", RESET_SUPPORTED_TYPES)
 @pytest.mark.parametrize("noise", [0, 0.1, 0.7])
 @pytest.mark.parametrize("gate", [X, Y, Z, H])
 def test_amplitude_damping_representation_with_choi(
@@ -41,22 +58,55 @@ def test_amplitude_damping_representation_with_choi(
     q = LineQubit(0)
     ideal_circuit = convert_from_mitiq(Circuit(gate.on(q)), circuit_type)
     ideal_choi = _circuit_to_choi(Circuit(gate.on(q)))
-    op_rep = _represent_operation_with_amplitude_damping_noise(
+    op_rep = represent_operation_with_amplitude_damping_noise(
         ideal_circuit,
         noise,
     )
     choi_components = []
     for coeff, noisy_op in op_rep.basis_expansion:
-        implementable_circ = noisy_op.circuit
-        depolarizing_op = AmplitudeDampingChannel(noise).on(q)
+        # A conversion can relabel the qubits of the input circuit, while the
+        # Choi helper assumes line qubits, so relabel them back.
+        (native_qubit,) = noisy_op.circuit.all_qubits()
+        implementable_circ = noisy_op.circuit.transform_qubits(
+            {native_qubit: q}
+        )
+        damping_op = AmplitudeDampingChannel(noise).on(q)
         # Apply noise after each sequence.
         # NOTE: noise is not applied after each operation.
-        implementable_circ.append(depolarizing_op)
+        implementable_circ.append(damping_op)
         sequence_choi = _operation_to_choi(implementable_circ)
         choi_components.append(coeff * sequence_choi)
 
     combination_choi = np.sum(choi_components, axis=0)
     assert np.allclose(ideal_choi, combination_choi, atol=1e-7)
+
+
+@pytest.mark.parametrize("circuit_type", RESET_SUPPORTED_TYPES)
+def test_representation_keeps_the_input_circuit_type(circuit_type: str):
+    """The noisy operations are returned in the type of the input circuit."""
+    q = LineQubit(0)
+    circuit = convert_from_mitiq(Circuit(H(q)), circuit_type)
+    op_rep = represent_operation_with_amplitude_damping_noise(circuit, 0.1)
+    for noisy_op in op_rep.noisy_operations:
+        assert type(noisy_op.native_circuit) is type(circuit)
+
+
+@pytest.mark.parametrize("circuit_type", RESET_UNSUPPORTED_TYPES)
+def test_representation_without_reset_support(circuit_type: str):
+    """Frontends which cannot express a reset get a clear error rather than a
+    representation which silently drops it.
+    """
+    q = LineQubit(0)
+    circuit = convert_from_mitiq(Circuit(H(q)), circuit_type)
+    with pytest.raises(UnsupportedCircuitError, match="reset"):
+        represent_operation_with_amplitude_damping_noise(circuit, 0.1)
+
+
+def test_two_qubit_representation_error():
+    qubits = LineQubit.range(2)
+    circuit = Circuit(H.on_each(*qubits))
+    with pytest.raises(ValueError, match="single-qubit"):
+        represent_operation_with_amplitude_damping_noise(circuit, 0.1)
 
 
 def test_damping_kraus():

--- a/mitiq/pec/representations/tests/test_optimal.py
+++ b/mitiq/pec/representations/tests/test_optimal.py
@@ -33,9 +33,9 @@ from mitiq.pec.channels import (
     kraus_to_super,
 )
 from mitiq.pec.representations import (
-    _represent_operation_with_amplitude_damping_noise,
     amplitude_damping_kraus,
     global_depolarizing_kraus,
+    represent_operation_with_amplitude_damping_noise,
     represent_operation_with_local_depolarizing_noise,
 )
 from mitiq.pec.representations.optimal import (
@@ -302,7 +302,7 @@ def test_find_optimal_representation_single_qubit_amp_damping(circ_type):
             initial_guess=[0, 0, 0],
         )
         # Expected analytical result
-        expected_rep = _represent_operation_with_amplitude_damping_noise(
+        expected_rep = represent_operation_with_amplitude_damping_noise(
             ideal_op_native,
             noise_level,
         )


### PR DESCRIPTION
## Description

Fixes #702.

The amplitude damping representation was Cirq only. It raised
`NotImplementedError("The input ideal_operation must be a cirq.Circuit.")` for
every other frontend. It was private too. It now accepts any `QPROGRAM` the way
the depolarizing and biased noise representations do (deep copy, convert to
Cirq, build the extra operations on the converted qubits, append them back to
the caller's own circuit with `append_cirq_circuit_to_qprogram`). It is public
now as `represent_operation_with_amplitude_damping_noise`.

Before, on `main`:

```
cirq       OK norm=1.2222
qiskit     NotImplementedError: The input ideal_operation must be a cirq.Circuit.
openqasm   NotImplementedError: The input ideal_operation must be a cirq.Circuit.
braket     NotImplementedError: The input ideal_operation must be a cirq.Circuit.
pennylane  NotImplementedError: The input ideal_operation must be a cirq.Circuit.
pyquil     NotImplementedError: The input ideal_operation must be a cirq.Circuit.
qibo       NotImplementedError: The input ideal_operation must be a cirq.Circuit.
```

After, Qiskit and OpenQASM circuits work and give a representation whose Choi
matrix matches the ideal operation exactly. That closes the loop on #2469,
where a user wanting PEC for amplitude damping from Qiskit was told the only
workaround was to write the circuit in Cirq. It works now because Cirq 1.5
taught its QASM parser to read `reset` (quantumlib/Cirq#6710), which
@b-goldsmith diagnosed in that thread. Mitiq pins `cirq-core>=1.6.0`, so the
blocker is gone.

This also removes the `# TODO: this may be extended to an arbitrary QPROGRAM`
comment in `damping.py` plus the matching placeholder in the test file, which
already had `circuit_type` parametrized over `["cirq"]` waiting for this.

### Frontends that cannot express a reset

The representation's third basis element is a reset of the qubit
(:math:`\mathcal{P}_{|0\rangle}` in Theorem 3 of the cited paper), so it can
only be built where the frontend can carry one. Two different things happen:

- Braket, Qibo and pyQuil fail the conversion. Braket has no reset
  instruction. Qibo's QASM reader rejects `reset`. The Cirq to Quil path
  refuses to emit it. The generic `CircuitConversionError` does not say why, so
  it is now caught and re-raised naming the reset.
- PennyLane silently drops it. `pennylane_qiskit` warns and returns a circuit
  without the reset, so a plain generalization would hand back a representation
  whose third basis element is a copy of the first. The coefficients still sum
  to 1, so nothing looks wrong, but it no longer represents the ideal
  operation: I measured a Choi error of 0.026352 at `noise_level=0.1` for that
  broken representation, against 0.0 for Cirq.

So the code checks that the reset survives the round trip into the caller's
circuit type and raises `UnsupportedCircuitError` if it does not, with a
message that names the reset and the frontends that do support it. The check is
behavioural rather than a hardcoded list, so a frontend that gains reset
support starts working here with no further change. This follows @rmlarose's
call in the issue thread: "If this representation requires a reset channel and
a particular front-end doesn't support reset, it makes sense for this function
to fail with that front-end."

### Tests

`mitiq/pec/representations/tests/test_damping.py` goes from 25 to 82 tests:

- the norm test and the Choi acceptance test now run for Cirq, Qiskit and
  OpenQASM, over the same gates and noise levels as before,
- the noisy operations are asserted to come back in the input circuit type,
- Braket, PennyLane, pyQuil and Qibo are asserted to raise
  `UnsupportedCircuitError`,
- a two-qubit input is asserted to raise `ValueError`, which lets the three
  `# pragma: no cover` comments on that branch go away,
- one test asserts the supported plus unsupported frontend lists cover
  `SUPPORTED_PROGRAM_TYPES`, so adding a frontend forces a decision here.

The Choi test needed one fix to work off Cirq. It built the damping channel on
`LineQubit(0)`, but a conversion can relabel the qubit (Qiskit gives
`NamedQubit('q_0')`) and `_circuit_to_choi` assumes line qubits, so the circuit
is relabelled before the comparison.

### Docs

`pec-3-options.md` documents the representation next to the depolarizing one,
with a runnable cell on the Qiskit `ideal_operation` that page already defines
plus the reset caveat. `apidoc.md` already runs
`automodule:: mitiq.pec.representations.damping :members:`, so the function now
renders there.

While making it public I found the docstring cited `:cite:`Takagi2020``, which
is not a key in `docs/source/refs.bib`. The paper is there as
`Takagi_2020_PRR`, the key `pec-1-intro.md` already uses for this same
analytical result, so that is what the docstring cites now. The docstring also
names Theorem 3 and states the one-norm the theorem gives,
`(1 + noise_level) / (1 - noise_level)`, which that work shows is achievable
with a lower bound of `(sqrt(1 - noise_level) + noise_level / 2) / (1 -
noise_level)`, so it no longer reads as if the cost were proven optimal.

The private `_represent_operation_with_amplitude_damping_noise` is gone rather
than aliased. It was never public API. Its only callers were Mitiq's own
tests. Happy to keep an alias if you would rather not break the private name.

### Verified locally

```
uv run pytest -n auto -q --ignore=mitiq/interface/mitiq_pyquil
  2625 passed, 2 xfailed in 165.51s      (main at 3e1833d: 2568 passed, 2 xfailed)
uv run pytest mitiq/pec/representations -q
  362 passed                             (main at 3e1833d: 305 passed)
uv run ruff check                 All checks passed!
uv run ruff format --check        160 files already formatted
uv run mypy mitiq                 Success: no issues found in 113 source files
DOCS_LITE=1 uv run make -C docs html   build succeeded
```

Python 3.11.15, cirq-core 1.6.1. `make test-pyquil` was not run, since it needs
the QVM and quilc servers. This change does not touch
`mitiq/interface/mitiq_pyquil`. The pyQuil path here is covered by the new
unsupported-frontend test, which only converts.

### AI use

I used Claude (Anthropic) while writing this change. I chose the approach,
reviewed every line, verified the representation against Theorem 3 of the cited
paper before touching the code, then ran the tests, lint and type checks above
myself. I can explain and defend any part of it.

---

### License

- [x] I license this contribution under the terms of the GNU GPL, version 3 and grant Unitary Foundation the right to provide additional permissions as described in section 7 of the GNU GPL, version 3.

Before opening the PR, please ensure you have completed the following where appropriate.

- [x] I added unit tests for new code.
- [x] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [x] I used [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) docstrings for functions.
- [x] I [updated the documentation](../blob/main/docs/CONTRIBUTING_DOCS.md) where relevant.
